### PR TITLE
Update to enginekit 0.2.0 and dogma 0.3.0.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -143,11 +143,9 @@ func (e *Engine) Dispatch(
 	options ...OperationOption,
 ) error {
 	oo := newOperationOptions(options)
-
 	t := message.TypeOf(m)
-	r, ok := e.roles[t]
 
-	if !ok {
+	if _, ok := e.routes[t]; !ok {
 		oo.observers.Notify(
 			fact.DispatchCycleSkipped{
 				Message:         m,
@@ -159,6 +157,7 @@ func (e *Engine) Dispatch(
 		return nil
 	}
 
+	r := e.roles[t]
 	r.MustBe(message.CommandRole, message.EventRole)
 
 	var env *envelope.Envelope

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,0 +1,73 @@
+package engine_test
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/enginekit/fixtures"
+	. "github.com/dogmatiq/testkit/engine"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Engine", func() {
+	Describe("func New", func() {
+		var (
+			aggregate   *fixtures.AggregateMessageHandler
+			process     *fixtures.ProcessMessageHandler
+			integration *fixtures.IntegrationMessageHandler
+			projection  *fixtures.ProjectionMessageHandler
+			app         *fixtures.Application
+		)
+
+		BeforeEach(func() {
+			aggregate = &fixtures.AggregateMessageHandler{
+				ConfigureFunc: func(c dogma.AggregateConfigurer) {
+					c.Name("<aggregate>")
+					c.ConsumesCommandType(fixtures.MessageA{})
+					c.ProducesEventType(fixtures.MessageE{})
+				},
+			}
+
+			process = &fixtures.ProcessMessageHandler{
+				ConfigureFunc: func(c dogma.ProcessConfigurer) {
+					c.Name("<process>")
+					c.ConsumesEventType(fixtures.MessageB{})
+					c.ConsumesEventType(fixtures.MessageE{}) // shared with <projection>
+					c.ProducesCommandType(fixtures.MessageC{})
+				},
+			}
+
+			integration = &fixtures.IntegrationMessageHandler{
+				ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+					c.Name("<integration>")
+					c.ConsumesCommandType(fixtures.MessageC{})
+					c.ProducesEventType(fixtures.MessageF{})
+				},
+			}
+
+			projection = &fixtures.ProjectionMessageHandler{
+				ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+					c.Name("<projection>")
+					c.ConsumesEventType(fixtures.MessageD{})
+					c.ConsumesEventType(fixtures.MessageE{}) // shared with <process>
+				},
+			}
+
+			app = &fixtures.Application{
+				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+					c.Name("<app>")
+					c.RegisterAggregate(aggregate)
+					c.RegisterProcess(process)
+					c.RegisterIntegration(integration)
+					c.RegisterProjection(projection)
+				},
+			}
+		})
+
+		When("the configuration is valid", func() {
+			It("does not return an error", func() {
+				_, err := New(app)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/dogmatiq/testkit
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dogmatiq/dapper v0.3.2
-	github.com/dogmatiq/dogma v0.2.0
-	github.com/dogmatiq/enginekit v0.1.0
+	github.com/dogmatiq/dogma v0.3.0
+	github.com/dogmatiq/enginekit v0.2.0
 	github.com/dogmatiq/iago v0.4.0
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
@@ -12,4 +12,6 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0
+	golang.org/x/net v0.0.0-20190225153610-fe579d43d832 // indirect
+	golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dogmatiq/dapper v0.3.2 h1:amB05g0KSVmXhwdrGXgBTjHTGSw8HwhC6mqThDDhEKw=
 github.com/dogmatiq/dapper v0.3.2/go.mod h1:wvWzpY8JYKHRZE80Mf0jdjSDkMezyv/amjgbirHUyaw=
-github.com/dogmatiq/dogma v0.1.0 h1:x4WDPsBPNGtDkx1CijlLHmgeeFvFHTc8qEud0OJanUo=
-github.com/dogmatiq/dogma v0.1.0/go.mod h1:kzDxrkzdgrJattEUoLmoFdyHZtib4H5oa98VcewQEI8=
-github.com/dogmatiq/dogma v0.2.0 h1:IqKsiUQgOKGto1/3T2V580RMZlLw0KARqF4C5q6u+18=
-github.com/dogmatiq/dogma v0.2.0/go.mod h1:kzDxrkzdgrJattEUoLmoFdyHZtib4H5oa98VcewQEI8=
-github.com/dogmatiq/enginekit v0.1.0 h1:hXnoonrHJJGy1+5zadLLRKBMCSvcz4TZf9XfCsZ4258=
-github.com/dogmatiq/enginekit v0.1.0/go.mod h1:S9qIlbc/jBB8pZQYrGaEyWDVQDVLNFRPhD6Iqmy/lVQ=
+github.com/dogmatiq/dogma v0.3.0 h1:Egfo6zjEDwLXYtk59al3nlSngqbq5agzxnPMaQih1Sg=
+github.com/dogmatiq/dogma v0.3.0/go.mod h1:kzDxrkzdgrJattEUoLmoFdyHZtib4H5oa98VcewQEI8=
+github.com/dogmatiq/enginekit v0.2.0 h1:rIsMzNAyeqUIqvaiRV7aN2FcrBUzPgMvbeV+V5wzpn4=
+github.com/dogmatiq/enginekit v0.2.0/go.mod h1:bCXYIbptGRMdLriktoaGBwYKlO+L8Hd5+s9jvi3q6zc=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -43,6 +41,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190225153610-fe579d43d832 h1:2IdId8zoI92l1bUzjAOygcAOkmCe13HY1j0rqPPPzB8=
+golang.org/x/net v0.0.0-20190225153610-fe579d43d832/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
@@ -51,6 +51,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUk
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 h1:FDfvYgoVsA7TTZSbgiqjAbfPbK47CNHdWl3h/PJtii0=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 h1:Zw7eRv6INHGfu15LVRN1vrrwusJbnfJjAZn3D1VkQIE=
+golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This contains changes necessary for the in-memory engine to work with these versions, the major feature of which is the requirement that handlers declare their produced message types.

It does not include any change that ensures that handlers only produce messages that they had previously declared. Such a change can be made in a future PR (see #13).