### PR TITLE
Use `message.TypeContainer` for sets of produced types in controllers.

### DIFF
--- a/engine/configurer.go
+++ b/engine/configurer.go
@@ -34,7 +34,7 @@ func (c *configurer) VisitAggregateConfig(_ context.Context, cfg *config.Aggrega
 			cfg.HandlerName,
 			cfg.Handler,
 			&c.engine.messageIDs,
-			roleMapToSet(cfg.ProducedMessageTypes()),
+			cfg.ProducedMessageTypes(),
 		),
 		cfg.ConsumedMessageTypes(),
 	)
@@ -48,7 +48,7 @@ func (c *configurer) VisitProcessConfig(_ context.Context, cfg *config.ProcessCo
 			cfg.HandlerName,
 			cfg.Handler,
 			&c.engine.messageIDs,
-			roleMapToSet(cfg.ProducedMessageTypes()),
+			cfg.ProducedMessageTypes(),
 		),
 		cfg.ConsumedMessageTypes(),
 	)
@@ -62,7 +62,7 @@ func (c *configurer) VisitIntegrationConfig(_ context.Context, cfg *config.Integ
 			cfg.HandlerName,
 			cfg.Handler,
 			&c.engine.messageIDs,
-			roleMapToSet(cfg.ProducedMessageTypes()),
+			cfg.ProducedMessageTypes(),
 		),
 		cfg.ConsumedMessageTypes(),
 	)
@@ -91,16 +91,4 @@ func (c *configurer) registerController(
 	for t := range types {
 		c.engine.routes[t] = append(c.engine.routes[t], ctrl)
 	}
-}
-
-// roleMapToSet converts a map of message type to role, as used by the enginekit
-// config system, into a type set.
-func roleMapToSet(m map[message.Type]message.Role) message.TypeSet {
-	s := message.TypeSet{}
-
-	for t := range m {
-		s.Add(t)
-	}
-
-	return s
 }

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -17,7 +17,7 @@ type Controller struct {
 	name       string
 	handler    dogma.AggregateMessageHandler
 	messageIDs *envelope.MessageIDGenerator
-	produced   message.TypeSet
+	produced   message.TypeContainer
 	instances  map[string]dogma.AggregateRoot
 }
 
@@ -26,7 +26,7 @@ func NewController(
 	n string,
 	h dogma.AggregateMessageHandler,
 	g *envelope.MessageIDGenerator,
-	t message.TypeSet,
+	t message.TypeContainer,
 ) *Controller {
 	return &Controller{
 		name:       n,

--- a/engine/controller/aggregate/scope.go
+++ b/engine/controller/aggregate/scope.go
@@ -23,7 +23,7 @@ type scope struct {
 	exists     bool
 	created    bool // true if Create() returned true at least once
 	destroyed  bool // true if Destroy() returned true at least once
-	produced   message.TypeSet
+	produced   message.TypeContainer
 	command    *envelope.Envelope
 	events     []*envelope.Envelope
 }

--- a/engine/controller/integration/controller.go
+++ b/engine/controller/integration/controller.go
@@ -17,7 +17,7 @@ type Controller struct {
 	name       string
 	handler    dogma.IntegrationMessageHandler
 	messageIDs *envelope.MessageIDGenerator
-	produced   message.TypeSet
+	produced   message.TypeContainer
 }
 
 // NewController returns a new controller for the given handler.
@@ -25,7 +25,7 @@ func NewController(
 	n string,
 	h dogma.IntegrationMessageHandler,
 	g *envelope.MessageIDGenerator,
-	t message.TypeSet,
+	t message.TypeContainer,
 ) *Controller {
 	return &Controller{
 		name:       n,

--- a/engine/controller/integration/scope.go
+++ b/engine/controller/integration/scope.go
@@ -19,7 +19,7 @@ type scope struct {
 	messageIDs *envelope.MessageIDGenerator
 	observer   fact.Observer
 	now        time.Time
-	produced   message.TypeSet
+	produced   message.TypeContainer
 	command    *envelope.Envelope
 	events     []*envelope.Envelope
 }

--- a/engine/controller/process/controller.go
+++ b/engine/controller/process/controller.go
@@ -18,7 +18,7 @@ type Controller struct {
 	name       string
 	handler    dogma.ProcessMessageHandler
 	messageIDs *envelope.MessageIDGenerator
-	produced   message.TypeSet
+	produced   message.TypeContainer
 	instances  map[string]dogma.ProcessRoot
 	timeouts   []*envelope.Envelope
 }
@@ -28,7 +28,7 @@ func NewController(
 	n string,
 	h dogma.ProcessMessageHandler,
 	g *envelope.MessageIDGenerator,
-	t message.TypeSet,
+	t message.TypeContainer,
 ) *Controller {
 	return &Controller{
 		name:       n,

--- a/engine/controller/process/scope.go
+++ b/engine/controller/process/scope.go
@@ -21,7 +21,7 @@ type scope struct {
 	now        time.Time
 	root       dogma.ProcessRoot
 	exists     bool
-	produced   message.TypeSet
+	produced   message.TypeContainer
 	env        *envelope.Envelope // event or timeout
 	commands   []*envelope.Envelope
 	ready      []*envelope.Envelope // timeouts <= now

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dogmatiq/dapper v0.3.2
 	github.com/dogmatiq/dogma v0.3.0
-	github.com/dogmatiq/enginekit v0.2.0
+	github.com/dogmatiq/enginekit v0.3.0
 	github.com/dogmatiq/iago v0.4.0
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/dogmatiq/dapper v0.3.2 h1:amB05g0KSVmXhwdrGXgBTjHTGSw8HwhC6mqThDDhEKw
 github.com/dogmatiq/dapper v0.3.2/go.mod h1:wvWzpY8JYKHRZE80Mf0jdjSDkMezyv/amjgbirHUyaw=
 github.com/dogmatiq/dogma v0.3.0 h1:Egfo6zjEDwLXYtk59al3nlSngqbq5agzxnPMaQih1Sg=
 github.com/dogmatiq/dogma v0.3.0/go.mod h1:kzDxrkzdgrJattEUoLmoFdyHZtib4H5oa98VcewQEI8=
-github.com/dogmatiq/enginekit v0.2.0 h1:rIsMzNAyeqUIqvaiRV7aN2FcrBUzPgMvbeV+V5wzpn4=
-github.com/dogmatiq/enginekit v0.2.0/go.mod h1:bCXYIbptGRMdLriktoaGBwYKlO+L8Hd5+s9jvi3q6zc=
+github.com/dogmatiq/enginekit v0.3.0 h1:if1BUYY1mP7VGH2MPvz2xF13dD8cc9ZwmuFXnTN7SQc=
+github.com/dogmatiq/enginekit v0.3.0/go.mod h1:bCXYIbptGRMdLriktoaGBwYKlO+L8Hd5+s9jvi3q6zc=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=


### PR DESCRIPTION
This means an update to `enginekit` v0.3.0