### PR TITLE
Add file/line information to log message section headings.

### DIFF
--- a/interface_test.go
+++ b/interface_test.go
@@ -1,14 +1,18 @@
 package testkit_test
 
+import "fmt"
+
 // mockT is a mock of the T interface.
 type mockT struct {
+	Logs []string
 }
 
 func (t *mockT) Log(args ...interface{}) {
-
+	t.Logs = append(t.Logs, fmt.Sprintln(args...))
 }
-func (t *mockT) Logf(f string, args ...interface{}) {
 
+func (t *mockT) Logf(f string, args ...interface{}) {
+	t.Logs = append(t.Logs, fmt.Sprintf(f, args...))
 }
 
 func (t *mockT) FailNow() {

--- a/test.go
+++ b/test.go
@@ -196,10 +196,14 @@ func (t *Test) end(a assert.Assertion) {
 		r = render.DefaultRenderer{}
 	}
 
-	t.logHeading("ASSERTION REPORT")
-
+	caller := t.findCaller()
 	buf := &strings.Builder{}
-	buf.WriteString("\n")
+	fmt.Fprintf(
+		buf,
+		"--- ASSERTION REPORT (%s:%d) ---\n\n",
+		path.Base(caller.File),
+		caller.Line,
+	)
 
 	rep := a.BuildReport(a.Ok(), r)
 	must.WriteTo(buf, rep)

--- a/test.go
+++ b/test.go
@@ -196,8 +196,10 @@ func (t *Test) end(a assert.Assertion) {
 		r = render.DefaultRenderer{}
 	}
 
+	t.logHeading("ASSERTION REPORT")
+
 	buf := &strings.Builder{}
-	buf.WriteString("--- ASSERTION REPORT ---\n\n")
+	buf.WriteString("\n")
 
 	rep := a.BuildReport(a.Ok(), r)
 	must.WriteTo(buf, rep)

--- a/test.go
+++ b/test.go
@@ -229,14 +229,12 @@ func (t *Test) logHeading(f string, v ...interface{}) {
 
 // findCaller returns the frame of the deepest caller in the stack that is
 // not a method of the testkit.Test type.
-//
-// If none of the callers
 func (t *Test) findCaller() (f runtime.Frame) {
 	const window = 5
 	offset := 2 // start by excluding this function and runtime.Callers()
 
 	for {
-		pc := make([]uintptr, window) // we assume that Test itself does
+		pc := make([]uintptr, window)
 		n := runtime.Callers(offset, pc)
 		pc = pc[:n]
 		offset += window

--- a/test_test.go
+++ b/test_test.go
@@ -37,7 +37,7 @@ var _ = Describe("type Test", func() {
 		})
 
 		Describe("func Prepare()", func() {
-			It("logs a heading", func() {
+			It("logs file and line information in headings", func() {
 				test.Prepare() // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
 				Expect(t.Logs).To(ContainElement(
 					"--- PREPARING APPLICATION FOR TEST (test_test.go:41) ---",
@@ -46,7 +46,7 @@ var _ = Describe("type Test", func() {
 		})
 
 		Describe("func ExecuteCommand()", func() {
-			It("logs a heading", func() {
+			It("logs file and line information in headings", func() {
 				test.ExecuteCommand( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
 					fixtures.MessageC1,
 					noopAssertion{},
@@ -54,41 +54,53 @@ var _ = Describe("type Test", func() {
 				Expect(t.Logs).To(ContainElement(
 					"--- EXECUTING TEST COMMAND (test_test.go:50) ---",
 				))
+				Expect(t.Logs).To(ContainElement(
+					"--- ASSERTION REPORT (test_test.go:50) ---",
+				))
 			})
 		})
 
 		Describe("func RecordEvent()", func() {
-			It("logs a heading", func() {
+			It("logs file and line information in headings", func() {
 				test.RecordEvent( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
 					fixtures.MessageC1,
 					noopAssertion{},
 				)
 				Expect(t.Logs).To(ContainElement(
-					"--- RECORDING TEST EVENT (test_test.go:62) ---",
+					"--- RECORDING TEST EVENT (test_test.go:65) ---",
+				))
+				Expect(t.Logs).To(ContainElement(
+					"--- ASSERTION REPORT (test_test.go:65) ---",
 				))
 			})
 		})
 
 		Describe("func AdvanceTimeBy()", func() {
-			It("logs a heading", func() {
+			It("logs file and line information in headings", func() {
 				test.AdvanceTimeBy( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
 					3*time.Second,
 					noopAssertion{},
 				)
 				Expect(t.Logs).To(ContainElement(
-					"--- ADVANCING TIME BY 3s (test_test.go:74) ---",
+					"--- ADVANCING TIME BY 3s (test_test.go:80) ---",
+				))
+				Expect(t.Logs).To(ContainElement(
+					"--- ASSERTION REPORT (test_test.go:80) ---",
 				))
 			})
 		})
 
 		Describe("func AdvanceTimeTo()", func() {
-			It("logs a heading", func() {
+			It("logs file and line information in headings", func() {
 				test.AdvanceTimeTo( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
 					time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC),
 					noopAssertion{},
 				)
 				Expect(t.Logs).To(ContainElement(
-					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z (test_test.go:86) ---",
+					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z (test_test.go:95) ---",
+				))
+				Expect(t.Logs).To(ContainElement(
+					"--- ASSERTION REPORT (test_test.go:95) ---",
 				))
 			})
 		})

--- a/test_test.go
+++ b/test_test.go
@@ -1,0 +1,118 @@
+package testkit_test
+
+import (
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/enginekit/fixtures"
+	. "github.com/dogmatiq/testkit"
+	"github.com/dogmatiq/testkit/assert"
+	"github.com/dogmatiq/testkit/compare"
+	"github.com/dogmatiq/testkit/engine/fact"
+	"github.com/dogmatiq/testkit/render"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Test", func() {
+	var app *fixtures.Application
+
+	BeforeEach(func() {
+		app = &fixtures.Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+			},
+		}
+	})
+
+	Context("when verbose logging is enabled", func() {
+		var (
+			t    *mockT
+			test *Test
+		)
+
+		BeforeEach(func() {
+			t = &mockT{}
+			test = New(app).Begin(t, Verbose(true))
+		})
+
+		Describe("func Prepare()", func() {
+			It("logs a heading", func() {
+				test.Prepare() // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
+				Expect(t.Logs).To(ContainElement(
+					"--- PREPARING APPLICATION FOR TEST (test_test.go:41) ---",
+				))
+			})
+		})
+
+		Describe("func ExecuteCommand()", func() {
+			It("logs a heading", func() {
+				test.ExecuteCommand( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
+					fixtures.MessageC1,
+					noopAssertion{},
+				)
+				Expect(t.Logs).To(ContainElement(
+					"--- EXECUTING TEST COMMAND (test_test.go:50) ---",
+				))
+			})
+		})
+
+		Describe("func RecordEvent()", func() {
+			It("logs a heading", func() {
+				test.RecordEvent( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
+					fixtures.MessageC1,
+					noopAssertion{},
+				)
+				Expect(t.Logs).To(ContainElement(
+					"--- RECORDING TEST EVENT (test_test.go:62) ---",
+				))
+			})
+		})
+
+		Describe("func AdvanceTimeBy()", func() {
+			It("logs a heading", func() {
+				test.AdvanceTimeBy( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
+					3*time.Second,
+					noopAssertion{},
+				)
+				Expect(t.Logs).To(ContainElement(
+					"--- ADVANCING TIME BY 3s (test_test.go:74) ---",
+				))
+			})
+		})
+
+		Describe("func AdvanceTimeTo()", func() {
+			It("logs a heading", func() {
+				test.AdvanceTimeTo( // <-- THIS LINE NUMBER SHOULD APPEAR IN THE OUTPUT
+					time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC),
+					noopAssertion{},
+				)
+				Expect(t.Logs).To(ContainElement(
+					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z (test_test.go:86) ---",
+				))
+			})
+		})
+	})
+})
+
+type noopAssertion struct{}
+
+func (noopAssertion) Prepare(compare.Comparator) {
+
+}
+
+func (noopAssertion) Ok() bool {
+	return true
+}
+
+func (noopAssertion) BuildReport(ok bool, r render.Renderer) *assert.Report {
+	return &assert.Report{
+		TreeOk:   ok,
+		Ok:       ok,
+		Criteria: "pass unconditionally",
+	}
+}
+
+func (noopAssertion) Notify(fact.Fact) {
+
+}

--- a/test_test.go
+++ b/test_test.go
@@ -55,7 +55,7 @@ var _ = Describe("type Test", func() {
 					"--- EXECUTING TEST COMMAND (test_test.go:50) ---",
 				))
 				Expect(t.Logs).To(ContainElement(
-					"--- ASSERTION REPORT (test_test.go:50) ---",
+					"--- ASSERTION REPORT (test_test.go:50) ---\n\n✓ pass unconditionally\n\n",
 				))
 			})
 		})
@@ -70,7 +70,7 @@ var _ = Describe("type Test", func() {
 					"--- RECORDING TEST EVENT (test_test.go:65) ---",
 				))
 				Expect(t.Logs).To(ContainElement(
-					"--- ASSERTION REPORT (test_test.go:65) ---",
+					"--- ASSERTION REPORT (test_test.go:65) ---\n\n✓ pass unconditionally\n\n",
 				))
 			})
 		})
@@ -85,7 +85,7 @@ var _ = Describe("type Test", func() {
 					"--- ADVANCING TIME BY 3s (test_test.go:80) ---",
 				))
 				Expect(t.Logs).To(ContainElement(
-					"--- ASSERTION REPORT (test_test.go:80) ---",
+					"--- ASSERTION REPORT (test_test.go:80) ---\n\n✓ pass unconditionally\n\n",
 				))
 			})
 		})
@@ -100,7 +100,7 @@ var _ = Describe("type Test", func() {
 					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z (test_test.go:95) ---",
 				))
 				Expect(t.Logs).To(ContainElement(
-					"--- ASSERTION REPORT (test_test.go:95) ---",
+					"--- ASSERTION REPORT (test_test.go:95) ---\n\n✓ pass unconditionally\n\n",
 				))
 			})
 		})

--- a/test_test.go
+++ b/test_test.go
@@ -110,7 +110,6 @@ var _ = Describe("type Test", func() {
 type noopAssertion struct{}
 
 func (noopAssertion) Prepare(compare.Comparator) {
-
 }
 
 func (noopAssertion) Ok() bool {
@@ -126,5 +125,4 @@ func (noopAssertion) BuildReport(ok bool, r render.Renderer) *assert.Report {
 }
 
 func (noopAssertion) Notify(fact.Fact) {
-
 }


### PR DESCRIPTION
This PR adds file and line information assertion reports (fixes #38) and to the sections of the verbose logging that correspond to the calls the user makes in their test (such as `Prepare()`, `ExecuteCommand()`, `AdvanceTimeBy()`, etc).