### PR TITLE
Panic when an unrecognized message is given to the engine.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/enginekit/config"
@@ -146,15 +147,10 @@ func (e *Engine) Dispatch(
 	t := message.TypeOf(m)
 
 	if _, ok := e.routes[t]; !ok {
-		oo.observers.Notify(
-			fact.DispatchCycleSkipped{
-				Message:         m,
-				EngineTime:      oo.now,
-				EnabledHandlers: oo.enabledHandlers,
-			},
-		)
-
-		return nil
+		panic(fmt.Sprintf(
+			"dispatch cycle skipped because the %s message type is not routed to any handlers",
+			t,
+		))
 	}
 
 	r := e.roles[t]

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -148,7 +148,7 @@ func (e *Engine) Dispatch(
 
 	if _, ok := e.routes[t]; !ok {
 		panic(fmt.Sprintf(
-			"dispatch cycle skipped because the %s message type is not routed to any handlers",
+			"the %s message type is not consumed by any handlers",
 			t,
 		))
 	}

--- a/engine/fact/dispatch.go
+++ b/engine/fact/dispatch.go
@@ -3,7 +3,6 @@ package fact
 import (
 	"time"
 
-	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/enginekit/handler"
 	"github.com/dogmatiq/testkit/engine/envelope"
 )
@@ -20,17 +19,6 @@ type DispatchCycleBegun struct {
 type DispatchCycleCompleted struct {
 	Envelope        *envelope.Envelope
 	Error           error
-	EnabledHandlers map[handler.Type]bool
-}
-
-// DispatchCycleSkipped indicates that Engine.Dispatch() has been called
-// with a message that is not routed to any handlers.
-//
-// Note that when dispatch is called with an unroutable message, it is unknown
-// whether it was intended to be a command or an event.
-type DispatchCycleSkipped struct {
-	Message         dogma.Message
-	EngineTime      time.Time
 	EnabledHandlers map[handler.Type]bool
 }
 

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -28,8 +28,6 @@ func (l *Logger) Notify(f Fact) {
 	switch x := f.(type) {
 	case DispatchCycleBegun:
 		l.dispatchCycleBegun(x)
-	case DispatchCycleSkipped:
-		l.dispatchCycleSkipped(x)
 	case DispatchBegun:
 		l.dispatchBegun(x)
 	case HandlingCompleted:
@@ -91,20 +89,6 @@ func (l *Logger) dispatchCycleBegun(f DispatchCycleBegun) {
 		"dispatching",
 		formatEngineTime(f.EngineTime),
 		formatEnabledHandlers(f.EnabledHandlers),
-	)
-}
-
-// dispatchCycleSkipped returns the log message for f.
-func (l *Logger) dispatchCycleSkipped(f DispatchCycleSkipped) {
-	l.log(
-		&envelope.Envelope{},
-		[]logging.Icon{
-			logging.InboundIcon,
-			logging.SystemIcon,
-			"",
-		},
-		message.TypeOf(f.Message).String(),
-		"dispatch cycle skipped because this message type is not routed to any handlers",
 	)
 }
 

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -87,13 +87,6 @@ var _ = Describe("type Logger", func() {
 					Error:    errors.New("<error>"),
 				},
 			),
-			Entry(
-				"DispatchCycleSkipped",
-				"= ----  ∵ ----  ⋲ ----  ▼ ⚙    fixtures.MessageC ● dispatch cycle skipped because this message type is not routed to any handlers",
-				DispatchCycleSkipped{
-					Message: fixtures.MessageC1,
-				},
-			),
 
 			Entry(
 				"DispatchBegun",

--- a/engine/fact/observer_test.go
+++ b/engine/fact/observer_test.go
@@ -1,7 +1,6 @@
 package fact_test
 
 import (
-	"github.com/dogmatiq/enginekit/fixtures"
 	. "github.com/dogmatiq/testkit/engine/fact"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,8 +9,8 @@ import (
 var _ = Describe("type ObserverGroup", func() {
 	Describe("func Notify()", func() {
 		It("notifies each of the observers in the group", func() {
-			f := DispatchCycleSkipped{
-				Message: fixtures.MessageA1,
+			f := HandlingBegun{
+				HandlerName: "<handler-1>",
 			}
 			n := 0
 			g := ObserverGroup{
@@ -35,11 +34,11 @@ var _ = Describe("type ObserverGroup", func() {
 var _ = Describe("type Buffer", func() {
 	Describe("func Notify()", func() {
 		It("appends the fact to the buffer", func() {
-			f1 := DispatchCycleSkipped{
-				Message: fixtures.MessageA1,
+			f1 := HandlingBegun{
+				HandlerName: "<handler-1>",
 			}
-			f2 := DispatchCycleSkipped{
-				Message: fixtures.MessageA2,
+			f2 := HandlingBegun{
+				HandlerName: "<handler-2>",
 			}
 			b := &Buffer{}
 
@@ -57,8 +56,8 @@ var _ = Describe("type Buffer", func() {
 var _ = Describe("var Ignore", func() {
 	Describe("func Notify()", func() {
 		It("does nothing", func() {
-			Ignore.Notify(DispatchCycleSkipped{
-				Message: fixtures.MessageA1,
+			Ignore.Notify(HandlingBegun{
+				HandlerName: "<handler-1>",
 			})
 		})
 	})

--- a/test_test.go
+++ b/test_test.go
@@ -21,6 +21,22 @@ var _ = Describe("type Test", func() {
 		app = &fixtures.Application{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "<app-key>")
+				c.RegisterAggregate(&fixtures.AggregateMessageHandler{
+					RouteCommandToInstanceFunc: func(m dogma.Message) string {
+						return "<instance>"
+					},
+					ConfigureFunc: func(c dogma.AggregateConfigurer) {
+						c.Identity("<aggregate>", "<aggregate-key>")
+						c.ConsumesCommandType(fixtures.MessageC{})
+						c.ProducesEventType(fixtures.MessageE{})
+					},
+				})
+				c.RegisterProjection(&fixtures.ProjectionMessageHandler{
+					ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+						c.Identity("<projection>", "<projection-key>")
+						c.ConsumesEventType(fixtures.MessageE{})
+					},
+				})
 			},
 		}
 	})
@@ -63,7 +79,7 @@ var _ = Describe("type Test", func() {
 		Describe("func RecordEvent()", func() {
 			It("logs file and line information in headings", func() {
 				test.RecordEvent(
-					fixtures.MessageC1,
+					fixtures.MessageE1,
 					noopAssertion{},
 				)
 				Expect(t.Logs).To(ContainElement(


### PR DESCRIPTION
The previous behavior was to record a `DispatchCycleSkipped` fact and rely on the user's tests to capture the lack of activity as a result of the unrecognized message. Using a panic gives much more direct feedback.