### PR TITLE
Remove usage of enginekit errors.

### DIFF
--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -118,12 +118,24 @@ func (c *Controller) Handle(
 
 	c.handler.HandleCommand(s, env.Message)
 
-	if (s.created || s.destroyed) && len(s.events) == 0 {
-		panic(handler.EventNotRecordedError{
-			Handler:      c.identity,
-			InstanceID:   id,
-			WasDestroyed: s.destroyed,
-		})
+	if len(s.events) == 0 {
+		if s.created {
+			panic(fmt.Sprintf(
+				"the '%s' aggregate message handler created the '%s' instance without recording an event while handling a %s command",
+				c.identity.Name,
+				id,
+				message.TypeOf(env.Message),
+			))
+		}
+
+		if s.destroyed {
+			panic(fmt.Sprintf(
+				"the '%s' aggregate message handler destroyed the '%s' instance without recording an event while handling a %s command",
+				c.identity.Name,
+				id,
+				message.TypeOf(env.Message),
+			))
+		}
 	}
 
 	if s.exists {

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -96,10 +96,10 @@ func (c *Controller) Handle(
 		r = c.handler.New()
 
 		if r == nil {
-			panic(handler.NilRootError{
-				Handler:     c.identity,
-				HandlerType: c.Type(),
-			})
+			panic(fmt.Sprintf(
+				"the '%s' aggregate message handler returned a nil root from New()",
+				c.identity.Name,
+			))
 		}
 	}
 

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -2,6 +2,7 @@ package aggregate
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/dogmatiq/dogma"
@@ -67,10 +68,11 @@ func (c *Controller) Handle(
 
 	id := c.handler.RouteCommandToInstance(env.Message)
 	if id == "" {
-		panic(handler.EmptyInstanceIDError{
-			Handler:     c.identity,
-			HandlerType: c.Type(),
-		})
+		panic(fmt.Sprintf(
+			"the '%s' aggregate message handler attempted to route a %s command to an empty instance ID",
+			c.identity.Name,
+			message.TypeOf(env.Message),
+		))
 	}
 
 	r, exists := c.instances[id]

--- a/engine/controller/process/controller.go
+++ b/engine/controller/process/controller.go
@@ -117,10 +117,10 @@ func (c *Controller) Handle(
 		r = c.handler.New()
 
 		if r == nil {
-			panic(handler.NilRootError{
-				Handler:     c.identity,
-				HandlerType: c.Type(),
-			})
+			panic(fmt.Sprintf(
+				"the '%s' process message handler returned a nil root from New()",
+				c.identity.Name,
+			))
 		}
 	}
 

--- a/engine/controller/process/controller.go
+++ b/engine/controller/process/controller.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -180,10 +181,11 @@ func (c *Controller) routeEvent(
 
 	if ok {
 		if id == "" {
-			panic(handler.EmptyInstanceIDError{
-				Handler:     c.identity,
-				HandlerType: c.Type(),
-			})
+			panic(fmt.Sprintf(
+				"the '%s' process message handler attempted to route a %s event to an empty instance ID",
+				c.identity.Name,
+				message.TypeOf(env.Message),
+			))
 		}
 
 		return id, true, nil


### PR DESCRIPTION
These errors are somewhat internal to the engine, and as such they serve no interoperability purpose. I'm removing them solely to eliminate an unnecessary coupling to a shared module (enginekit, in this case).