### PR TITLE
Use `dogma/fixtures` instead of `enginekit/fixtures`, where possible.

### DIFF
--- a/compare/comparator_test.go
+++ b/compare/comparator_test.go
@@ -1,7 +1,7 @@
 package compare_test
 
 import (
-	"github.com/dogmatiq/enginekit/fixtures"
+	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/compare"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,22 +15,22 @@ var _ = Describe("type DefaultComparator", func() {
 	Describe("func MessageIsEqual", func() {
 		It("returns true if the values have the same type and value", func() {
 			Expect(comparator.MessageIsEqual(
-				fixtures.MessageA1,
-				fixtures.MessageA1,
+				MessageA1,
+				MessageA1,
 			)).To(BeTrue())
 		})
 
 		It("returns false if the values have the same type with different values", func() {
 			Expect(comparator.MessageIsEqual(
-				fixtures.MessageA1,
-				fixtures.MessageA2,
+				MessageA1,
+				MessageA2,
 			)).To(BeFalse())
 		})
 
 		It("returns false if the values are different types", func() {
 			Expect(comparator.MessageIsEqual(
-				fixtures.MessageA1,
-				fixtures.MessageA2,
+				MessageA1,
+				MessageA2,
 			)).To(BeFalse())
 		})
 	})
@@ -38,22 +38,22 @@ var _ = Describe("type DefaultComparator", func() {
 	Describe("func AggregateRootIsEqual", func() {
 		It("returns true if tlues have the same type and value", func() {
 			Expect(comparator.AggregateRootIsEqual(
-				&fixtures.AggregateRoot{Value: "<foo>"},
-				&fixtures.AggregateRoot{Value: "<foo>"},
+				&AggregateRoot{Value: "<foo>"},
+				&AggregateRoot{Value: "<foo>"},
 			)).To(BeTrue())
 		})
 
 		It("returns false if the values have the same type with different values", func() {
 			Expect(comparator.AggregateRootIsEqual(
-				&fixtures.AggregateRoot{Value: "<foo>"},
-				&fixtures.AggregateRoot{Value: "<bar>"},
+				&AggregateRoot{Value: "<foo>"},
+				&AggregateRoot{Value: "<bar>"},
 			)).To(BeFalse())
 		})
 
 		It("returns false if the values are different types", func() {
 			Expect(comparator.AggregateRootIsEqual(
-				&fixtures.AggregateRoot{Value: "<foo>"},
-				&struct{ fixtures.AggregateRoot }{},
+				&AggregateRoot{Value: "<foo>"},
+				&struct{ AggregateRoot }{},
 			)).To(BeFalse())
 		})
 	})
@@ -61,22 +61,22 @@ var _ = Describe("type DefaultComparator", func() {
 	Describe("func ProcessRootIsEqual", func() {
 		It("returns true if tlues have the same type and value", func() {
 			Expect(comparator.ProcessRootIsEqual(
-				&fixtures.ProcessRoot{Value: "<foo>"},
-				&fixtures.ProcessRoot{Value: "<foo>"},
+				&ProcessRoot{Value: "<foo>"},
+				&ProcessRoot{Value: "<foo>"},
 			)).To(BeTrue())
 		})
 
 		It("returns false if the values have the same type with different values", func() {
 			Expect(comparator.ProcessRootIsEqual(
-				&fixtures.ProcessRoot{Value: "<foo>"},
-				&fixtures.ProcessRoot{Value: "<bar>"},
+				&ProcessRoot{Value: "<foo>"},
+				&ProcessRoot{Value: "<bar>"},
 			)).To(BeFalse())
 		})
 
 		It("returns false if the values are different types", func() {
 			Expect(comparator.ProcessRootIsEqual(
-				&fixtures.ProcessRoot{Value: "<foo>"},
-				&struct{ fixtures.ProcessRoot }{},
+				&ProcessRoot{Value: "<foo>"},
+				&struct{ ProcessRoot }{},
 			)).To(BeFalse())
 		})
 	})

--- a/compare/fuzzy_test.go
+++ b/compare/fuzzy_test.go
@@ -3,7 +3,7 @@ package compare_test
 import (
 	"reflect"
 
-	"github.com/dogmatiq/enginekit/fixtures"
+	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/compare"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,8 +13,8 @@ var _ = Describe("func FuzzyTypeComparison", func() {
 	It("returns SameTypes when given two identical types", func() {
 		Expect(
 			FuzzyTypeComparison(
-				reflect.TypeOf(fixtures.MessageA1),
-				reflect.TypeOf(fixtures.MessageA1),
+				reflect.TypeOf(MessageA1),
+				reflect.TypeOf(MessageA1),
 			),
 		).To(Equal(
 			SameTypes,
@@ -24,8 +24,8 @@ var _ = Describe("func FuzzyTypeComparison", func() {
 	It("returns SameTypes when given two unrelated types", func() {
 		Expect(
 			FuzzyTypeComparison(
-				reflect.TypeOf(fixtures.MessageA1),
-				reflect.TypeOf(fixtures.MessageB1),
+				reflect.TypeOf(MessageA1),
+				reflect.TypeOf(MessageB1),
 			),
 		).To(Equal(
 			UnrelatedTypes,
@@ -33,8 +33,8 @@ var _ = Describe("func FuzzyTypeComparison", func() {
 	})
 
 	It("returns some intermediate value when given types that differ only by 'pointer depth'", func() {
-		a := reflect.PtrTo(reflect.TypeOf(fixtures.MessageA1))
-		b := reflect.TypeOf(fixtures.MessageA1)
+		a := reflect.PtrTo(reflect.TypeOf(MessageA1))
+		b := reflect.TypeOf(MessageA1)
 
 		sim := FuzzyTypeComparison(a, b)
 
@@ -43,8 +43,8 @@ var _ = Describe("func FuzzyTypeComparison", func() {
 	})
 
 	It("returns the same value regardless of parameter order", func() {
-		a := reflect.PtrTo(reflect.TypeOf(fixtures.MessageA1))
-		b := reflect.TypeOf(fixtures.MessageA1)
+		a := reflect.PtrTo(reflect.TypeOf(MessageA1))
+		b := reflect.TypeOf(MessageA1)
 
 		Expect(
 			FuzzyTypeComparison(a, b),
@@ -54,7 +54,7 @@ var _ = Describe("func FuzzyTypeComparison", func() {
 	})
 
 	It("returns a higher value for more similar types", func() {
-		a := reflect.TypeOf(fixtures.MessageA1)
+		a := reflect.TypeOf(MessageA1)
 		b := reflect.PtrTo(a)
 		c := reflect.PtrTo(b)
 

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dogmatiq/testkit/engine/controller"
-
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/enginekit/fixtures"
 	handlerkit "github.com/dogmatiq/enginekit/handler"
 	"github.com/dogmatiq/enginekit/identity"
 	"github.com/dogmatiq/enginekit/message"
+	"github.com/dogmatiq/testkit/engine/controller"
 	. "github.com/dogmatiq/testkit/engine/controller/aggregate"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	"github.com/dogmatiq/testkit/engine/fact"

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/enginekit/fixtures"
+	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/engine"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/dogmatiq/enginekit/fixtures"
+	. "github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/enginekit/handler"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	. "github.com/dogmatiq/testkit/engine/fact"
@@ -22,13 +22,13 @@ var _ = Describe("type Logger", func() {
 
 		command := envelope.NewCommand(
 			"100",
-			fixtures.MessageC1,
+			MessageC1,
 			time.Now(),
 		)
 
 		event := envelope.NewEvent(
 			"100",
-			fixtures.MessageE1,
+			MessageE1,
 			time.Now(),
 		)
 
@@ -234,7 +234,7 @@ var _ = Describe("type Logger", func() {
 					Envelope:    command,
 					EventEnvelope: command.NewEvent(
 						"200",
-						fixtures.MessageE1,
+						MessageE1,
 						time.Now(),
 						envelope.Origin{},
 					),
@@ -316,7 +316,7 @@ var _ = Describe("type Logger", func() {
 					Envelope:    event,
 					CommandEnvelope: event.NewCommand(
 						"200",
-						fixtures.MessageC1,
+						MessageC1,
 						time.Now(),
 						envelope.Origin{},
 					),
@@ -330,7 +330,7 @@ var _ = Describe("type Logger", func() {
 					InstanceID:  "<instance>",
 					TimeoutEnvelope: event.NewTimeout(
 						"200",
-						fixtures.MessageT1,
+						MessageT1,
 						time.Now(),
 						now,
 						envelope.Origin{
@@ -363,7 +363,7 @@ var _ = Describe("type Logger", func() {
 					Envelope:    command,
 					EventEnvelope: command.NewEvent(
 						"200",
-						fixtures.MessageE1,
+						MessageE1,
 						time.Now(),
 						envelope.Origin{},
 					),

--- a/render/renderer_test.go
+++ b/render/renderer_test.go
@@ -3,7 +3,7 @@ package render
 import (
 	"io"
 
-	"github.com/dogmatiq/enginekit/fixtures"
+	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflicts
 	"github.com/dogmatiq/iago/iotest"
 	"github.com/dogmatiq/iago/must"
 	. "github.com/onsi/ginkgo"

--- a/render/string_test.go
+++ b/render/string_test.go
@@ -3,7 +3,7 @@ package render_test
 import (
 	"strings"
 
-	"github.com/dogmatiq/enginekit/fixtures"
+	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflicts
 	. "github.com/dogmatiq/testkit/render"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test_test.go
+++ b/test_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/dogmatiq/dogma"
-	"github.com/dogmatiq/enginekit/fixtures"
+	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/assert"
 	"github.com/dogmatiq/testkit/compare"
@@ -15,26 +15,26 @@ import (
 )
 
 var _ = Describe("type Test", func() {
-	var app *fixtures.Application
+	var app *Application
 
 	BeforeEach(func() {
-		app = &fixtures.Application{
+		app = &Application{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "<app-key>")
-				c.RegisterAggregate(&fixtures.AggregateMessageHandler{
+				c.RegisterAggregate(&AggregateMessageHandler{
 					RouteCommandToInstanceFunc: func(m dogma.Message) string {
 						return "<instance>"
 					},
 					ConfigureFunc: func(c dogma.AggregateConfigurer) {
 						c.Identity("<aggregate>", "<aggregate-key>")
-						c.ConsumesCommandType(fixtures.MessageC{})
-						c.ProducesEventType(fixtures.MessageE{})
+						c.ConsumesCommandType(MessageC{})
+						c.ProducesEventType(MessageE{})
 					},
 				})
-				c.RegisterProjection(&fixtures.ProjectionMessageHandler{
+				c.RegisterProjection(&ProjectionMessageHandler{
 					ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 						c.Identity("<projection>", "<projection-key>")
-						c.ConsumesEventType(fixtures.MessageE{})
+						c.ConsumesEventType(MessageE{})
 					},
 				})
 			},
@@ -64,7 +64,7 @@ var _ = Describe("type Test", func() {
 		Describe("func ExecuteCommand()", func() {
 			It("logs file and line information in headings", func() {
 				test.ExecuteCommand(
-					fixtures.MessageC1,
+					MessageC1,
 					noopAssertion{},
 				)
 				Expect(t.Logs).To(ContainElement(
@@ -79,7 +79,7 @@ var _ = Describe("type Test", func() {
 		Describe("func RecordEvent()", func() {
 			It("logs file and line information in headings", func() {
 				test.RecordEvent(
-					fixtures.MessageE1,
+					MessageE1,
 					noopAssertion{},
 				)
 				Expect(t.Logs).To(ContainElement(

--- a/testoption_test.go
+++ b/testoption_test.go
@@ -5,10 +5,9 @@ import (
 	"time"
 
 	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/engine"
-
-	"github.com/dogmatiq/enginekit/fixtures"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -18,10 +17,10 @@ var _ = Describe("func WithStartTime()", func() {
 		now := time.Date(2001, 2, 3, 4, 5, 6, 7, time.UTC)
 		called := false
 
-		handler := &fixtures.ProjectionMessageHandler{
+		handler := &ProjectionMessageHandler{
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<handler-name>", "<handler-key>")
-				c.ConsumesEventType(fixtures.MessageA{})
+				c.ConsumesEventType(MessageA{})
 			},
 			HandleEventFunc: func(
 				_ context.Context,
@@ -35,7 +34,7 @@ var _ = Describe("func WithStartTime()", func() {
 			},
 		}
 
-		app := &fixtures.Application{
+		app := &Application{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "<app-key>")
 				c.RegisterProjection(handler)
@@ -50,7 +49,7 @@ var _ = Describe("func WithStartTime()", func() {
 					engine.EnableProjections(true),
 				),
 			).
-			Prepare(fixtures.MessageA1)
+			Prepare(MessageA1)
 
 		Expect(called).To(BeTrue())
 	})


### PR DESCRIPTION
This is in preparation for a switch from `enginekit/config` to `configkit` (#48).