### PR TITLE
Add `assert.Should()`, for specifying user-defined assertions.

### DIFF
--- a/assert/message_test.go
+++ b/assert/message_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = Describe("type MessageAssertion", func() {
+var _ = Describe("type messageAssertion", func() {
 	var (
 		aggregate   *AggregateMessageHandler
 		process     *ProcessMessageHandler

--- a/assert/user.go
+++ b/assert/user.go
@@ -8,7 +8,7 @@ import (
 
 // AssertionContext is passed to user-defined assertion functions.
 type AssertionContext struct {
-	// Comparitor provides logic for comparing messages and application state.
+	// Comparator provides logic for comparing messages and application state.
 	Comparator compare.Comparator
 
 	// Facts is an ordered slice of the facts that occurred.

--- a/assert/user.go
+++ b/assert/user.go
@@ -69,7 +69,7 @@ func (a *userDefined) Ok() bool {
 // BuildReport generates a report about the assertion.
 //
 // ok is true if the assertion is considered to have passed. This may not be
-// the same value as returned from Ok() when this assertion is used as
+// the same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
 func (a *userDefined) BuildReport(ok bool, r render.Renderer) *Report {
 	rep := &Report{

--- a/assert/user.go
+++ b/assert/user.go
@@ -29,14 +29,14 @@ func Should(
 	cr string,
 	fn func(AssertionContext) error,
 ) Assertion {
-	return &userDefined{
+	return &userAssertion{
 		criteria: cr,
 		assert:   fn,
 	}
 }
 
-// userDefined is a user-defined assertion.
-type userDefined struct {
+// userAssertion is a user-defined assertion.
+type userAssertion struct {
 	criteria string
 	assert   func(AssertionContext) error
 	ctx      AssertionContext
@@ -45,19 +45,19 @@ type userDefined struct {
 }
 
 // Notify the observer of a fact.
-func (a *userDefined) Notify(f fact.Fact) {
+func (a *userAssertion) Notify(f fact.Fact) {
 	a.ctx.Facts = append(a.ctx.Facts, f)
 }
 
 // Prepare is called to prepare the assertion for a new test.
 //
 // c is the comparator used to compare messages and other entities.
-func (a *userDefined) Prepare(c compare.Comparator) {
+func (a *userAssertion) Prepare(c compare.Comparator) {
 	a.ctx.Comparator = c
 }
 
 // Ok returns true if the assertion passed.
-func (a *userDefined) Ok() bool {
+func (a *userAssertion) Ok() bool {
 	if !a.done {
 		a.err = a.assert(a.ctx)
 		a.done = true
@@ -71,7 +71,7 @@ func (a *userDefined) Ok() bool {
 // ok is true if the assertion is considered to have passed. This may not be
 // the same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
-func (a *userDefined) BuildReport(ok bool, r render.Renderer) *Report {
+func (a *userAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 	rep := &Report{
 		TreeOk:   ok,
 		Ok:       a.Ok(),

--- a/assert/user.go
+++ b/assert/user.go
@@ -1,0 +1,89 @@
+package assert
+
+import (
+	"github.com/dogmatiq/testkit/compare"
+	"github.com/dogmatiq/testkit/engine/fact"
+	"github.com/dogmatiq/testkit/render"
+)
+
+// AssertionContext is passed to user-defined assertion functions.
+type AssertionContext struct {
+	// Comparitor provides logic for comparing messages and application state.
+	Comparator compare.Comparator
+
+	// Facts is an ordered slice of the facts that occurred.
+	Facts []fact.Fact
+}
+
+// Should returns an assertion that uses a user-defined function to check for
+// specific criteria.
+//
+// cr is a human-readable description of the expectation of the assertion. It
+// should be phrased as an imperative statement, such as "insert a customer".
+//
+// fn is the function that performs the assertion logic. It returns a non-nil
+// error to indicate an assertion failure. It is passed an AssertionContext
+// which contains dependencies and engine state that can be used to implement
+// the assertion logic.
+func Should(
+	cr string,
+	fn func(AssertionContext) error,
+) Assertion {
+	return &userDefined{
+		criteria: cr,
+		assert:   fn,
+	}
+}
+
+// userDefined is a user-defined assertion.
+type userDefined struct {
+	criteria string
+	assert   func(AssertionContext) error
+	ctx      AssertionContext
+	done     bool
+	err      error
+}
+
+// Notify the observer of a fact.
+func (a *userDefined) Notify(f fact.Fact) {
+	a.ctx.Facts = append(a.ctx.Facts, f)
+}
+
+// Prepare is called to prepare the assertion for a new test.
+//
+// c is the comparator used to compare messages and other entities.
+func (a *userDefined) Prepare(c compare.Comparator) {
+	a.ctx.Comparator = c
+}
+
+// Ok returns true if the assertion passed.
+func (a *userDefined) Ok() bool {
+	if !a.done {
+		a.err = a.assert(a.ctx)
+		a.done = true
+	}
+
+	return a.err == nil
+}
+
+// BuildReport generates a report about the assertion.
+//
+// ok is true if the assertion is considered to have passed. This may not be
+// the same value as returned from Ok() when this assertion is used as
+// sub-assertion inside a composite.
+func (a *userDefined) BuildReport(ok bool, r render.Renderer) *Report {
+	rep := &Report{
+		TreeOk:   ok,
+		Ok:       a.Ok(),
+		Criteria: a.criteria,
+	}
+
+	if ok || a.Ok() {
+		return rep
+	}
+
+	rep.Outcome = "the user-defined assertion returned a non-nil error"
+	rep.Explanation = a.err.Error()
+
+	return rep
+}

--- a/assert/user_test.go
+++ b/assert/user_test.go
@@ -1,0 +1,110 @@
+package assert_test
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/testkit"
+	"github.com/dogmatiq/testkit/assert"
+	. "github.com/dogmatiq/testkit/assert"
+	"github.com/dogmatiq/testkit/internal/testingmock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("type userAssertion", func() {
+	var (
+		aggregate *AggregateMessageHandler
+		app       dogma.Application
+	)
+
+	BeforeEach(func() {
+		aggregate = &AggregateMessageHandler{
+			ConfigureFunc: func(c dogma.AggregateConfigurer) {
+				c.Identity("<aggregate>", "<aggregate-key>")
+				c.ConsumesCommandType(MessageA{})
+				c.ProducesEventType(MessageB{})
+			},
+			RouteCommandToInstanceFunc: func(dogma.Message) string {
+				return "<aggregate-instance>"
+			},
+			HandleCommandFunc: func(
+				s dogma.AggregateCommandScope,
+				m dogma.Message,
+			) {
+				s.Create()
+				s.RecordEvent(
+					MessageB{Value: "<value>"},
+				)
+			},
+		}
+
+		app = &Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+				c.RegisterAggregate(aggregate)
+			},
+		}
+	})
+
+	test := func(
+		assertion Assertion,
+		ok bool,
+		report ...string,
+	) {
+		t := &testingmock.T{
+			FailSilently: true,
+		}
+
+		testkit.
+			New(app).
+			Begin(t).
+			ExecuteCommand(
+				MessageA{},
+				assertion,
+			)
+
+		logs := strings.TrimSpace(strings.Join(t.Logs, "\n"))
+		lines := strings.Split(logs, "\n")
+
+		gomega.Expect(lines).To(gomega.Equal(report))
+		gomega.Expect(t.Failed).To(gomega.Equal(!ok))
+	}
+
+	DescribeTable(
+		"func Should()",
+		test,
+		Entry(
+			"assertion passed",
+			assert.Should(
+				"<criteria>",
+				func(AssertionContext) error {
+					return nil
+				},
+			),
+			true, // ok
+			`--- ASSERTION REPORT ---`,
+			``,
+			`✓ <criteria>`,
+		),
+		Entry(
+			"assertion failed",
+			assert.Should(
+				"<criteria>",
+				func(AssertionContext) error {
+					return errors.New("<explanation>")
+				},
+			),
+			false, // ok
+			`--- ASSERTION REPORT ---`,
+			``,
+			`✗ <criteria> (the user-defined assertion returned a non-nil error)`,
+			``,
+			`  | EXPLANATION`,
+			`  |     <explanation>`,
+		),
+	)
+})


### PR DESCRIPTION
This PR adds the `assert.Should()` method, which allows the user to provide a function to be used as an assertion in the test runner.

Fixes #46.
