### PR TITLE
Provide a testing.T-like value to custom user assertions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+## Added
+
+- **[BC]** Add `assert.Assertion.End()`
+
+## Changed
+
+- **[BC]** Changed `assert.Should()` to provide a `testing.T`-like value, instead of using an error to indicate an assertion failure
+- **[BC]** Rename `assert.Assertion.Prepare()` to `Begin()`
+- **[BC]** Add `verbose` parameter to `assert.Assertion.BuildReport()`
+
 ## [0.4.0] - 2020-02-04
 
 ### Added

--- a/assert/report.go
+++ b/assert/report.go
@@ -155,6 +155,7 @@ var (
 
 const (
 	suggestionsSection     = "Suggestions"
+	logSection             = "Log Messages"
 	messageDiffSection     = "Message Diff"
 	messageTypeDiffSection = "Message Type Diff"
 )

--- a/assert/user.go
+++ b/assert/user.go
@@ -1,68 +1,73 @@
 package assert
 
 import (
+	"fmt"
+
 	"github.com/dogmatiq/testkit/compare"
 	"github.com/dogmatiq/testkit/engine/fact"
 	"github.com/dogmatiq/testkit/render"
 )
 
-// AssertionContext is passed to user-defined assertion functions.
-type AssertionContext struct {
-	// Comparator provides logic for comparing messages and application state.
-	Comparator compare.Comparator
-
-	// Facts is an ordered slice of the facts that occurred.
-	Facts []fact.Fact
-}
-
 // Should returns an assertion that uses a user-defined function to check for
 // specific criteria.
 //
-// cr is a human-readable description of the expectation of the assertion. It
-// should be phrased as an imperative statement, such as "insert a customer".
+// cr is a human-readable description of the "criteria" or the "expectation"
+// that results in a passing assertion. It should be phrased as an imperative
+// statement, such as "insert a customer".
 //
-// fn is the function that performs the assertion logic. It returns a non-nil
-// error to indicate an assertion failure. It is passed an AssertionContext
-// which contains dependencies and engine state that can be used to implement
-// the assertion logic.
+// fn is the function that performs the assertion logic. It is passed a *T
+// value, which is a superset of the *testing.T struct that is passed
 func Should(
 	cr string,
-	fn func(AssertionContext) error,
+	fn func(t *T),
 ) Assertion {
 	return &userAssertion{
-		criteria: cr,
-		assert:   fn,
+		t:      T{name: cr},
+		assert: fn,
 	}
 }
 
 // userAssertion is a user-defined assertion.
 type userAssertion struct {
-	criteria string
-	assert   func(AssertionContext) error
-	ctx      AssertionContext
-	err      error
+	t      T
+	assert func(*T)
 }
 
 // Notify the observer of a fact.
 func (a *userAssertion) Notify(f fact.Fact) {
-	a.ctx.Facts = append(a.ctx.Facts, f)
+	a.t.Facts = append(a.t.Facts, f)
 }
 
 // Begin is called to prepare the assertion for a new test.
 //
 // c is the comparator used to compare messages and other entities.
 func (a *userAssertion) Begin(c compare.Comparator) {
-	a.ctx.Comparator = c
+	a.t.Comparator = c
 }
 
 // End is called once the test is complete.
 func (a *userAssertion) End() {
-	a.err = a.assert(a.ctx)
+	defer func() {
+		for i := len(a.t.cleanup) - 1; i >= 0; i-- {
+			a.t.cleanup[i]()
+		}
+
+		switch r := recover().(type) {
+		case abortUserAssertion:
+			return // keep to see coverage
+		case nil:
+			return // keep to see coverage
+		default:
+			panic(r)
+		}
+	}()
+
+	a.assert(&a.t)
 }
 
 // Ok returns true if the assertion passed.
 func (a *userAssertion) Ok() bool {
-	return a.err == nil
+	return !a.t.failed
 }
 
 // BuildReport generates a report about the assertion.
@@ -74,15 +79,143 @@ func (a *userAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report
 	rep := &Report{
 		TreeOk:   ok,
 		Ok:       a.Ok(),
-		Criteria: a.criteria,
+		Criteria: a.t.name,
 	}
 
 	if ok || a.Ok() {
 		return rep
 	}
 
-	rep.Outcome = "the user-defined assertion returned a non-nil error"
-	rep.Explanation = a.err.Error()
+	if a.t.failed {
+		rep.Outcome = "the user-defined assertion failed"
+	} else if a.t.skipped {
+		rep.Outcome = "the user-defined assertion was skipped"
+	}
+
+	if len(a.t.messages) == 1 && a.t.explanation != "" {
+		// If there is only one log message, and it was supplied by Error(),
+		// Errorf(), Fatal(), or Fatalf(), show it as the explanation, rather
+		// than in a logging section.
+		rep.Explanation = a.t.explanation
+		return rep
+	}
 
 	return rep
+}
+
+// T is a superset of *testing.T that is passed to user-defined assertion
+// functions.
+type T struct {
+	// Comparator provides logic for comparing messages and application state.
+	compare.Comparator
+
+	// Facts is an ordered slice of the facts that occurred.
+	Facts []fact.Fact
+
+	name        string
+	skipped     bool
+	failed      bool
+	explanation string
+	messages    []string
+	cleanup     []func()
+}
+
+type abortUserAssertion struct{}
+
+// Cleanup registers a function to be called when the test is complete. Cleanup
+// functions will be called in last added, first called order.
+func (t *T) Cleanup(fn func()) {
+	t.cleanup = append(t.cleanup, fn)
+}
+
+// Error is equivalent to Log() followed by Fail().
+func (t *T) Error(args ...interface{}) {
+	t.log(true, fmt.Sprint(args...))
+	t.Fail()
+}
+
+// Errorf is equivalent to Logf() followed by Fail().
+func (t *T) Errorf(format string, args ...interface{}) {
+	t.log(true, fmt.Sprintf(format, args...))
+	t.Fail()
+}
+
+// Fail marks the function as having failed but continues execution.
+func (t *T) Fail() {
+	t.failed = true
+}
+
+// FailNow marks the function as having failed and stops its execution.
+func (t *T) FailNow() {
+	t.failed = true
+	panic(abortUserAssertion{})
+}
+
+// Failed reports whether the test has failed.
+func (t *T) Failed() bool {
+	return t.failed
+}
+
+// Fatal is equivalent to Log() followed by FailNow().
+func (t *T) Fatal(args ...interface{}) {
+	t.log(true, fmt.Sprint(args...))
+	t.FailNow()
+}
+
+// Fatalf is equivalent to Logf() followed by FailNow().
+func (t *T) Fatalf(format string, args ...interface{}) {
+	t.log(true, fmt.Sprintf(format, args...))
+	t.FailNow()
+}
+
+// Helper marks the calling function as a test helper function.
+func (t *T) Helper() {
+}
+
+// Log formats its arguments using default formatting, analogous to Println(),
+// and records the text in the assertion report.
+func (t *T) Log(args ...interface{}) {
+	t.log(false, fmt.Sprint(args...))
+}
+
+// Logf formats its arguments according to the format, analogous to Printf(),
+// and records the text in the assertion report.
+func (t *T) Logf(format string, args ...interface{}) {
+	t.log(false, fmt.Sprintf(format, args...))
+}
+
+// Name returns the name of the running test.
+func (t *T) Name() string {
+	return t.name
+}
+
+// Skip is equivalent to Log() followed by SkipNow().
+func (t *T) Skip(args ...interface{}) {
+	t.Log(args...)
+	t.SkipNow()
+}
+
+// SkipNow marks the test as having been skipped and stops its execution.
+func (t *T) SkipNow() {
+	t.skipped = true
+	panic(abortUserAssertion{})
+}
+
+// Skipf is equivalent to Logf() followed by SkipNow().
+func (t *T) Skipf(format string, args ...interface{}) {
+	t.Logf(format, args...)
+	t.SkipNow()
+}
+
+// Skipped reports whether the test was skipped.
+func (t *T) Skipped() bool {
+	return t.skipped
+}
+
+func (t *T) log(fail bool, s string) {
+	t.messages = append(t.messages, s)
+
+	if fail && t.explanation == "" {
+		t.explanation = s
+	}
 }

--- a/assert/user.go
+++ b/assert/user.go
@@ -168,7 +168,18 @@ func (t *T) Fatalf(format string, args ...interface{}) {
 	t.FailNow()
 }
 
+// Parallel signals that this test is to be run in parallel with (and only with)
+// other parallel tests.
+//
+// It is a no-op in this implementation, but is included to increase
+// compatibility with the *testing.T type.
+func (t *T) Parallel() {
+}
+
 // Helper marks the calling function as a test helper function.
+//
+// It is a no-op in this implementation, but is included to increase
+// compatibility with the *testing.T type.
 func (t *T) Helper() {
 }
 

--- a/assert/user_test.go
+++ b/assert/user_test.go
@@ -1,7 +1,6 @@
 package assert_test
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/dogmatiq/dogma"
@@ -68,9 +67,7 @@ var _ = Context("user assertions", func() {
 				"assertion passed",
 				Should(
 					"<criteria>",
-					func(AssertionContext) error {
-						return nil
-					},
+					func(*T) {},
 				),
 				true, // ok
 				`--- ASSERTION REPORT ---`,
@@ -81,14 +78,14 @@ var _ = Context("user assertions", func() {
 				"assertion failed",
 				Should(
 					"<criteria>",
-					func(AssertionContext) error {
-						return errors.New("<explanation>")
+					func(t *T) {
+						t.Fatal("<explanation>")
 					},
 				),
 				false, // ok
 				`--- ASSERTION REPORT ---`,
 				``,
-				`✗ <criteria> (the user-defined assertion returned a non-nil error)`,
+				`✗ <criteria> (the user-defined assertion failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     <explanation>`,

--- a/assert/user_test.go
+++ b/assert/user_test.go
@@ -36,7 +36,7 @@ var _ = Context("user assertions", func() {
 	})
 
 	test := func(
-		assertion Assertion,
+		fn func(*T),
 		ok bool,
 		report ...string,
 	) {
@@ -46,10 +46,10 @@ var _ = Context("user assertions", func() {
 
 		testkit.
 			New(app).
-			Begin(t).
+			Begin(t, testkit.Verbose(false)).
 			ExecuteCommand(
 				MessageA{},
-				assertion,
+				Should("<criteria>", fn),
 			)
 
 		logs := strings.TrimSpace(strings.Join(t.Logs, "\n"))
@@ -65,10 +65,7 @@ var _ = Context("user assertions", func() {
 			test,
 			Entry(
 				"assertion passed",
-				Should(
-					"<criteria>",
-					func(*T) {},
-				),
+				func(*T) {},
 				true, // ok
 				`--- ASSERTION REPORT ---`,
 				``,
@@ -76,20 +73,428 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion failed",
-				Should(
-					"<criteria>",
-					func(t *T) {
-						t.Fatal("<explanation>")
-					},
-				),
+				func(t *T) {
+					t.Fail()
+				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
 				``,
 				`✗ <criteria> (the user-defined assertion failed)`,
 				``,
 				`  | EXPLANATION`,
-				`  |     <explanation>`,
+				`  |     Fail() called at user_test.go:77`,
+			),
+			Entry(
+				"assertion skipped",
+				func(t *T) {
+					t.SkipNow()
+				},
+				true, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✓ <criteria> (the user-defined assertion was skipped)`,
+			),
+			Entry(
+				"assertion logged a message with Log()",
+				func(t *T) {
+					t.Log("<message>")
+					t.Fail() // must fail for log to be shown
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Fail() called at user_test.go:101`,
+				`  | `,
+				`  | LOG MESSAGES`,
+				`  |     <message>`,
+			),
+			Entry(
+				"assertion logged a message with Logf()",
+				func(t *T) {
+					t.Logf("<format %s>", "value")
+					t.Fail() // must fail for log to be shown
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Fail() called at user_test.go:118`,
+				`  | `,
+				`  | LOG MESSAGES`,
+				`  |     <format value>`,
+			),
+			Entry(
+				"assertion logged a message with Error()",
+				func(t *T) {
+					t.Error("<message>")
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Error() called at user_test.go:134`,
+				`  | `,
+				`  | LOG MESSAGES`,
+				`  |     <message>`,
+			),
+			Entry(
+				"assertion logged a message with Errorf()",
+				func(t *T) {
+					t.Errorf("<format %s>", "value")
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Errorf() called at user_test.go:150`,
+				`  | `,
+				`  | LOG MESSAGES`,
+				`  |     <format value>`,
+			),
+			Entry(
+				"assertion logged a message with Fatal()",
+				func(t *T) {
+					t.Fatal("<message>")
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Fatal() called at user_test.go:166`,
+				`  | `,
+				`  | LOG MESSAGES`,
+				`  |     <message>`,
+			),
+			Entry(
+				"assertion logged a message with Fatalf()",
+				func(t *T) {
+					t.Fatalf("<format %s>", "value")
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Fatalf() called at user_test.go:182`,
+				`  | `,
+				`  | LOG MESSAGES`,
+				`  |     <format value>`,
+			),
+			Entry(
+				"assertion failed within helper",
+				func(t *T) {
+					helper := func() {
+						t.Helper()
+						t.Fail()
+					}
+
+					helper()
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Fail() called indirectly by call at user_test.go:203`,
+			),
+			Entry(
+				"assertion failed with fn marked as a helper",
+				func(t *T) {
+					t.Helper()
+					t.Fail()
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Fail() called at user_test.go:217`,
+			),
+			Entry(
+				"assertion failed within helper, with fn also marked as a helper",
+				func(t *T) {
+					t.Helper()
+
+					helper := func() {
+						t.Helper()
+						t.Fail()
+					}
+
+					helper()
+				},
+				false, // ok
+				`--- ASSERTION REPORT ---`,
+				``,
+				`✗ <criteria> (the user-defined assertion failed)`,
+				``,
+				`  | EXPLANATION`,
+				`  |     Fail() called indirectly by call at user_test.go:237`,
 			),
 		)
+	})
+
+	Describe("type T", func() {
+		var run func(func(*T)) *testingmock.T
+
+		BeforeEach(func() {
+			run = func(fn func(*T)) *testingmock.T {
+				t := &testingmock.T{
+					FailSilently: true,
+				}
+
+				testkit.
+					New(app).
+					Begin(t).
+					ExecuteCommand(
+						MessageA{},
+						Should("<criteria>", fn),
+					)
+
+				return t
+			}
+		})
+
+		Describe("func Cleanup()", func() {
+			It("registers a function to be executed when the test ends", func() {
+				called := false
+				run(func(t *T) {
+					t.Cleanup(func() {
+						called = true
+					})
+				})
+
+				gomega.Expect(called).To(gomega.BeTrue())
+			})
+		})
+
+		Describe("func Error()", func() {
+			It("marks the test as failed", func() {
+				run(func(t *T) {
+					t.Error()
+					gomega.Expect(t.Failed()).To(gomega.BeTrue())
+				})
+			})
+
+			It("does not abort execution", func() {
+				completed := false
+				run(func(t *T) {
+					t.Error()
+					completed = true
+				})
+
+				gomega.Expect(completed).To(gomega.BeTrue())
+			})
+		})
+
+		Describe("func Errorf()", func() {
+			It("marks the test as failed", func() {
+				run(func(t *T) {
+					t.Errorf("<format>")
+					gomega.Expect(t.Failed()).To(gomega.BeTrue())
+				})
+			})
+
+			It("does not abort execution", func() {
+				completed := false
+				run(func(t *T) {
+					t.Errorf("<format>")
+					completed = true
+				})
+
+				gomega.Expect(completed).To(gomega.BeTrue())
+			})
+		})
+
+		Describe("func Fail()", func() {
+			It("marks the test as failed", func() {
+				run(func(t *T) {
+					t.Fail()
+					gomega.Expect(t.Failed()).To(gomega.BeTrue())
+				})
+			})
+
+			It("does not abort execution", func() {
+				completed := false
+				run(func(t *T) {
+					t.Fail()
+					completed = true
+				})
+
+				gomega.Expect(completed).To(gomega.BeTrue())
+			})
+		})
+
+		Describe("func FailNow()", func() {
+			It("marks the test as failed", func() {
+				run(func(t *T) {
+					defer func() {
+						gomega.Expect(t.Failed()).To(gomega.BeTrue())
+					}()
+
+					t.FailNow()
+				})
+			})
+
+			It("aborts execution", func() {
+				run(func(t *T) {
+					t.FailNow()
+					Fail("execution was not aborted")
+				})
+			})
+		})
+
+		Describe("func Fatal()", func() {
+			It("marks the test as failed", func() {
+				run(func(t *T) {
+					defer func() {
+						gomega.Expect(t.Failed()).To(gomega.BeTrue())
+					}()
+
+					t.Fatal()
+				})
+			})
+
+			It("aborts execution", func() {
+				run(func(t *T) {
+					t.Fatal()
+					Fail("execution was not aborted")
+				})
+			})
+		})
+
+		Describe("func Fatalf()", func() {
+			It("marks the test as failed", func() {
+				run(func(t *T) {
+					defer func() {
+						gomega.Expect(t.Failed()).To(gomega.BeTrue())
+					}()
+
+					t.Fatalf("<format>")
+				})
+			})
+
+			It("aborts execution", func() {
+				run(func(t *T) {
+					t.Fatalf("<format>")
+					Fail("execution was not aborted")
+				})
+			})
+		})
+
+		Describe("func Parallel()", func() {
+			It("does not panic", func() {
+				run(func(t *T) {
+					gomega.Expect(func() {
+						t.Parallel()
+					}).NotTo(gomega.Panic())
+				})
+			})
+		})
+
+		Describe("func Name()", func() {
+			It("returns the criteria string", func() {
+				run(func(t *T) {
+					gomega.Expect(t.Name()).To(gomega.Equal("<criteria>"))
+				})
+			})
+		})
+
+		Describe("func Skip()", func() {
+			It("marks the test as skipped", func() {
+				run(func(t *T) {
+					defer func() {
+						gomega.Expect(t.Skipped()).To(gomega.BeTrue())
+					}()
+
+					t.Skip()
+				})
+			})
+
+			It("prevents a failure from taking effect", func() {
+				t := run(func(t *T) {
+					t.Fail()
+					t.Skip()
+				})
+
+				gomega.Expect(t.Failed).To(gomega.BeFalse())
+			})
+
+			It("aborts execution", func() {
+				run(func(t *T) {
+					t.Skip()
+					Fail("execution was not aborted")
+				})
+			})
+		})
+
+		Describe("func SkipNow(", func() {
+			It("marks the test as skipped", func() {
+				run(func(t *T) {
+					defer func() {
+						gomega.Expect(t.Skipped()).To(gomega.BeTrue())
+					}()
+
+					t.SkipNow()
+				})
+			})
+
+			It("prevents a failure from taking effect", func() {
+				t := run(func(t *T) {
+					t.Fail()
+					t.SkipNow()
+				})
+
+				gomega.Expect(t.Failed).To(gomega.BeFalse())
+			})
+
+			It("aborts execution", func() {
+				run(func(t *T) {
+					t.SkipNow()
+					Fail("execution was not aborted")
+				})
+			})
+		})
+
+		Describe("func Skipf()", func() {
+			It("marks the test as skipped", func() {
+				run(func(t *T) {
+					defer func() {
+						gomega.Expect(t.Skipped()).To(gomega.BeTrue())
+					}()
+
+					t.Skipf("<format>")
+				})
+			})
+
+			It("prevents a failure from taking effect", func() {
+				t := run(func(t *T) {
+					t.Fail()
+					t.Skipf("<format>")
+				})
+
+				gomega.Expect(t.Failed).To(gomega.BeFalse())
+			})
+
+			It("aborts execution", func() {
+				run(func(t *T) {
+					t.Skipf("<format>")
+					Fail("execution was not aborted")
+				})
+			})
+		})
 	})
 })


### PR DESCRIPTION
This PR changes `assert.Should()` (which is used to make custom assertions during a testkit test), to provide the user with an `*assert.T` value, which shares much of its interface with Go's `*testing.T`.

Like in a standard Go test, this `T` value can be used to mark the test as failed, log error messages, etc. This replaces the `error` return value that was used to signal an assertion failure prior to this PR.

The goal here is to allow user assertions to use any third-party packages that allow integration via their own `testing.T`-like interface, including, but not limited to Ginkgo and Gomega.