### PR TITLE
Rename `T` types to avoid collisions with `testing.T`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+## Changed
+
+- **[BC]** Renamed `T` to `TestingT`, to avoid conflicts with `*testing.T` when dot-importing
+- **[BC]** Renamed `assert.T` to `S`, to avoid conflicts with `*testing.T` when dot-importing
+
 ## [0.5.0] - 2020-06-11
 
 ## Added

--- a/assert/user_test.go
+++ b/assert/user_test.go
@@ -270,14 +270,21 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Cleanup()", func() {
 			It("registers a function to be executed when the test ends", func() {
-				called := false
+				var order []int
+
 				run(func(t *T) {
 					t.Cleanup(func() {
-						called = true
+						order = append(order, 1)
+					})
+
+					t.Cleanup(func() {
+						order = append(order, 2)
 					})
 				})
 
-				gomega.Expect(called).To(gomega.BeTrue())
+				gomega.Expect(order).To(gomega.Equal(
+					[]int{2, 1},
+				))
 			})
 		})
 

--- a/assert/user_test.go
+++ b/assert/user_test.go
@@ -36,7 +36,7 @@ var _ = Context("user assertions", func() {
 	})
 
 	test := func(
-		fn func(*T),
+		fn func(*S),
 		ok bool,
 		report ...string,
 	) {
@@ -65,7 +65,7 @@ var _ = Context("user assertions", func() {
 			test,
 			Entry(
 				"assertion passed",
-				func(*T) {},
+				func(*S) {},
 				true, // ok
 				`--- ASSERTION REPORT ---`,
 				``,
@@ -73,8 +73,8 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion failed",
-				func(t *T) {
-					t.Fail()
+				func(s *S) {
+					s.Fail()
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -86,8 +86,8 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion skipped",
-				func(t *T) {
-					t.SkipNow()
+				func(s *S) {
+					s.SkipNow()
 				},
 				true, // ok
 				`--- ASSERTION REPORT ---`,
@@ -96,9 +96,9 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion logged a message with Log()",
-				func(t *T) {
-					t.Log("<message>")
-					t.Fail() // must fail for log to be shown
+				func(s *S) {
+					s.Log("<message>")
+					s.Fail() // must fail for log to be shown
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -113,9 +113,9 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion logged a message with Logf()",
-				func(t *T) {
-					t.Logf("<format %s>", "value")
-					t.Fail() // must fail for log to be shown
+				func(s *S) {
+					s.Logf("<format %s>", "value")
+					s.Fail() // must fail for log to be shown
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -130,8 +130,8 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion logged a message with Error()",
-				func(t *T) {
-					t.Error("<message>")
+				func(s *S) {
+					s.Error("<message>")
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -146,8 +146,8 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion logged a message with Errorf()",
-				func(t *T) {
-					t.Errorf("<format %s>", "value")
+				func(s *S) {
+					s.Errorf("<format %s>", "value")
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -162,8 +162,8 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion logged a message with Fatal()",
-				func(t *T) {
-					t.Fatal("<message>")
+				func(s *S) {
+					s.Fatal("<message>")
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -178,8 +178,8 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion logged a message with Fatalf()",
-				func(t *T) {
-					t.Fatalf("<format %s>", "value")
+				func(s *S) {
+					s.Fatalf("<format %s>", "value")
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -194,10 +194,10 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion failed within helper",
-				func(t *T) {
+				func(s *S) {
 					helper := func() {
-						t.Helper()
-						t.Fail()
+						s.Helper()
+						s.Fail()
 					}
 
 					helper()
@@ -212,9 +212,9 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion failed with fn marked as a helper",
-				func(t *T) {
-					t.Helper()
-					t.Fail()
+				func(s *S) {
+					s.Helper()
+					s.Fail()
 				},
 				false, // ok
 				`--- ASSERTION REPORT ---`,
@@ -226,12 +226,12 @@ var _ = Context("user assertions", func() {
 			),
 			Entry(
 				"assertion failed within helper, with fn also marked as a helper",
-				func(t *T) {
-					t.Helper()
+				func(s *S) {
+					s.Helper()
 
 					helper := func() {
-						t.Helper()
-						t.Fail()
+						s.Helper()
+						s.Fail()
 					}
 
 					helper()
@@ -248,10 +248,10 @@ var _ = Context("user assertions", func() {
 	})
 
 	Describe("type T", func() {
-		var run func(func(*T)) *testingmock.T
+		var run func(func(*S)) *testingmock.T
 
 		BeforeEach(func() {
-			run = func(fn func(*T)) *testingmock.T {
+			run = func(fn func(*S)) *testingmock.T {
 				t := &testingmock.T{
 					FailSilently: true,
 				}
@@ -272,12 +272,12 @@ var _ = Context("user assertions", func() {
 			It("registers a function to be executed when the test ends", func() {
 				var order []int
 
-				run(func(t *T) {
-					t.Cleanup(func() {
+				run(func(s *S) {
+					s.Cleanup(func() {
 						order = append(order, 1)
 					})
 
-					t.Cleanup(func() {
+					s.Cleanup(func() {
 						order = append(order, 2)
 					})
 				})
@@ -290,16 +290,16 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Error()", func() {
 			It("marks the test as failed", func() {
-				run(func(t *T) {
-					t.Error()
-					gomega.Expect(t.Failed()).To(gomega.BeTrue())
+				run(func(s *S) {
+					s.Error()
+					gomega.Expect(s.Failed()).To(gomega.BeTrue())
 				})
 			})
 
 			It("does not abort execution", func() {
 				completed := false
-				run(func(t *T) {
-					t.Error()
+				run(func(s *S) {
+					s.Error()
 					completed = true
 				})
 
@@ -309,16 +309,16 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Errorf()", func() {
 			It("marks the test as failed", func() {
-				run(func(t *T) {
-					t.Errorf("<format>")
-					gomega.Expect(t.Failed()).To(gomega.BeTrue())
+				run(func(s *S) {
+					s.Errorf("<format>")
+					gomega.Expect(s.Failed()).To(gomega.BeTrue())
 				})
 			})
 
 			It("does not abort execution", func() {
 				completed := false
-				run(func(t *T) {
-					t.Errorf("<format>")
+				run(func(s *S) {
+					s.Errorf("<format>")
 					completed = true
 				})
 
@@ -328,16 +328,16 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Fail()", func() {
 			It("marks the test as failed", func() {
-				run(func(t *T) {
-					t.Fail()
-					gomega.Expect(t.Failed()).To(gomega.BeTrue())
+				run(func(s *S) {
+					s.Fail()
+					gomega.Expect(s.Failed()).To(gomega.BeTrue())
 				})
 			})
 
 			It("does not abort execution", func() {
 				completed := false
-				run(func(t *T) {
-					t.Fail()
+				run(func(s *S) {
+					s.Fail()
 					completed = true
 				})
 
@@ -347,18 +347,18 @@ var _ = Context("user assertions", func() {
 
 		Describe("func FailNow()", func() {
 			It("marks the test as failed", func() {
-				run(func(t *T) {
+				run(func(s *S) {
 					defer func() {
-						gomega.Expect(t.Failed()).To(gomega.BeTrue())
+						gomega.Expect(s.Failed()).To(gomega.BeTrue())
 					}()
 
-					t.FailNow()
+					s.FailNow()
 				})
 			})
 
 			It("aborts execution", func() {
-				run(func(t *T) {
-					t.FailNow()
+				run(func(s *S) {
+					s.FailNow()
 					Fail("execution was not aborted")
 				})
 			})
@@ -366,18 +366,18 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Fatal()", func() {
 			It("marks the test as failed", func() {
-				run(func(t *T) {
+				run(func(s *S) {
 					defer func() {
-						gomega.Expect(t.Failed()).To(gomega.BeTrue())
+						gomega.Expect(s.Failed()).To(gomega.BeTrue())
 					}()
 
-					t.Fatal()
+					s.Fatal()
 				})
 			})
 
 			It("aborts execution", func() {
-				run(func(t *T) {
-					t.Fatal()
+				run(func(s *S) {
+					s.Fatal()
 					Fail("execution was not aborted")
 				})
 			})
@@ -385,18 +385,18 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Fatalf()", func() {
 			It("marks the test as failed", func() {
-				run(func(t *T) {
+				run(func(s *S) {
 					defer func() {
-						gomega.Expect(t.Failed()).To(gomega.BeTrue())
+						gomega.Expect(s.Failed()).To(gomega.BeTrue())
 					}()
 
-					t.Fatalf("<format>")
+					s.Fatalf("<format>")
 				})
 			})
 
 			It("aborts execution", func() {
-				run(func(t *T) {
-					t.Fatalf("<format>")
+				run(func(s *S) {
+					s.Fatalf("<format>")
 					Fail("execution was not aborted")
 				})
 			})
@@ -404,9 +404,9 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Parallel()", func() {
 			It("does not panic", func() {
-				run(func(t *T) {
+				run(func(s *S) {
 					gomega.Expect(func() {
-						t.Parallel()
+						s.Parallel()
 					}).NotTo(gomega.Panic())
 				})
 			})
@@ -414,35 +414,35 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Name()", func() {
 			It("returns the criteria string", func() {
-				run(func(t *T) {
-					gomega.Expect(t.Name()).To(gomega.Equal("<criteria>"))
+				run(func(s *S) {
+					gomega.Expect(s.Name()).To(gomega.Equal("<criteria>"))
 				})
 			})
 		})
 
 		Describe("func Skip()", func() {
 			It("marks the test as skipped", func() {
-				run(func(t *T) {
+				run(func(s *S) {
 					defer func() {
-						gomega.Expect(t.Skipped()).To(gomega.BeTrue())
+						gomega.Expect(s.Skipped()).To(gomega.BeTrue())
 					}()
 
-					t.Skip()
+					s.Skip()
 				})
 			})
 
 			It("prevents a failure from taking effect", func() {
-				t := run(func(t *T) {
-					t.Fail()
-					t.Skip()
+				t := run(func(s *S) {
+					s.Fail()
+					s.Skip()
 				})
 
 				gomega.Expect(t.Failed).To(gomega.BeFalse())
 			})
 
 			It("aborts execution", func() {
-				run(func(t *T) {
-					t.Skip()
+				run(func(s *S) {
+					s.Skip()
 					Fail("execution was not aborted")
 				})
 			})
@@ -450,27 +450,27 @@ var _ = Context("user assertions", func() {
 
 		Describe("func SkipNow(", func() {
 			It("marks the test as skipped", func() {
-				run(func(t *T) {
+				run(func(s *S) {
 					defer func() {
-						gomega.Expect(t.Skipped()).To(gomega.BeTrue())
+						gomega.Expect(s.Skipped()).To(gomega.BeTrue())
 					}()
 
-					t.SkipNow()
+					s.SkipNow()
 				})
 			})
 
 			It("prevents a failure from taking effect", func() {
-				t := run(func(t *T) {
-					t.Fail()
-					t.SkipNow()
+				t := run(func(s *S) {
+					s.Fail()
+					s.SkipNow()
 				})
 
 				gomega.Expect(t.Failed).To(gomega.BeFalse())
 			})
 
 			It("aborts execution", func() {
-				run(func(t *T) {
-					t.SkipNow()
+				run(func(s *S) {
+					s.SkipNow()
 					Fail("execution was not aborted")
 				})
 			})
@@ -478,27 +478,27 @@ var _ = Context("user assertions", func() {
 
 		Describe("func Skipf()", func() {
 			It("marks the test as skipped", func() {
-				run(func(t *T) {
+				run(func(s *S) {
 					defer func() {
-						gomega.Expect(t.Skipped()).To(gomega.BeTrue())
+						gomega.Expect(s.Skipped()).To(gomega.BeTrue())
 					}()
 
-					t.Skipf("<format>")
+					s.Skipf("<format>")
 				})
 			})
 
 			It("prevents a failure from taking effect", func() {
-				t := run(func(t *T) {
-					t.Fail()
-					t.Skipf("<format>")
+				t := run(func(s *S) {
+					s.Fail()
+					s.Skipf("<format>")
 				})
 
 				gomega.Expect(t.Failed).To(gomega.BeFalse())
 			})
 
 			It("aborts execution", func() {
-				run(func(t *T) {
-					t.Skipf("<format>")
+				run(func(s *S) {
+					s.Skipf("<format>")
 					Fail("execution was not aborted")
 				})
 			})

--- a/dogma.go
+++ b/dogma.go
@@ -1,6 +1,6 @@
 package testkit
 
-func log(t T, args ...interface{}) { t.Log(args...) }
+func log(t TestingT, args ...interface{}) { t.Log(args...) }
 
 // ABOUT THIS FILE (dogma.go)
 //

--- a/interface.go
+++ b/interface.go
@@ -1,10 +1,10 @@
 package testkit
 
-// T is the interface via which the test framework consumes Go's *testing.T
-// value.
+// TestingT is the interface via which the test framework consumes Go's
+// *testing.T value.
 //
 // It allows use of stand-ins, such as Ginkgo's GinkgoT() value.
-type T interface {
+type TestingT interface {
 	Log(args ...interface{})
 	Logf(f string, args ...interface{})
 	FailNow()
@@ -19,7 +19,7 @@ type T interface {
 // See https://github.com/dogmatiq/testkit/issues/61
 // See https://github.com/onsi/ginkgo/pull/585
 type tHelper interface {
-	T
+	TestingT
 
 	Helper()
 }

--- a/runner.go
+++ b/runner.go
@@ -34,7 +34,7 @@ func New(
 }
 
 // Begin starts a new test.
-func (r *Runner) Begin(t T, options ...TestOption) *Test {
+func (r *Runner) Begin(t TestingT, options ...TestOption) *Test {
 	return r.BeginContext(
 		context.Background(),
 		t,
@@ -43,7 +43,7 @@ func (r *Runner) Begin(t T, options ...TestOption) *Test {
 }
 
 // BeginContext starts a new test within a context.
-func (r *Runner) BeginContext(ctx context.Context, t T, options ...TestOption) *Test {
+func (r *Runner) BeginContext(ctx context.Context, t TestingT, options ...TestOption) *Test {
 	to := newTestOptions(options, r.verbose)
 
 	opts := to.operationOptions

--- a/test.go
+++ b/test.go
@@ -17,7 +17,7 @@ import (
 // Test contains the state of a single test.
 type Test struct {
 	ctx              context.Context
-	t                T
+	t                TestingT
 	verbose          bool
 	engine           *engine.Engine
 	now              time.Time


### PR DESCRIPTION
This PR renames the `assert.T` type to `S` (as in `Should()`, the function it's used with), and the `testkit.T` type to `TestingT`. 

This is to avoid conflicts between testkit packages and `testing` itself when dot-importing, as is common in tests.