### PR TITLE
Allow `nil` assertions when advancing the engine clock.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Changed
+
+- `Test.AdvanceTimeBy()` and `AdvanceTimeTo()` can now be called without making any assertions by passing a `nil` assertion
+
 ## [0.6.1] - 2020-10-19
 
 ## Added

--- a/test.go
+++ b/test.go
@@ -90,6 +90,8 @@ func (t *Test) RecordEvent(
 
 // AdvanceTimeBy artificially advances the engine's notion of the current time
 // by a fixed duration. The duration must be positive.
+//
+// a may be nil to avoid making any assertion.
 func (t *Test) AdvanceTimeBy(
 	delta time.Duration,
 	a assert.Assertion,
@@ -112,6 +114,8 @@ func (t *Test) AdvanceTimeBy(
 
 // AdvanceTimeTo artificially advances the engine's notion of the current time
 // to a specific time. The time must be greater than the current engine time.
+//
+// a may be nil to avoid making any assertion.
 func (t *Test) AdvanceTimeTo(
 	now time.Time,
 	a assert.Assertion,
@@ -145,9 +149,13 @@ func (t *Test) advanceTime(
 
 	t.now = now
 
-	t.begin(a)
-	t.tick(options, a)
-	t.end(a)
+	if a == nil {
+		t.tick(options, a)
+	} else {
+		t.begin(a)
+		t.tick(options, a)
+		t.end(a)
+	}
 
 	return t
 }

--- a/test_test.go
+++ b/test_test.go
@@ -105,6 +105,19 @@ var _ = Describe("type Test", func() {
 					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
 				))
 			})
+
+			It("can be called without making an assertion", func() {
+				test.AdvanceTimeBy(
+					3*time.Second,
+					nil,
+				)
+				Expect(t.Logs).To(ContainElement(
+					"--- ADVANCING TIME BY 3s ---",
+				))
+				Expect(t.Logs).NotTo(ContainElement(
+					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
+				))
+			})
 		})
 
 		Describe("func AdvanceTimeTo()", func() {
@@ -117,6 +130,19 @@ var _ = Describe("type Test", func() {
 					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z ---",
 				))
 				Expect(t.Logs).To(ContainElement(
+					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
+				))
+			})
+
+			It("can be called without making an assertion", func() {
+				test.AdvanceTimeTo(
+					time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC),
+					nil,
+				)
+				Expect(t.Logs).To(ContainElement(
+					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z ---",
+				))
+				Expect(t.Logs).NotTo(ContainElement(
 					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
 				))
 			})


### PR DESCRIPTION
Fixes #106