### PR TITLE
Rebuild aggregate state from events on every command.

### DIFF
--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -276,20 +276,6 @@ var _ = Describe("type Controller", func() {
 				))
 			})
 
-			It("does not call New()", func() {
-				handler.NewFunc = func() dogma.AggregateRoot {
-					Fail("unexpected call to New()")
-					return nil
-				}
-
-				controller.Handle(
-					context.Background(),
-					fact.Ignore,
-					time.Now(),
-					command,
-				)
-			})
-
 			It("panics if the instance is destroyed without recording an event", func() {
 				handler.HandleCommandFunc = func(
 					s dogma.AggregateCommandScope,


### PR DESCRIPTION
Fixes #104

This PR changes the underlying in-memory engine to avoid storing a "snapshot" of aggregate state to help catch errors of the kind discussed in #30.