### PR TITLE
Replace `Test.AdvanceTime[By|To]()` with single `AdvanceTime()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `Test.AdvanceTime()`, `ByDuration()` and `ToTime()`
+
+### Removed
+
+- **[BC]** Remove `Test.AdvanceTimeTo()` and `AdvanceTimeBy()`
+
 ## [0.6.2] - 2020-10-19
 
 ### Changed

--- a/test_test.go
+++ b/test_test.go
@@ -92,59 +92,61 @@ var _ = Describe("type Test", func() {
 			})
 		})
 
-		Describe("func AdvanceTimeBy()", func() {
-			It("logs file and line information in headings", func() {
-				test.AdvanceTimeBy(
-					3*time.Second,
-					noopAssertion{},
-				)
-				Expect(t.Logs).To(ContainElement(
-					"--- ADVANCING TIME BY 3s ---",
-				))
-				Expect(t.Logs).To(ContainElement(
-					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
-				))
+		Describe("func AdvanceTime()", func() {
+			When("passed a By() advancer", func() {
+				It("logs file and line information in headings", func() {
+					test.AdvanceTime(
+						ByDuration(3*time.Second),
+						noopAssertion{},
+					)
+					Expect(t.Logs).To(ContainElement(
+						"--- ADVANCING TIME BY 3s ---",
+					))
+					Expect(t.Logs).To(ContainElement(
+						"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
+					))
+				})
+
+				It("can be called without making an assertion", func() {
+					test.AdvanceTime(
+						ByDuration(3*time.Second),
+						nil,
+					)
+					Expect(t.Logs).To(ContainElement(
+						"--- ADVANCING TIME BY 3s ---",
+					))
+					Expect(t.Logs).NotTo(ContainElement(
+						"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
+					))
+				})
 			})
 
-			It("can be called without making an assertion", func() {
-				test.AdvanceTimeBy(
-					3*time.Second,
-					nil,
-				)
-				Expect(t.Logs).To(ContainElement(
-					"--- ADVANCING TIME BY 3s ---",
-				))
-				Expect(t.Logs).NotTo(ContainElement(
-					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
-				))
-			})
-		})
+			When("passed a ToTime() advancer", func() {
+				It("logs file and line information in headings", func() {
+					test.AdvanceTime(
+						ToTime(time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC)),
+						noopAssertion{},
+					)
+					Expect(t.Logs).To(ContainElement(
+						"--- ADVANCING TIME TO 2100-01-02T03:04:05Z ---",
+					))
+					Expect(t.Logs).To(ContainElement(
+						"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
+					))
+				})
 
-		Describe("func AdvanceTimeTo()", func() {
-			It("logs file and line information in headings", func() {
-				test.AdvanceTimeTo(
-					time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC),
-					noopAssertion{},
-				)
-				Expect(t.Logs).To(ContainElement(
-					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z ---",
-				))
-				Expect(t.Logs).To(ContainElement(
-					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
-				))
-			})
-
-			It("can be called without making an assertion", func() {
-				test.AdvanceTimeTo(
-					time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC),
-					nil,
-				)
-				Expect(t.Logs).To(ContainElement(
-					"--- ADVANCING TIME TO 2100-01-02T03:04:05Z ---",
-				))
-				Expect(t.Logs).NotTo(ContainElement(
-					"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
-				))
+				It("can be called without making an assertion", func() {
+					test.AdvanceTime(
+						ToTime(time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC)),
+						nil,
+					)
+					Expect(t.Logs).To(ContainElement(
+						"--- ADVANCING TIME TO 2100-01-02T03:04:05Z ---",
+					))
+					Expect(t.Logs).NotTo(ContainElement(
+						"--- ASSERTION REPORT ---\n\n✓ pass unconditionally\n\n",
+					))
+				})
 			})
 		})
 	})

--- a/test_test.go
+++ b/test_test.go
@@ -148,6 +148,17 @@ var _ = Describe("type Test", func() {
 					))
 				})
 			})
+
+			It("panics if the advancer produces a time in the past", func() {
+				Expect(func() {
+					test.AdvanceTime(
+						func(time.Time) (time.Time, string) {
+							return time.Time{}, ""
+						},
+						nil,
+					)
+				}).To(PanicWith("new time must be after the current time"))
+			})
 		})
 	})
 })

--- a/time.go
+++ b/time.go
@@ -1,0 +1,24 @@
+package testkit
+
+import (
+	"fmt"
+	"time"
+)
+
+// TimeAdvancer is a function that determines the new time that the engine is
+// advanced to during a call to Test.AdvanceTime().
+type TimeAdvancer func(before time.Time) (after time.Time, description string)
+
+// ToTime returns a TimeAdvance that advances the engine time to a specific time.
+func ToTime(t time.Time) TimeAdvancer {
+	return func(time.Time) (time.Time, string) {
+		return t, fmt.Sprintf("ADVANCING TIME TO %s", t.Format(time.RFC3339))
+	}
+}
+
+// ByDuration returns a TimeAdvance that advances the engine time by a fixed duration.
+func ByDuration(d time.Duration) TimeAdvancer {
+	return func(now time.Time) (time.Time, string) {
+		return now.Add(d), fmt.Sprintf("ADVANCING TIME BY %s", d)
+	}
+}

--- a/time.go
+++ b/time.go
@@ -9,14 +9,14 @@ import (
 // advanced to during a call to Test.AdvanceTime().
 type TimeAdvancer func(before time.Time) (after time.Time, description string)
 
-// ToTime returns a TimeAdvance that advances the engine time to a specific time.
+// ToTime returns a TimeAdvancer that advances the engine time to a specific time.
 func ToTime(t time.Time) TimeAdvancer {
 	return func(time.Time) (time.Time, string) {
 		return t, fmt.Sprintf("ADVANCING TIME TO %s", t.Format(time.RFC3339))
 	}
 }
 
-// ByDuration returns a TimeAdvance that advances the engine time by a fixed duration.
+// ByDuration returns a TimeAdvancer that advances the engine time by a fixed duration.
 func ByDuration(d time.Duration) TimeAdvancer {
 	return func(now time.Time) (time.Time, string) {
 		return now.Add(d), fmt.Sprintf("ADVANCING TIME BY %s", d)


### PR DESCRIPTION
Partially addresses #110 

This PR replaces the two separate methods on `Test` for advancing time with a single method that takes an "advancer" function which computes the new "now". This allows for extensibility by implementing domain-specific "advancers", such as `ToNextBusinessDay()`, etc.

