### PR TITLE
Allow for optional assertions on AdvanceTime()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- **[BC]** Add `assert.Assertion.MustOk()`
+- Add `assert.OptionalAssertion` and `assert.Nothing`
 - Add `Test.AdvanceTime()`, `ByDuration()` and `ToTime()`
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- **[BC]** Add `assert.Assertion.MustOk()`
-- Add `assert.OptionalAssertion` and `assert.Nothing`
 - Add `Test.AdvanceTime()`, `ByDuration()` and `ToTime()`
+- Add `assert.OptionalAssertion` and `assert.Nothing`
+- **[BC]** Add `assert.Assertion.TryOk()` (via `OptionalAssertion`)
 
 ### Removed
 

--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -41,7 +41,7 @@ type Assertion interface {
 	Ok() bool
 }
 
-// Nothing is an "optional assertion" that always passes and does not build an
+// Nothing is an "optional assertion" that always passes and does not build a
 // report.
 var Nothing OptionalAssertion = noopAssertion{}
 

--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -19,11 +19,10 @@ type OptionalAssertion interface {
 	// End is called once the test is complete.
 	End()
 
-	// Ok returns true if the assertion passed.
+	// TryOk returns true if the assertion passed.
 	//
-	// If asserted is false, the assertion was a no-op and the value of pass is
-	// meaningless.
-	Ok() (ok bool, asserted bool)
+	// If asserted is false, the assertion was a no-op and ok is meaningless.
+	TryOk() (ok bool, asserted bool)
 
 	// BuildReport generates a report about the assertion.
 	//
@@ -38,8 +37,8 @@ type OptionalAssertion interface {
 type Assertion interface {
 	OptionalAssertion
 
-	// MustOk returns true if the assertion passed.
-	MustOk() bool
+	// Ok returns true if the assertion passed.
+	Ok() bool
 }
 
 // Nothing is an "optional assertion" that always passes and does not build an
@@ -51,7 +50,7 @@ type noopAssertion struct{}
 func (noopAssertion) Notify(fact.Fact)         {}
 func (noopAssertion) Begin(compare.Comparator) {}
 func (noopAssertion) End()                     {}
-func (noopAssertion) Ok() (bool, bool)         { return false, false }
+func (noopAssertion) TryOk() (bool, bool)      { return false, false }
 func (noopAssertion) BuildReport(bool, bool, render.Renderer) *Report {
 	panic("not implemented")
 }

--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dogmatiq/testkit/render"
 )
 
-// OptionalAssertion is an interface that accept all Assertion types, as well as
+// OptionalAssertion is an interface that accepts all Assertion types, as well as
 // the Nothing value.
 type OptionalAssertion interface {
 	fact.Observer

--- a/assert/assertion_test.go
+++ b/assert/assertion_test.go
@@ -1,0 +1,17 @@
+package assert_test
+
+import (
+	. "github.com/dogmatiq/testkit/assert"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+var _ OptionalAssertion = (Assertion)(nil) // ensure OptionalAssertion is always satisfied by Assertion
+
+var _ = Describe("var Nothing", func() {
+	It("does not satisfy the Assertion interface", func() {
+		gomega.Expect(func() {
+			var _ = Nothing.(Assertion)
+		}).To(gomega.Panic())
+	})
+})

--- a/assert/composite.go
+++ b/assert/composite.go
@@ -150,15 +150,18 @@ func (a *compositeAssertion) End() {
 }
 
 // Ok returns true if the assertion passed.
-func (a *compositeAssertion) Ok() bool {
+//
+// If asserted is false, the assertion was a no-op and the value of pass is
+// meaningless.
+func (a *compositeAssertion) Ok() (ok bool, asserted bool) {
 	if a.ok != nil {
-		return *a.ok
+		return *a.ok, true
 	}
 
 	n := 0
 
 	for _, sub := range a.SubAssertions {
-		if sub.Ok() {
+		if sub.MustOk() {
 			n++
 		}
 	}
@@ -168,7 +171,13 @@ func (a *compositeAssertion) Ok() bool {
 	a.ok = &ok
 	a.outcome = m
 
-	return *a.ok
+	return *a.ok, true
+}
+
+// MustOk returns true if the assertion passed.
+func (a *compositeAssertion) MustOk() bool {
+	ok, _ := a.Ok()
+	return ok
 }
 
 // BuildReport generates a report about the assertion.
@@ -177,7 +186,7 @@ func (a *compositeAssertion) Ok() bool {
 // same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
 func (a *compositeAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
-	a.Ok() // populate a.ok and a.outcome
+	a.MustOk() // populate a.ok and a.outcome
 
 	rep := &Report{
 		TreeOk:   ok,

--- a/assert/composite.go
+++ b/assert/composite.go
@@ -149,11 +149,10 @@ func (a *compositeAssertion) End() {
 	}
 }
 
-// Ok returns true if the assertion passed.
+// TryOk returns true if the assertion passed.
 //
-// If asserted is false, the assertion was a no-op and the value of pass is
-// meaningless.
-func (a *compositeAssertion) Ok() (ok bool, asserted bool) {
+// If asserted is false, the assertion was a no-op and ok is meaningless.
+func (a *compositeAssertion) TryOk() (ok bool, asserted bool) {
 	if a.ok != nil {
 		return *a.ok, true
 	}
@@ -161,7 +160,7 @@ func (a *compositeAssertion) Ok() (ok bool, asserted bool) {
 	n := 0
 
 	for _, sub := range a.SubAssertions {
-		if sub.MustOk() {
+		if sub.Ok() {
 			n++
 		}
 	}
@@ -174,9 +173,9 @@ func (a *compositeAssertion) Ok() (ok bool, asserted bool) {
 	return *a.ok, true
 }
 
-// MustOk returns true if the assertion passed.
-func (a *compositeAssertion) MustOk() bool {
-	ok, _ := a.Ok()
+// Ok returns true if the assertion passed.
+func (a *compositeAssertion) Ok() bool {
+	ok, _ := a.TryOk()
 	return ok
 }
 
@@ -186,7 +185,7 @@ func (a *compositeAssertion) MustOk() bool {
 // same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
 func (a *compositeAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
-	a.MustOk() // populate a.ok and a.outcome
+	a.Ok() // populate a.ok and a.outcome
 
 	rep := &Report{
 		TreeOk:   ok,

--- a/assert/composite_test.go
+++ b/assert/composite_test.go
@@ -226,8 +226,8 @@ const (
 
 func (a constAssertion) Begin(compare.Comparator) {}
 func (a constAssertion) End()                     {}
-func (a constAssertion) Ok() (bool, bool)         { return bool(a), true }
-func (a constAssertion) MustOk() bool             { return bool(a) }
+func (a constAssertion) TryOk() (bool, bool)      { return bool(a), true }
+func (a constAssertion) Ok() bool                 { return bool(a) }
 func (a constAssertion) Notify(fact.Fact)         {}
 
 func (a constAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {

--- a/assert/composite_test.go
+++ b/assert/composite_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/testkit"
-	"github.com/dogmatiq/testkit/assert"
 	. "github.com/dogmatiq/testkit/assert"
 	"github.com/dogmatiq/testkit/compare"
 	"github.com/dogmatiq/testkit/engine/fact"
@@ -227,15 +226,17 @@ const (
 
 func (a constAssertion) Begin(compare.Comparator) {}
 func (a constAssertion) End()                     {}
-func (a constAssertion) Ok() bool                 { return bool(a) }
+func (a constAssertion) Ok() (bool, bool)         { return bool(a), true }
+func (a constAssertion) MustOk() bool             { return bool(a) }
 func (a constAssertion) Notify(fact.Fact)         {}
-func (a constAssertion) BuildReport(ok, verbose bool, r render.Renderer) *assert.Report {
+
+func (a constAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
 	c := "<always fail>"
 	if a {
 		c = "<always pass>"
 	}
 
-	return &assert.Report{
+	return &Report{
 		TreeOk:   ok,
 		Ok:       bool(a),
 		Criteria: c,

--- a/assert/message.go
+++ b/assert/message.go
@@ -84,8 +84,17 @@ func (a *messageAssertion) End() {
 }
 
 // Ok returns true if the assertion passed.
-func (a *messageAssertion) Ok() bool {
-	return a.ok
+//
+// If asserted is false, the assertion was a no-op and the value of pass is
+// meaningless.
+func (a *messageAssertion) Ok() (ok bool, asserted bool) {
+	return a.ok, true
+}
+
+// MustOk returns true if the assertion passed.
+func (a *messageAssertion) MustOk() bool {
+	ok, _ := a.Ok()
+	return ok
 }
 
 // BuildReport generates a report about the assertion.

--- a/assert/message.go
+++ b/assert/message.go
@@ -83,17 +83,16 @@ func (a *messageAssertion) Begin(c compare.Comparator) {
 func (a *messageAssertion) End() {
 }
 
-// Ok returns true if the assertion passed.
+// TryOk returns true if the assertion passed.
 //
-// If asserted is false, the assertion was a no-op and the value of pass is
-// meaningless.
-func (a *messageAssertion) Ok() (ok bool, asserted bool) {
+// If asserted is false, the assertion was a no-op and ok is meaningless.
+func (a *messageAssertion) TryOk() (ok bool, asserted bool) {
 	return a.ok, true
 }
 
-// MustOk returns true if the assertion passed.
-func (a *messageAssertion) MustOk() bool {
-	ok, _ := a.Ok()
+// Ok returns true if the assertion passed.
+func (a *messageAssertion) Ok() bool {
+	ok, _ := a.TryOk()
 	return ok
 }
 

--- a/assert/messagetype.go
+++ b/assert/messagetype.go
@@ -70,17 +70,16 @@ func (a *messageTypeAssertion) Begin(c compare.Comparator) {
 func (a *messageTypeAssertion) End() {
 }
 
-// Ok returns true if the assertion passed.
+// TryOk returns true if the assertion passed.
 //
-// If asserted is false, the assertion was a no-op and the value of pass is
-// meaningless.
-func (a *messageTypeAssertion) Ok() (ok bool, asserted bool) {
+// If asserted is false, the assertion was a no-op and ok is meaningless.
+func (a *messageTypeAssertion) TryOk() (ok bool, asserted bool) {
 	return a.ok, true
 }
 
-// MustOk returns true if the assertion passed.
-func (a *messageTypeAssertion) MustOk() bool {
-	ok, _ := a.Ok()
+// Ok returns true if the assertion passed.
+func (a *messageTypeAssertion) Ok() bool {
+	ok, _ := a.TryOk()
 	return ok
 }
 

--- a/assert/messagetype.go
+++ b/assert/messagetype.go
@@ -71,8 +71,17 @@ func (a *messageTypeAssertion) End() {
 }
 
 // Ok returns true if the assertion passed.
-func (a *messageTypeAssertion) Ok() bool {
-	return a.ok
+//
+// If asserted is false, the assertion was a no-op and the value of pass is
+// meaningless.
+func (a *messageTypeAssertion) Ok() (ok bool, asserted bool) {
+	return a.ok, true
+}
+
+// MustOk returns true if the assertion passed.
+func (a *messageTypeAssertion) MustOk() bool {
+	ok, _ := a.Ok()
+	return ok
 }
 
 // BuildReport generates a report about the assertion.

--- a/assert/user.go
+++ b/assert/user.go
@@ -71,8 +71,17 @@ func (a *userAssertion) End() {
 }
 
 // Ok returns true if the assertion passed.
-func (a *userAssertion) Ok() bool {
-	return a.s.skipped || !a.s.failed
+//
+// If asserted is false, the assertion was a no-op and the value of pass is
+// meaningless.
+func (a *userAssertion) Ok() (ok bool, asserted bool) {
+	return a.s.skipped || !a.s.failed, true
+}
+
+// MustOk returns true if the assertion passed.
+func (a *userAssertion) MustOk() bool {
+	ok, _ := a.Ok()
+	return ok
 }
 
 // BuildReport generates a report about the assertion.
@@ -83,7 +92,7 @@ func (a *userAssertion) Ok() bool {
 func (a *userAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
 	rep := &Report{
 		TreeOk:   ok,
-		Ok:       a.Ok(),
+		Ok:       a.MustOk(),
 		Criteria: a.s.name,
 	}
 
@@ -93,7 +102,7 @@ func (a *userAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report
 		rep.Outcome = "the user-defined assertion failed"
 	}
 
-	if !verbose && (ok || a.Ok()) {
+	if !verbose && (ok || a.MustOk()) {
 		return rep
 	}
 

--- a/assert/user.go
+++ b/assert/user.go
@@ -70,17 +70,16 @@ func (a *userAssertion) End() {
 	a.assert(&a.s)
 }
 
-// Ok returns true if the assertion passed.
+// TryOk returns true if the assertion passed.
 //
-// If asserted is false, the assertion was a no-op and the value of pass is
-// meaningless.
-func (a *userAssertion) Ok() (ok bool, asserted bool) {
+// If asserted is false, the assertion was a no-op and ok is meaningless.
+func (a *userAssertion) TryOk() (ok bool, asserted bool) {
 	return a.s.skipped || !a.s.failed, true
 }
 
-// MustOk returns true if the assertion passed.
-func (a *userAssertion) MustOk() bool {
-	ok, _ := a.Ok()
+// Ok returns true if the assertion passed.
+func (a *userAssertion) Ok() bool {
+	ok, _ := a.TryOk()
 	return ok
 }
 
@@ -92,7 +91,7 @@ func (a *userAssertion) MustOk() bool {
 func (a *userAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
 	rep := &Report{
 		TreeOk:   ok,
-		Ok:       a.MustOk(),
+		Ok:       a.Ok(),
 		Criteria: a.s.name,
 	}
 
@@ -102,7 +101,7 @@ func (a *userAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report
 		rep.Outcome = "the user-defined assertion failed"
 	}
 
-	if !verbose && (ok || a.MustOk()) {
+	if !verbose && (ok || a.Ok()) {
 		return rep
 	}
 

--- a/test.go
+++ b/test.go
@@ -221,7 +221,7 @@ func (t *Test) end(a assert.Assertion) {
 		"--- ASSERTION REPORT ---\n\n",
 	)
 
-	rep := a.BuildReport(a.Ok(), t.verbose, r)
+	rep := a.BuildReport(a.MustOk(), t.verbose, r)
 	must.WriteTo(buf, rep)
 
 	t.t.Log(buf.String())

--- a/test.go
+++ b/test.go
@@ -198,7 +198,7 @@ func (t *Test) end(a assert.OptionalAssertion) {
 
 	a.End()
 
-	ok, asserted := a.Ok()
+	ok, asserted := a.TryOk()
 	if !asserted {
 		return
 	}

--- a/test_test.go
+++ b/test_test.go
@@ -110,7 +110,7 @@ var _ = Describe("type Test", func() {
 				It("can be called without making an assertion", func() {
 					test.AdvanceTime(
 						ByDuration(3*time.Second),
-						nil,
+						assert.Nothing,
 					)
 					Expect(t.Logs).To(ContainElement(
 						"--- ADVANCING TIME BY 3s ---",
@@ -138,7 +138,7 @@ var _ = Describe("type Test", func() {
 				It("can be called without making an assertion", func() {
 					test.AdvanceTime(
 						ToTime(time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC)),
-						nil,
+						assert.Nothing,
 					)
 					Expect(t.Logs).To(ContainElement(
 						"--- ADVANCING TIME TO 2100-01-02T03:04:05Z ---",

--- a/test_test.go
+++ b/test_test.go
@@ -167,8 +167,8 @@ type noopAssertion struct{}
 
 func (noopAssertion) Begin(compare.Comparator) {}
 func (noopAssertion) End()                     {}
-func (noopAssertion) Ok() (bool, bool)         { return true, true }
-func (noopAssertion) MustOk() bool             { return true }
+func (noopAssertion) TryOk() (bool, bool)      { return true, true }
+func (noopAssertion) Ok() bool                 { return true }
 func (noopAssertion) Notify(fact.Fact)         {}
 
 func (noopAssertion) BuildReport(ok, verbose bool, r render.Renderer) *assert.Report {

--- a/test_test.go
+++ b/test_test.go
@@ -167,8 +167,10 @@ type noopAssertion struct{}
 
 func (noopAssertion) Begin(compare.Comparator) {}
 func (noopAssertion) End()                     {}
-func (noopAssertion) Ok() bool                 { return true }
+func (noopAssertion) Ok() (bool, bool)         { return true, true }
+func (noopAssertion) MustOk() bool             { return true }
 func (noopAssertion) Notify(fact.Fact)         {}
+
 func (noopAssertion) BuildReport(ok, verbose bool, r render.Renderer) *assert.Report {
 	return &assert.Report{
 		TreeOk:   ok,


### PR DESCRIPTION
Fixes #110 

This PR changes the `assert.Assertion` interface around to allow for an `assert.OptionalAssertion` interface which is satisfied by all existing assertions as well as the new `assert.Nothing` value.

This allows `AdvanceTime()` to accept an `Optional` instead of an `Assertion`, thus removing the need to allow `nil` assertions which are unclear when seen in tests. It also helped clean up some of the internals of `Test` where assertions were optional.