### PR TITLE
Provide more context to UnexpectedMessage panics.

### DIFF
--- a/engine/configurer.go
+++ b/engine/configurer.go
@@ -55,8 +55,7 @@ func (c *configurer) VisitRichIntegration(_ context.Context, cfg configkit.RichI
 	mt := cfg.MessageTypes()
 	c.registerController(
 		integration.NewController(
-			cfg.Identity(),
-			cfg.Handler(),
+			cfg,
 			&c.engine.messageIDs,
 			mt.Produced,
 		),

--- a/engine/configurer.go
+++ b/engine/configurer.go
@@ -67,10 +67,7 @@ func (c *configurer) VisitRichIntegration(_ context.Context, cfg configkit.RichI
 func (c *configurer) VisitRichProjection(_ context.Context, cfg configkit.RichProjection) error {
 	mt := cfg.MessageTypes()
 	c.registerController(
-		projection.NewController(
-			cfg.Identity(),
-			cfg.Handler(),
-		),
+		projection.NewController(cfg),
 		mt.Consumed,
 	)
 

--- a/engine/configurer.go
+++ b/engine/configurer.go
@@ -40,8 +40,7 @@ func (c *configurer) VisitRichProcess(_ context.Context, cfg configkit.RichProce
 	mt := cfg.MessageTypes()
 	c.registerController(
 		process.NewController(
-			cfg.Identity(),
-			cfg.Handler(),
+			cfg,
 			&c.engine.messageIDs,
 			mt.Produced,
 		),

--- a/engine/configurer.go
+++ b/engine/configurer.go
@@ -26,8 +26,7 @@ func (c *configurer) VisitRichAggregate(_ context.Context, cfg configkit.RichAgg
 	mt := cfg.MessageTypes()
 	c.registerController(
 		aggregate.NewController(
-			cfg.Identity(),
-			cfg.Handler(),
+			cfg,
 			&c.engine.messageIDs,
 			mt.Produced,
 		),

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/testkit/engine/controller"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	"github.com/dogmatiq/testkit/engine/fact"
 )
@@ -65,7 +66,16 @@ func (c *Controller) Handle(
 	ident := c.config.Identity()
 	handler := c.config.Handler()
 
-	id := handler.RouteCommandToInstance(env.Message)
+	var id string
+	controller.ConvertUnexpectedMessagePanic(
+		c.config,
+		"RouteCommandToInstance",
+		env.Message,
+		func() {
+			id = handler.RouteCommandToInstance(env.Message)
+		},
+	)
+
 	if id == "" {
 		panic(fmt.Sprintf(
 			"the '%s' aggregate message handler attempted to route a %s command to an empty instance ID",

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/configkit/message"
-	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	"github.com/dogmatiq/testkit/engine/fact"
 )
@@ -15,8 +14,7 @@ import (
 // Controller is an implementation of engine.Controller for
 // dogma.AggregateMessageHandler implementations.
 type Controller struct {
-	identity   configkit.Identity
-	handler    dogma.AggregateMessageHandler
+	config     configkit.RichAggregate
 	messageIDs *envelope.MessageIDGenerator
 	produced   message.TypeCollection
 	history    map[string][]*envelope.Envelope
@@ -24,14 +22,12 @@ type Controller struct {
 
 // NewController returns a new controller for the given handler.
 func NewController(
-	i configkit.Identity,
-	h dogma.AggregateMessageHandler,
+	c configkit.RichAggregate,
 	g *envelope.MessageIDGenerator,
 	t message.TypeCollection,
 ) *Controller {
 	return &Controller{
-		identity:   i,
-		handler:    h,
+		config:     c,
 		messageIDs: g,
 		produced:   t,
 	}
@@ -40,7 +36,7 @@ func NewController(
 // Identity returns the identity of the handler that is managed by this
 // controller.
 func (c *Controller) Identity() configkit.Identity {
-	return c.identity
+	return c.config.Identity()
 }
 
 // Type returns configkit.AggregateHandlerType.
@@ -66,17 +62,20 @@ func (c *Controller) Handle(
 ) ([]*envelope.Envelope, error) {
 	env.Role.MustBe(message.CommandRole)
 
-	id := c.handler.RouteCommandToInstance(env.Message)
+	ident := c.config.Identity()
+	handler := c.config.Handler()
+
+	id := handler.RouteCommandToInstance(env.Message)
 	if id == "" {
 		panic(fmt.Sprintf(
 			"the '%s' aggregate message handler attempted to route a %s command to an empty instance ID",
-			c.identity.Name,
+			ident.Name,
 			message.TypeOf(env.Message),
 		))
 	}
 
 	history, exists := c.history[id]
-	r := c.handler.New()
+	r := handler.New()
 
 	if exists {
 		for _, env := range history {
@@ -84,34 +83,34 @@ func (c *Controller) Handle(
 		}
 
 		obs.Notify(fact.AggregateInstanceLoaded{
-			HandlerName: c.identity.Name,
-			Handler:     c.handler,
+			HandlerName: ident.Name,
+			Handler:     handler,
 			InstanceID:  id,
 			Root:        r,
 			Envelope:    env,
 		})
 	} else {
 		obs.Notify(fact.AggregateInstanceNotFound{
-			HandlerName: c.identity.Name,
-			Handler:     c.handler,
+			HandlerName: ident.Name,
+			Handler:     handler,
 			InstanceID:  id,
 			Envelope:    env,
 		})
 
-		r = c.handler.New()
+		r = handler.New()
 
 		if r == nil {
 			panic(fmt.Sprintf(
 				"the '%s' aggregate message handler returned a nil root from New()",
-				c.identity.Name,
+				ident.Name,
 			))
 		}
 	}
 
 	s := &scope{
 		instanceID: id,
-		identity:   c.identity,
-		handler:    c.handler,
+		identity:   ident,
+		handler:    handler,
 		messageIDs: c.messageIDs,
 		observer:   obs,
 		now:        now,
@@ -121,13 +120,13 @@ func (c *Controller) Handle(
 		command:    env,
 	}
 
-	c.handler.HandleCommand(s, env.Message)
+	handler.HandleCommand(s, env.Message)
 
 	if len(s.events) == 0 {
 		if s.created {
 			panic(fmt.Sprintf(
 				"the '%s' aggregate message handler created the '%s' instance without recording an event while handling a %s command",
-				c.identity.Name,
+				ident.Name,
 				id,
 				message.TypeOf(env.Message),
 			))
@@ -136,7 +135,7 @@ func (c *Controller) Handle(
 		if s.destroyed {
 			panic(fmt.Sprintf(
 				"the '%s' aggregate message handler destroyed the '%s' instance without recording an event while handling a %s command",
-				c.identity.Name,
+				ident.Name,
 				id,
 				message.TypeOf(env.Message),
 			))

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -56,10 +56,8 @@ var _ = Describe("type Controller", func() {
 			},
 		}
 
-		config := configkit.FromAggregate(handler)
-
 		controller = NewController(
-			config,
+			configkit.FromAggregate(handler),
 			&messageIDs,
 			message.NewTypeSet(
 				MessageEType,

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -36,6 +36,11 @@ var _ = Describe("type Controller", func() {
 		)
 
 		handler = &AggregateMessageHandler{
+			ConfigureFunc: func(c dogma.AggregateConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageX{})
+			},
 			// setup routes for "C" (command) messages to an instance ID based on the
 			// message's content
 			RouteCommandToInstanceFunc: func(m dogma.Message) string {
@@ -51,9 +56,10 @@ var _ = Describe("type Controller", func() {
 			},
 		}
 
+		config := configkit.FromAggregate(handler)
+
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
+			config,
 			&messageIDs,
 			message.NewTypeSet(
 				MessageEType,

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -32,6 +32,11 @@ var _ = Describe("type scope", func() {
 		)
 
 		handler = &AggregateMessageHandler{
+			ConfigureFunc: func(c dogma.AggregateConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageE{})
+			},
 			RouteCommandToInstanceFunc: func(m dogma.Message) string {
 				switch m.(type) {
 				case MessageA:
@@ -42,9 +47,10 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
+		config := configkit.FromAggregate(handler)
+
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
+			config,
 			&messageIDs,
 			message.NewTypeSet(
 				MessageBType,

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -47,10 +47,8 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
-		config := configkit.FromAggregate(handler)
-
 		controller = NewController(
-			config,
+			configkit.FromAggregate(handler),
 			&messageIDs,
 			message.NewTypeSet(
 				MessageBType,

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -20,7 +20,7 @@ var _ = Describe("type scope", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *AggregateMessageHandler
-		controller *Controller
+		ctrl       *Controller
 		command    *envelope.Envelope
 	)
 
@@ -47,7 +47,7 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
-		controller = NewController(
+		ctrl = NewController(
 			configkit.FromAggregate(handler),
 			&messageIDs,
 			message.NewTypeSet(
@@ -69,7 +69,7 @@ var _ = Describe("type scope", func() {
 					Expect(s.Exists()).To(BeFalse())
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -90,7 +90,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -110,7 +110,7 @@ var _ = Describe("type scope", func() {
 					s.RecordEvent(MessageE1) // event must be recorded when creating
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -130,7 +130,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -160,7 +160,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -180,7 +180,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -201,7 +201,7 @@ var _ = Describe("type scope", func() {
 				s.RecordEvent(MessageE1) // event must be recorded when creating
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -226,7 +226,7 @@ var _ = Describe("type scope", func() {
 					Expect(s.Exists()).To(BeTrue())
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -246,7 +246,7 @@ var _ = Describe("type scope", func() {
 					Expect(s.Root()).To(Equal(&AggregateRoot{}))
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -267,7 +267,7 @@ var _ = Describe("type scope", func() {
 					s.RecordEvent(MessageE1) // event must be recorded when creating
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -287,7 +287,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -312,7 +312,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -347,7 +347,7 @@ var _ = Describe("type scope", func() {
 
 				buf := &fact.Buffer{}
 				now := time.Now()
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					now,
@@ -385,7 +385,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -407,7 +407,7 @@ var _ = Describe("type scope", func() {
 				Expect(s.InstanceID()).To(Equal("<instance>"))
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -431,7 +431,7 @@ var _ = Describe("type scope", func() {
 
 		It("records a fact", func() {
 			buf := &fact.Buffer{}
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				buf,
 				time.Now(),

--- a/engine/controller/integration/controller_test.go
+++ b/engine/controller/integration/controller_test.go
@@ -24,7 +24,8 @@ var _ = Describe("type Controller", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *IntegrationMessageHandler
-		controller *Controller
+		config     configkit.RichIntegration
+		ctrl       *Controller
 		command    *envelope.Envelope
 	)
 
@@ -43,8 +44,10 @@ var _ = Describe("type Controller", func() {
 			},
 		}
 
-		controller = NewController(
-			configkit.FromIntegration(handler),
+		config = configkit.FromIntegration(handler)
+
+		ctrl = NewController(
+			config,
 			&messageIDs,
 			message.NewTypeSet(
 				MessageBType,
@@ -57,7 +60,7 @@ var _ = Describe("type Controller", func() {
 
 	Describe("func Identity()", func() {
 		It("returns the handler identity", func() {
-			Expect(controller.Identity()).To(Equal(
+			Expect(ctrl.Identity()).To(Equal(
 				configkit.MustNewIdentity("<name>", "<key>"),
 			))
 		})
@@ -65,13 +68,13 @@ var _ = Describe("type Controller", func() {
 
 	Describe("func Type()", func() {
 		It("returns configkit.IntegrationHandlerType", func() {
-			Expect(controller.Type()).To(Equal(configkit.IntegrationHandlerType))
+			Expect(ctrl.Type()).To(Equal(configkit.IntegrationHandlerType))
 		})
 	})
 
 	Describe("func Tick()", func() {
 		It("does not return any envelopes", func() {
-			envelopes, err := controller.Tick(
+			envelopes, err := ctrl.Tick(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -82,7 +85,7 @@ var _ = Describe("type Controller", func() {
 
 		It("does not record any facts", func() {
 			buf := &fact.Buffer{}
-			_, err := controller.Tick(
+			_, err := ctrl.Tick(
 				context.Background(),
 				buf,
 				time.Now(),
@@ -105,7 +108,7 @@ var _ = Describe("type Controller", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -128,7 +131,7 @@ var _ = Describe("type Controller", func() {
 			}
 
 			now := time.Now()
-			events, err := controller.Handle(
+			events, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				now,
@@ -169,7 +172,7 @@ var _ = Describe("type Controller", func() {
 				return expected
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -196,7 +199,7 @@ var _ = Describe("type Controller", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -209,7 +212,7 @@ var _ = Describe("type Controller", func() {
 
 	Describe("func Reset()", func() {
 		It("does nothing", func() {
-			controller.Reset()
+			ctrl.Reset()
 		})
 	})
 })

--- a/engine/controller/integration/controller_test.go
+++ b/engine/controller/integration/controller_test.go
@@ -35,11 +35,16 @@ var _ = Describe("type Controller", func() {
 			time.Now(),
 		)
 
-		handler = &IntegrationMessageHandler{}
+		handler = &IntegrationMessageHandler{
+			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageX{})
+			},
+		}
 
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
+			configkit.FromIntegration(handler),
 			&messageIDs,
 			message.NewTypeSet(
 				MessageBType,

--- a/engine/controller/integration/scope.go
+++ b/engine/controller/integration/scope.go
@@ -13,8 +13,7 @@ import (
 
 // scope is an implementation of dogma.IntegrationCommandScope.
 type scope struct {
-	identity   configkit.Identity
-	handler    dogma.IntegrationMessageHandler
+	config     configkit.RichIntegration
 	messageIDs *envelope.MessageIDGenerator
 	observer   fact.Observer
 	now        time.Time
@@ -27,7 +26,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 	if !s.produced.HasM(m) {
 		panic(fmt.Sprintf(
 			"the '%s' handler is not configured to record events of type %T",
-			s.identity.Name,
+			s.config.Identity().Name,
 			m,
 		))
 	}
@@ -37,7 +36,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 		m,
 		s.now,
 		envelope.Origin{
-			HandlerName: s.identity.Name,
+			HandlerName: s.config.Identity().Name,
 			HandlerType: configkit.IntegrationHandlerType,
 		},
 	)
@@ -45,8 +44,8 @@ func (s *scope) RecordEvent(m dogma.Message) {
 	s.events = append(s.events, env)
 
 	s.observer.Notify(fact.EventRecordedByIntegration{
-		HandlerName:   s.identity.Name,
-		Handler:       s.handler,
+		HandlerName:   s.config.Identity().Name,
+		Handler:       s.config.Handler(),
 		Envelope:      s.command,
 		EventEnvelope: env,
 	})
@@ -54,8 +53,8 @@ func (s *scope) RecordEvent(m dogma.Message) {
 
 func (s *scope) Log(f string, v ...interface{}) {
 	s.observer.Notify(fact.MessageLoggedByIntegration{
-		HandlerName:  s.identity.Name,
-		Handler:      s.handler,
+		HandlerName:  s.config.Identity().Name,
+		Handler:      s.config.Handler(),
 		Envelope:     s.command,
 		LogFormat:    f,
 		LogArguments: v,

--- a/engine/controller/integration/scope_test.go
+++ b/engine/controller/integration/scope_test.go
@@ -20,7 +20,7 @@ var _ = Describe("type scope", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *IntegrationMessageHandler
-		controller *Controller
+		ctrl       *Controller
 		command    *envelope.Envelope
 	)
 
@@ -39,7 +39,7 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
-		controller = NewController(
+		ctrl = NewController(
 			configkit.FromIntegration(handler),
 			&messageIDs,
 			message.NewTypeSet(
@@ -66,7 +66,7 @@ var _ = Describe("type scope", func() {
 		It("records a fact", func() {
 			buf := &fact.Buffer{}
 			now := time.Now()
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				buf,
 				now,
@@ -103,7 +103,7 @@ var _ = Describe("type scope", func() {
 			}
 
 			Expect(func() {
-				controller.Handle(
+				ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -127,7 +127,7 @@ var _ = Describe("type scope", func() {
 
 		It("records a fact", func() {
 			buf := &fact.Buffer{}
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				buf,
 				time.Now(),

--- a/engine/controller/integration/scope_test.go
+++ b/engine/controller/integration/scope_test.go
@@ -31,11 +31,16 @@ var _ = Describe("type scope", func() {
 			time.Now(),
 		)
 
-		handler = &IntegrationMessageHandler{}
+		handler = &IntegrationMessageHandler{
+			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageX{})
+			},
+		}
 
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
+			configkit.FromIntegration(handler),
 			&messageIDs,
 			message.NewTypeSet(
 				MessageBType,

--- a/engine/controller/panic.go
+++ b/engine/controller/panic.go
@@ -1,6 +1,9 @@
 package controller
 
 import (
+	"runtime"
+	"strings"
+
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 )
@@ -11,11 +14,26 @@ type UnexpectedMessage struct {
 	// Handler is the handler that panicked.
 	Handler configkit.RichHandler
 
-	// Method is that method of the handler that panicked.
+	// Interface is the name of the interface containing the method that the
+	// controller called resulting in the panic.
+	Interface string
+
+	// Method is the name of the method that the controller called resulting in
+	// the panic.
 	Method string
 
 	// Message is the message that caused the handler to panic.
 	Message dogma.Message
+
+	// PanicFunc is the name of the function that panicked, if known.
+	PanicFunc string
+
+	// PanicFile is the name of the file where the panic originated, if known.
+	PanicFile string
+
+	// PanicLine is the line number within the file where the panic originated,
+	// if known.
+	PanicLine int
 }
 
 // ConvertUnexpectedMessagePanic calls fn() and converts dogma.UnexpectedMessage
@@ -23,7 +41,7 @@ type UnexpectedMessage struct {
 // the failure.
 func ConvertUnexpectedMessagePanic(
 	h configkit.RichHandler,
-	method string,
+	iface, method string,
 	m dogma.Message,
 	fn func(),
 ) {
@@ -35,10 +53,16 @@ func ConvertUnexpectedMessagePanic(
 		}
 
 		if v == dogma.UnexpectedMessage {
+			name, file, line := findPanicSite()
+
 			v = UnexpectedMessage{
-				Handler: h,
-				Method:  method,
-				Message: m,
+				Handler:   h,
+				Interface: iface,
+				Method:    method,
+				Message:   m,
+				PanicFunc: name,
+				PanicFile: file,
+				PanicLine: line,
 			}
 		}
 
@@ -46,4 +70,27 @@ func ConvertUnexpectedMessagePanic(
 	}()
 
 	fn()
+}
+
+func findPanicSite() (string, string, int) {
+	var (
+		name, file string
+		line       int
+		pc         [16]uintptr
+	)
+
+	n := runtime.Callers(3, pc[:])
+	for _, pc := range pc[:n] {
+		fn := runtime.FuncForPC(pc)
+
+		if fn != nil {
+			name = fn.Name()
+			if !strings.HasPrefix(name, "runtime.") {
+				file, line = fn.FileLine(pc)
+				break
+			}
+		}
+	}
+
+	return name, file, line
 }

--- a/engine/controller/panic.go
+++ b/engine/controller/panic.go
@@ -18,10 +18,10 @@ type UnexpectedMessage struct {
 	Message dogma.Message
 }
 
-// ConvertUnexpectedMessage calls fn() and converts dogma.UnexpectedMessage
+// ConvertUnexpectedMessagePanic calls fn() and converts dogma.UnexpectedMessage
 // values to an controller.UnexpectedMessage value to provide more context about
 // the failure.
-func ConvertUnexpectedMessage(
+func ConvertUnexpectedMessagePanic(
 	h configkit.RichHandler,
 	method string,
 	m dogma.Message,
@@ -29,6 +29,10 @@ func ConvertUnexpectedMessage(
 ) {
 	defer func() {
 		v := recover()
+
+		if v == nil {
+			return
+		}
 
 		if v == dogma.UnexpectedMessage {
 			v = UnexpectedMessage{

--- a/engine/controller/panic_test.go
+++ b/engine/controller/panic_test.go
@@ -1,0 +1,68 @@
+package controller_test
+
+import (
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/testkit/engine/controller"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func ConvertUnexpectedMessagePanic()", func() {
+	It("calls the function", func() {
+		called := false
+
+		ConvertUnexpectedMessagePanic(
+			nil,
+			"<method>",
+			MessageA1,
+			func() {
+				called = true
+			},
+		)
+
+		Expect(called).To(BeTrue())
+	})
+
+	It("propagates panic values", func() {
+		Expect(func() {
+			ConvertUnexpectedMessagePanic(
+				nil,
+				"<method>",
+				MessageA1,
+				func() {
+					panic("<panic>")
+				},
+			)
+		}).To(PanicWith("<panic>"))
+	})
+
+	It("converts UnexpectedMessage values", func() {
+		config := configkit.FromProjection(
+			&ProjectionMessageHandler{
+				ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+					c.Identity("<name>", "<key>")
+					c.ConsumesEventType(MessageE{})
+				},
+			},
+		)
+
+		Expect(func() {
+			ConvertUnexpectedMessagePanic(
+				config,
+				"<method>",
+				MessageA1,
+				func() {
+					panic(dogma.UnexpectedMessage)
+				},
+			)
+		}).To(PanicWith(
+			UnexpectedMessage{
+				Handler: config,
+				Method:  "<method>",
+				Message: MessageA1,
+			},
+		))
+	})
+})

--- a/engine/controller/process/controller_test.go
+++ b/engine/controller/process/controller_test.go
@@ -25,7 +25,8 @@ var _ = Describe("type Controller", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *ProcessMessageHandler
-		controller *Controller
+		config     configkit.RichProcess
+		ctrl       *Controller
 		event      *envelope.Envelope
 		timeout    *envelope.Envelope
 	)
@@ -74,8 +75,10 @@ var _ = Describe("type Controller", func() {
 			},
 		}
 
-		controller = NewController(
-			configkit.FromProcess(handler),
+		config = configkit.FromProcess(handler)
+
+		ctrl = NewController(
+			config,
 			&messageIDs,
 			message.NewTypeSet(
 				MessageCType,
@@ -87,7 +90,7 @@ var _ = Describe("type Controller", func() {
 
 	Describe("func Identity()", func() {
 		It("returns the handler identity", func() {
-			Expect(controller.Identity()).To(Equal(
+			Expect(ctrl.Identity()).To(Equal(
 				configkit.MustNewIdentity("<name>", "<key>"),
 			))
 		})
@@ -95,7 +98,7 @@ var _ = Describe("type Controller", func() {
 
 	Describe("func Type()", func() {
 		It("returns configkit.ProcessHandlerType", func() {
-			Expect(controller.Type()).To(Equal(configkit.ProcessHandlerType))
+			Expect(ctrl.Type()).To(Equal(configkit.ProcessHandlerType))
 		})
 	})
 
@@ -129,7 +132,7 @@ var _ = Describe("type Controller", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				createdTime,
@@ -141,7 +144,7 @@ var _ = Describe("type Controller", func() {
 		})
 
 		It("returns timeouts that are ready to be handled", func() {
-			timeouts, err := controller.Tick(
+			timeouts, err := ctrl.Tick(
 				context.Background(),
 				fact.Ignore,
 				t2Time, // advance time
@@ -175,7 +178,7 @@ var _ = Describe("type Controller", func() {
 		})
 
 		It("does not return the same timeouts multiple times", func() {
-			timeouts, err := controller.Tick(
+			timeouts, err := ctrl.Tick(
 				context.Background(),
 				fact.Ignore,
 				t2Time, // advance time
@@ -184,7 +187,7 @@ var _ = Describe("type Controller", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(timeouts).To(HaveLen(2))
 
-			timeouts, err = controller.Tick(
+			timeouts, err = ctrl.Tick(
 				context.Background(),
 				fact.Ignore,
 				t2Time, // advance time
@@ -201,7 +204,7 @@ var _ = Describe("type Controller", func() {
 				time.Now(),
 			)
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				createdTime,
@@ -219,7 +222,7 @@ var _ = Describe("type Controller", func() {
 				return nil
 			}
 
-			_, err = controller.Handle(
+			_, err = ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -228,7 +231,7 @@ var _ = Describe("type Controller", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// expect only the timeout from the E2 instance.
-			timeouts, err := controller.Tick(
+			timeouts, err := ctrl.Tick(
 				context.Background(),
 				fact.Ignore,
 				t2Time,
@@ -276,7 +279,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -298,7 +301,7 @@ var _ = Describe("type Controller", func() {
 					return expected
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -322,7 +325,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				envelopes, err := controller.Handle(
+				envelopes, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					now,
@@ -368,7 +371,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				envelopes, err := controller.Handle(
+				envelopes, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					now,
@@ -392,7 +395,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				envelopes, err := controller.Handle(
+				envelopes, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					now,
@@ -420,7 +423,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -450,7 +453,7 @@ var _ = Describe("type Controller", func() {
 						return nil
 					}
 
-					_, err := controller.Handle(
+					_, err := ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -462,7 +465,7 @@ var _ = Describe("type Controller", func() {
 
 				It("records a fact", func() {
 					buf := &fact.Buffer{}
-					_, err := controller.Handle(
+					_, err := ctrl.Handle(
 						context.Background(),
 						buf,
 						time.Now(),
@@ -492,7 +495,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -515,7 +518,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -537,7 +540,7 @@ var _ = Describe("type Controller", func() {
 					return expected
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -560,7 +563,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				envelopes, err := controller.Handle(
+				envelopes, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					now,
@@ -605,7 +608,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				envelopes, err := controller.Handle(
+				envelopes, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					now,
@@ -628,7 +631,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				envelopes, err := controller.Handle(
+				envelopes, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					now,
@@ -656,7 +659,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -677,7 +680,7 @@ var _ = Describe("type Controller", func() {
 						return nil
 					}
 
-					_, err := controller.Handle(
+					_, err := ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -698,7 +701,7 @@ var _ = Describe("type Controller", func() {
 						return nil
 					}
 
-					_, err := controller.Handle(
+					_, err := ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -710,7 +713,7 @@ var _ = Describe("type Controller", func() {
 
 				It("records a fact", func() {
 					buf := &fact.Buffer{}
-					_, err := controller.Handle(
+					_, err := ctrl.Handle(
 						context.Background(),
 						buf,
 						time.Now(),
@@ -742,7 +745,7 @@ var _ = Describe("type Controller", func() {
 				return "<instance>", true, expected
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -761,7 +764,7 @@ var _ = Describe("type Controller", func() {
 			}
 
 			Expect(func() {
-				controller.Handle(
+				ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -773,7 +776,7 @@ var _ = Describe("type Controller", func() {
 		When("the instance does not exist", func() {
 			It("records a fact", func() {
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -797,7 +800,7 @@ var _ = Describe("type Controller", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -818,7 +821,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -832,7 +835,7 @@ var _ = Describe("type Controller", func() {
 
 			It("records a fact", func() {
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -857,7 +860,7 @@ var _ = Describe("type Controller", func() {
 					return nil
 				}
 
-				controller.Handle(
+				ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -878,7 +881,7 @@ var _ = Describe("type Controller", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -891,10 +894,10 @@ var _ = Describe("type Controller", func() {
 		})
 
 		It("removes all instances", func() {
-			controller.Reset()
+			ctrl.Reset()
 
 			buf := &fact.Buffer{}
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				buf,
 				time.Now(),

--- a/engine/controller/process/controller_test.go
+++ b/engine/controller/process/controller_test.go
@@ -50,6 +50,11 @@ var _ = Describe("type Controller", func() {
 		)
 
 		handler = &ProcessMessageHandler{
+			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesEventType(MessageX{})
+				c.ProducesCommandType(MessageC{})
+			},
 			// setup routes for "E" (event) messages to an instance ID based on the
 			// message's content
 			RouteEventToInstanceFunc: func(
@@ -70,8 +75,7 @@ var _ = Describe("type Controller", func() {
 		}
 
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
+			configkit.FromProcess(handler),
 			&messageIDs,
 			message.NewTypeSet(
 				MessageCType,

--- a/engine/controller/process/controller_test.go
+++ b/engine/controller/process/controller_test.go
@@ -52,8 +52,8 @@ var _ = Describe("type Controller", func() {
 		handler = &ProcessMessageHandler{
 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
 				c.Identity("<name>", "<key>")
-				c.ConsumesEventType(MessageX{})
-				c.ProducesCommandType(MessageC{})
+				c.ConsumesEventType(MessageE{})
+				c.ProducesCommandType(MessageX{})
 			},
 			// setup routes for "E" (event) messages to an instance ID based on the
 			// message's content

--- a/engine/controller/process/scope_test.go
+++ b/engine/controller/process/scope_test.go
@@ -32,6 +32,11 @@ var _ = Describe("type scope", func() {
 		)
 
 		handler = &ProcessMessageHandler{
+			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesEventType(MessageX{})
+				c.ProducesCommandType(MessageC{})
+			},
 			RouteEventToInstanceFunc: func(
 				_ context.Context,
 				m dogma.Message,
@@ -46,9 +51,7 @@ var _ = Describe("type scope", func() {
 		}
 
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
-			&messageIDs,
+			configkit.FromProcess(handler), &messageIDs,
 			message.NewTypeSet(
 				MessageBType,
 				MessageCType,

--- a/engine/controller/process/scope_test.go
+++ b/engine/controller/process/scope_test.go
@@ -34,8 +34,8 @@ var _ = Describe("type scope", func() {
 		handler = &ProcessMessageHandler{
 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
 				c.Identity("<name>", "<key>")
-				c.ConsumesEventType(MessageX{})
-				c.ProducesCommandType(MessageC{})
+				c.ConsumesEventType(MessageE{})
+				c.ProducesCommandType(MessageX{})
 			},
 			RouteEventToInstanceFunc: func(
 				_ context.Context,

--- a/engine/controller/process/scope_test.go
+++ b/engine/controller/process/scope_test.go
@@ -20,7 +20,7 @@ var _ = Describe("type scope", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *ProcessMessageHandler
-		controller *Controller
+		ctrl       *Controller
 		event      *envelope.Envelope
 	)
 
@@ -50,7 +50,7 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
-		controller = NewController(
+		ctrl = NewController(
 			configkit.FromProcess(handler), &messageIDs,
 			message.NewTypeSet(
 				MessageBType,
@@ -73,7 +73,7 @@ var _ = Describe("type scope", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -96,7 +96,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -117,7 +117,7 @@ var _ = Describe("type scope", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -138,7 +138,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -170,7 +170,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -192,7 +192,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -214,7 +214,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -236,7 +236,7 @@ var _ = Describe("type scope", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -263,7 +263,7 @@ var _ = Describe("type scope", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -285,7 +285,7 @@ var _ = Describe("type scope", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -307,7 +307,7 @@ var _ = Describe("type scope", func() {
 					return nil
 				}
 
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					fact.Ignore,
 					time.Now(),
@@ -328,7 +328,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -354,7 +354,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				buf := &fact.Buffer{}
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					time.Now(),
@@ -394,7 +394,7 @@ var _ = Describe("type scope", func() {
 			It("records a fact", func() {
 				buf := &fact.Buffer{}
 				now := time.Now()
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					now,
@@ -434,7 +434,7 @@ var _ = Describe("type scope", func() {
 				}
 
 				Expect(func() {
-					controller.Handle(
+					ctrl.Handle(
 						context.Background(),
 						fact.Ignore,
 						time.Now(),
@@ -466,7 +466,7 @@ var _ = Describe("type scope", func() {
 			It("records a fact", func() {
 				buf := &fact.Buffer{}
 				now := time.Now()
-				_, err := controller.Handle(
+				_, err := ctrl.Handle(
 					context.Background(),
 					buf,
 					now,
@@ -511,7 +511,7 @@ var _ = Describe("type scope", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -537,7 +537,7 @@ var _ = Describe("type scope", func() {
 
 		It("records a fact", func() {
 			buf := &fact.Buffer{}
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				buf,
 				time.Now(),

--- a/engine/controller/projection/controller.go
+++ b/engine/controller/projection/controller.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/configkit/message"
-	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	"github.com/dogmatiq/testkit/engine/fact"
 )
@@ -14,25 +13,22 @@ import (
 // Controller is an implementation of engine.Controller for
 // dogma.ProjectionMessageHandler implementations.
 type Controller struct {
-	identity configkit.Identity
-	handler  dogma.ProjectionMessageHandler
+	config configkit.RichProjection
 }
 
 // NewController returns a new controller for the given handler.
 func NewController(
-	i configkit.Identity,
-	h dogma.ProjectionMessageHandler,
+	c configkit.RichProjection,
 ) *Controller {
 	return &Controller{
-		identity: i,
-		handler:  h,
+		config: c,
 	}
 }
 
 // Identity returns the identity of the handler that is managed by this
 // controller.
 func (c *Controller) Identity() configkit.Identity {
-	return c.identity
+	return c.config.Identity()
 }
 
 // Type returns configkit.ProjectionHandlerType.
@@ -58,15 +54,18 @@ func (c *Controller) Handle(
 ) ([]*envelope.Envelope, error) {
 	env.Role.MustBe(message.EventRole)
 
-	if t := c.handler.TimeoutHint(env.Message); t != 0 {
+	ident := c.config.Identity()
+	handler := c.config.Handler()
+
+	if t := handler.TimeoutHint(env.Message); t != 0 {
 		var cancel func()
 		ctx, cancel = context.WithTimeout(ctx, t)
 		defer cancel()
 	}
 
 	s := &scope{
-		identity: c.identity,
-		handler:  c.handler,
+		identity: ident,
+		handler:  handler,
 		observer: obs,
 		event:    env,
 	}
@@ -81,7 +80,7 @@ func (c *Controller) Handle(
 	// handled, the resource version is updated to a non-empty value, indicating
 	// that the message has been processed.
 	res := []byte(env.MessageID)
-	cur, err := c.handler.ResourceVersion(ctx, res)
+	cur, err := handler.ResourceVersion(ctx, res)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +91,7 @@ func (c *Controller) Handle(
 		return nil, nil
 	}
 
-	ok, err := c.handler.HandleEvent(
+	ok, err := handler.HandleEvent(
 		ctx,
 		res,
 		nil,       // current version
@@ -107,7 +106,7 @@ func (c *Controller) Handle(
 	// If this call to handle actually applied the event, close the resource as
 	// we'll never invoke the handler with this message again.
 	if ok {
-		return nil, c.handler.CloseResource(ctx, res)
+		return nil, handler.CloseResource(ctx, res)
 	}
 
 	return nil, nil

--- a/engine/controller/projection/controller_test.go
+++ b/engine/controller/projection/controller_test.go
@@ -30,10 +30,15 @@ var _ = Describe("type Controller", func() {
 	)
 
 	BeforeEach(func() {
-		handler = &ProjectionMessageHandler{}
+		handler = &ProjectionMessageHandler{
+			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesEventType(MessageE{})
+			},
+		}
+
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
+			configkit.FromProjection(handler),
 		)
 	})
 

--- a/engine/controller/projection/controller_test.go
+++ b/engine/controller/projection/controller_test.go
@@ -20,9 +20,10 @@ var _ controller.Controller = &Controller{}
 
 var _ = Describe("type Controller", func() {
 	var (
-		handler    *ProjectionMessageHandler
-		controller *Controller
-		event      = envelope.NewEvent(
+		handler *ProjectionMessageHandler
+		config  configkit.RichProjection
+		ctrl    *Controller
+		event   = envelope.NewEvent(
 			"1000",
 			MessageA1,
 			time.Now(),
@@ -37,14 +38,14 @@ var _ = Describe("type Controller", func() {
 			},
 		}
 
-		controller = NewController(
-			configkit.FromProjection(handler),
-		)
+		config = configkit.FromProjection(handler)
+
+		ctrl = NewController(config)
 	})
 
 	Describe("func Identity()", func() {
 		It("returns the handler identity", func() {
-			Expect(controller.Identity()).To(Equal(
+			Expect(ctrl.Identity()).To(Equal(
 				configkit.MustNewIdentity("<name>", "<key>"),
 			))
 		})
@@ -52,13 +53,13 @@ var _ = Describe("type Controller", func() {
 
 	Describe("func Type()", func() {
 		It("returns configkit.ProjectionHandlerType", func() {
-			Expect(controller.Type()).To(Equal(configkit.ProjectionHandlerType))
+			Expect(ctrl.Type()).To(Equal(configkit.ProjectionHandlerType))
 		})
 	})
 
 	Describe("func Tick()", func() {
 		It("does not return any envelopes", func() {
-			envelopes, err := controller.Tick(
+			envelopes, err := ctrl.Tick(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -69,7 +70,7 @@ var _ = Describe("type Controller", func() {
 
 		It("does not record any facts", func() {
 			buf := &fact.Buffer{}
-			_, err := controller.Tick(
+			_, err := ctrl.Tick(
 				context.Background(),
 				buf,
 				time.Now(),
@@ -93,7 +94,7 @@ var _ = Describe("type Controller", func() {
 				return true, nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -116,7 +117,7 @@ var _ = Describe("type Controller", func() {
 				return false, expected
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -136,7 +137,7 @@ var _ = Describe("type Controller", func() {
 				return nil, expected
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -159,7 +160,7 @@ var _ = Describe("type Controller", func() {
 				return false, nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -187,7 +188,7 @@ var _ = Describe("type Controller", func() {
 				return false, nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -208,7 +209,7 @@ var _ = Describe("type Controller", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -237,7 +238,7 @@ var _ = Describe("type Controller", func() {
 				return nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -265,7 +266,7 @@ var _ = Describe("type Controller", func() {
 				return true, nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -278,7 +279,7 @@ var _ = Describe("type Controller", func() {
 
 	Describe("func Reset()", func() {
 		It("does nothing", func() {
-			controller.Reset()
+			ctrl.Reset()
 		})
 	})
 })

--- a/engine/controller/projection/scope.go
+++ b/engine/controller/projection/scope.go
@@ -4,15 +4,13 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
-	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	"github.com/dogmatiq/testkit/engine/fact"
 )
 
 // scope is an implementation of dogma.ProjectionEventScope.
 type scope struct {
-	identity configkit.Identity
-	handler  dogma.ProjectionMessageHandler
+	config   configkit.RichProjection
 	observer fact.Observer
 	event    *envelope.Envelope
 }
@@ -23,8 +21,8 @@ func (s *scope) RecordedAt() time.Time {
 
 func (s *scope) Log(f string, v ...interface{}) {
 	s.observer.Notify(fact.MessageLoggedByProjection{
-		HandlerName:  s.identity.Name,
-		Handler:      s.handler,
+		HandlerName:  s.config.Identity().Name,
+		Handler:      s.config.Handler(),
 		Envelope:     s.event,
 		LogFormat:    f,
 		LogArguments: v,

--- a/engine/controller/projection/scope_test.go
+++ b/engine/controller/projection/scope_test.go
@@ -16,9 +16,9 @@ import (
 
 var _ = Describe("type scope", func() {
 	var (
-		handler    *ProjectionMessageHandler
-		controller *Controller
-		event      = envelope.NewEvent(
+		handler *ProjectionMessageHandler
+		ctrl    *Controller
+		event   = envelope.NewEvent(
 			"1000",
 			MessageA1,
 			time.Now(),
@@ -33,7 +33,7 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
-		controller = NewController(
+		ctrl = NewController(
 			configkit.FromProjection(handler),
 		)
 	})
@@ -52,7 +52,7 @@ var _ = Describe("type scope", func() {
 				return true, nil
 			}
 
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				fact.Ignore,
 				time.Now(),
@@ -77,7 +77,7 @@ var _ = Describe("type scope", func() {
 
 		It("records a fact", func() {
 			buf := &fact.Buffer{}
-			_, err := controller.Handle(
+			_, err := ctrl.Handle(
 				context.Background(),
 				buf,
 				time.Now(),

--- a/engine/controller/projection/scope_test.go
+++ b/engine/controller/projection/scope_test.go
@@ -26,10 +26,15 @@ var _ = Describe("type scope", func() {
 	)
 
 	BeforeEach(func() {
-		handler = &ProjectionMessageHandler{}
+		handler = &ProjectionMessageHandler{
+			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesEventType(MessageE{})
+			},
+		}
+
 		controller = NewController(
-			configkit.MustNewIdentity("<name>", "<key>"),
-			handler,
+			configkit.FromProjection(handler),
 		)
 	})
 

--- a/engine/controller/unexpectedmessage.go
+++ b/engine/controller/unexpectedmessage.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dogma"
+)
+
+// UnexpectedMessage is a panic value that provides more context when a handler
+// panics with a dogma.UnexpoectedMessage value.
+type UnexpectedMessage struct {
+	// Handler is the handler that panicked.
+	Handler configkit.RichHandler
+
+	// Method is that method of the handler that panicked.
+	Method string
+
+	// Message is the message that caused the handler to panic.
+	Message dogma.Message
+}
+
+// ConvertUnexpectedMessage calls fn() and converts dogma.UnexpectedMessage
+// values to an controller.UnexpectedMessage value to provide more context about
+// the failure.
+func ConvertUnexpectedMessage(
+	h configkit.RichHandler,
+	method string,
+	m dogma.Message,
+	fn func(),
+) {
+	defer func() {
+		v := recover()
+
+		if v == dogma.UnexpectedMessage {
+			v = UnexpectedMessage{
+				Handler: h,
+				Method:  method,
+				Message: m,
+			}
+		}
+
+		panic(v)
+	}()
+
+	fn()
+}


### PR DESCRIPTION
Partially addresses #29

This PR recovers from `dogma.UnexpectedMessage` panic values and "re-panics" with a `testkit/engine/controller.UnexpectedMessage` value which adds context about the message that was being handled and the method that was called when the original panic occurred.

- [x] `AggregateMessageHandler.RouteCommandToInstance()`
- [x] `AggregateMessageHandler.HandleCommand()`
- [x] `AggregateRoot.ApplyEvent()`
- [x] `ProcessMessageHandler.RouteEventToInstance()`
- [x] `ProcessMessageHandler.HandleEvent()`
- [x] `ProcessMessageHandler.HandleTimeout()`
- [x] `ProcessMessageHandler.TimeoutHint()`
- [x] `IntegrationMessageHandler.HandleCommand()`
- [x] `IntegrationMessageHandler.TimeoutHint()`
- [x] `ProjectionMessageHandler.HandleEvent()`
- [x] `ProjectionMessageHandler.TimeoutHint()`
