### PR TITLE
Remove verbose mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Removed
 
 - **[BC]** Remove `Test.AdvanceTimeTo()` and `AdvanceTimeBy()`
+- **[BC]** Remove `verbose` parameter `assert.Assertion.BuildReport()`
+- **[BC]** Remove `RunnerVerbose()` and `Verbose()` options
+
+### Changed
+
+- The `-v` (verbose) option to `go test` no longer affects testkit's behavior, full logs are always rendered
 
 ## [0.6.2] - 2020-10-19
 

--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -29,7 +29,7 @@ type OptionalAssertion interface {
 	// ok is true if the assertion is considered to have passed. This may not be
 	// the same value as returned from Ok() when this assertion is used as a
 	// sub-assertion inside a composite.
-	BuildReport(ok, verbose bool, r render.Renderer) *Report
+	BuildReport(ok bool, r render.Renderer) *Report
 }
 
 // An Assertion is a predicate for determining whether some specific criteria
@@ -51,6 +51,6 @@ func (noopAssertion) Notify(fact.Fact)         {}
 func (noopAssertion) Begin(compare.Comparator) {}
 func (noopAssertion) End()                     {}
 func (noopAssertion) TryOk() (bool, bool)      { return false, false }
-func (noopAssertion) BuildReport(bool, bool, render.Renderer) *Report {
+func (noopAssertion) BuildReport(bool, render.Renderer) *Report {
 	panic("not implemented")
 }

--- a/assert/common_test.go
+++ b/assert/common_test.go
@@ -129,6 +129,14 @@ func runTest(
 	logs := strings.TrimSpace(strings.Join(t.Logs, "\n"))
 	lines := strings.Split(logs, "\n")
 
+	for i, l := range lines {
+		if l == "--- ASSERTION REPORT ---" {
+			gomega.Expect(lines[i:]).To(gomega.Equal(expectReport))
+			gomega.Expect(t.Failed).To(gomega.Equal(!expectOk))
+			return
+		}
+	}
+
 	gomega.Expect(lines).To(gomega.Equal(expectReport))
 	gomega.Expect(t.Failed).To(gomega.Equal(!expectOk))
 }

--- a/assert/composite.go
+++ b/assert/composite.go
@@ -184,7 +184,7 @@ func (a *compositeAssertion) Ok() bool {
 // ok is true if the assertion is considered to have passed. This may not be the
 // same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
-func (a *compositeAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
+func (a *compositeAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 	a.Ok() // populate a.ok and a.outcome
 
 	rep := &Report{
@@ -196,7 +196,7 @@ func (a *compositeAssertion) BuildReport(ok, verbose bool, r render.Renderer) *R
 
 	for _, sub := range a.SubAssertions {
 		rep.Append(
-			sub.BuildReport(ok, verbose, r),
+			sub.BuildReport(ok, r),
 		)
 	}
 

--- a/assert/composite_test.go
+++ b/assert/composite_test.go
@@ -1,15 +1,11 @@
 package assert_test
 
 import (
-	"strings"
-
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
-	"github.com/dogmatiq/testkit"
 	. "github.com/dogmatiq/testkit/assert"
 	"github.com/dogmatiq/testkit/compare"
 	"github.com/dogmatiq/testkit/engine/fact"
-	"github.com/dogmatiq/testkit/internal/testingmock"
 	"github.com/dogmatiq/testkit/render"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -40,26 +36,17 @@ var _ = Context("composite assertions", func() {
 
 	test := func(
 		assertion Assertion,
-		ok bool,
-		report ...string,
+		expectOk bool,
+		expectReport ...string,
 	) {
-		t := &testingmock.T{
-			FailSilently: true,
-		}
-
-		testkit.
-			New(app).
-			Begin(t).
-			ExecuteCommand(
-				MessageA{},
-				assertion,
-			)
-
-		logs := strings.TrimSpace(strings.Join(t.Logs, "\n"))
-		lines := strings.Split(logs, "\n")
-
-		gomega.Expect(lines).To(gomega.Equal(report))
-		gomega.Expect(t.Failed).To(gomega.Equal(!ok))
+		runTest(
+			app,
+			MessageA{},
+			assertion,
+			nil, //options
+			expectOk,
+			expectReport,
+		)
 	}
 
 	Describe("func AllOf()", func() {
@@ -230,7 +217,7 @@ func (a constAssertion) TryOk() (bool, bool)      { return bool(a), true }
 func (a constAssertion) Ok() bool                 { return bool(a) }
 func (a constAssertion) Notify(fact.Fact)         {}
 
-func (a constAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
+func (a constAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 	c := "<always fail>"
 	if a {
 		c = "<always pass>"

--- a/assert/message.go
+++ b/assert/message.go
@@ -101,7 +101,7 @@ func (a *messageAssertion) Ok() bool {
 // ok is true if the assertion is considered to have passed. This may not be the
 // same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
-func (a *messageAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
+func (a *messageAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 	rep := &Report{
 		TreeOk: ok,
 		Ok:     a.ok,

--- a/assert/messagetype.go
+++ b/assert/messagetype.go
@@ -88,7 +88,7 @@ func (a *messageTypeAssertion) Ok() bool {
 // ok is true if the assertion is considered to have passed. This may not be the
 // same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
-func (a *messageTypeAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
+func (a *messageTypeAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 	rep := &Report{
 		TreeOk: ok,
 		Ok:     a.ok,

--- a/assert/user.go
+++ b/assert/user.go
@@ -88,7 +88,7 @@ func (a *userAssertion) Ok() bool {
 // ok is true if the assertion is considered to have passed. This may not be
 // the same value as returned from Ok() when this assertion is used as a
 // sub-assertion inside a composite.
-func (a *userAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report {
+func (a *userAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 	rep := &Report{
 		TreeOk:   ok,
 		Ok:       a.Ok(),
@@ -99,10 +99,6 @@ func (a *userAssertion) BuildReport(ok, verbose bool, r render.Renderer) *Report
 		rep.Outcome = "the user-defined assertion was skipped"
 	} else if a.s.failed {
 		rep.Outcome = "the user-defined assertion failed"
-	}
-
-	if !verbose && (ok || a.Ok()) {
-		return rep
 	}
 
 	rep.Explanation = a.s.explanation

--- a/internal/testingmock/mock.go
+++ b/internal/testingmock/mock.go
@@ -1,6 +1,9 @@
 package testingmock
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // T is a mock of the testkit.tHelper interface.
 type T struct {
@@ -11,12 +14,14 @@ type T struct {
 
 // Log is an implementation of testing.TB.Log().
 func (t *T) Log(args ...interface{}) {
-	t.Logs = append(t.Logs, fmt.Sprintln(args...))
+	lines := strings.Split(fmt.Sprint(args...), "\n")
+	t.Logs = append(t.Logs, lines...)
 }
 
 // Logf is an implementation of testing.TB.Logf().
 func (t *T) Logf(f string, args ...interface{}) {
-	t.Logs = append(t.Logs, fmt.Sprintf(f, args...))
+	lines := strings.Split(fmt.Sprintf(f, args...), "\n")
+	t.Logs = append(t.Logs, lines...)
 }
 
 // FailNow is an implementation of testing.TB.FailNow().

--- a/runneroption.go
+++ b/runneroption.go
@@ -7,21 +7,9 @@ import (
 // RunnerOption applies optional settings to a test runner.
 type RunnerOption func(*runnerOptions)
 
-// RunnerVerbose returns a runner option that enables or disables verbose test
-// output across the entire test runner.
-//
-// By default, tests produce verbose output if the -v flag is passed to "go
-// test".
-func RunnerVerbose(enabled bool) RunnerOption {
-	return func(ro *runnerOptions) {
-		ro.verbose = &enabled
-	}
-}
-
 // runnerOptions is a container for the options set via RunnerOption values.
 type runnerOptions struct {
 	engineOptions []engine.Option
-	verbose       *bool
 }
 
 // newRunnerOptions returns a new runnerOptions with the given options.

--- a/test.go
+++ b/test.go
@@ -18,7 +18,6 @@ import (
 type Test struct {
 	ctx              context.Context
 	t                TestingT
-	verbose          bool
 	engine           *engine.Engine
 	now              time.Time
 	operationOptions []engine.OperationOption
@@ -33,9 +32,7 @@ func (t *Test) Prepare(messages ...dogma.Message) *Test {
 		h.Helper()
 	}
 
-	if t.verbose {
-		t.logHeading("PREPARING APPLICATION FOR TEST")
-	}
+	t.logHeading("PREPARING APPLICATION FOR TEST")
 
 	for _, m := range messages {
 		t.dispatch(m, nil, assert.Nothing)
@@ -55,9 +52,7 @@ func (t *Test) ExecuteCommand(
 		h.Helper()
 	}
 
-	if t.verbose {
-		t.logHeading("EXECUTING TEST COMMAND")
-	}
+	t.logHeading("EXECUTING TEST COMMAND")
 
 	t.begin(a)
 	t.dispatch(m, options, a) // TODO: fail if TypeOf(m)'s role is not correct
@@ -77,9 +72,7 @@ func (t *Test) RecordEvent(
 		h.Helper()
 	}
 
-	if t.verbose {
-		t.logHeading("RECORDING TEST EVENT")
-	}
+	t.logHeading("RECORDING TEST EVENT")
 
 	t.begin(a)
 	t.dispatch(m, options, a) // TODO: fail if TypeOf(m)'s role is not correct
@@ -108,9 +101,7 @@ func (t *Test) AdvanceTime(
 		panic("new time must be after the current time")
 	}
 
-	if t.verbose {
-		t.logHeading("%s", heading)
-	}
+	t.logHeading("%s", heading)
 
 	t.now = now
 
@@ -214,7 +205,7 @@ func (t *Test) end(a assert.OptionalAssertion) {
 		"--- ASSERTION REPORT ---\n\n",
 	)
 
-	rep := a.BuildReport(ok, t.verbose, r)
+	rep := a.BuildReport(ok, r)
 	must.WriteTo(buf, rep)
 
 	t.t.Log(buf.String())

--- a/testoption.go
+++ b/testoption.go
@@ -1,7 +1,6 @@
 package testkit
 
 import (
-	"testing"
 	"time"
 
 	"github.com/dogmatiq/testkit/engine"
@@ -9,17 +8,6 @@ import (
 
 // TestOption applies optional settings to a test.
 type TestOption func(*testOptions)
-
-// Verbose returns a test option that enables or disables verbose test output
-// for an individual test.
-//
-// By default, tests produce verbose output if the -v flag is passed to "go
-// test".
-func Verbose(enabled bool) TestOption {
-	return func(to *testOptions) {
-		to.verbose = enabled
-	}
-}
 
 // WithStartTime returns a test option that sets the time of the test runner's
 // clock at the start of the test.
@@ -34,29 +22,17 @@ func WithStartTime(t time.Time) TestOption {
 // testOptions is a container for the options set via TestOption values.
 type testOptions struct {
 	operationOptions []engine.OperationOption
-	verbose          bool
 	time             time.Time
 }
 
 // newTestOptions returns a new testOptions with the given options.
-func newTestOptions(options []TestOption, verbose *bool) *testOptions {
-	var v bool
-	if verbose == nil {
-		// note: testing.Verbose() is called here instead of in New() so that
-		// New() can be called during package initialization, at which time
-		// testing.Verbose() will always return false.
-		v = testing.Verbose()
-	} else {
-		v = *verbose
-	}
-
+func newTestOptions(options []TestOption) *testOptions {
 	ro := &testOptions{
 		operationOptions: []engine.OperationOption{
 			engine.EnableIntegrations(false),
 			engine.EnableProjections(false),
 		},
-		verbose: v,
-		time:    time.Now(),
+		time: time.Now(),
 	}
 
 	for _, opt := range options {


### PR DESCRIPTION
Fixes #6

This PR removes "verbose" mode entirely, instead it always prints full engine logs and assertion reports.

This was a bit of an evolution from the original purpose of #6 which was to let users know that they could get more information by passing `-v` to `go test` in the case of a failure.

I then thought it'd be better if to just show the full logs (that is, the engine logs in addition to the assertion report) in the case of a failure anyway.

Finally, I realised that this is basically the behavior of `go test` by default. If you log via the `t` object it only prints those log messages if the test fails (unless you pass `-v`, then it prints full logs).

So, in the interested of simplicity I decided to remove any "verbose-mode" so that testkit always behaves the same and the regular `go test` behavior applies.
