### PR TITLE
Allow AggregateCommandScope.Destroy() and RecordEvent() to be called in any order.

### DIFF
--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -148,15 +148,6 @@ func (c *Controller) Handle(
 		},
 	)
 
-	if len(s.events) == 0 && s.destroyed {
-		panic(fmt.Sprintf(
-			"the '%s' aggregate message handler destroyed the '%s' instance without recording an event while handling a %s command",
-			ident.Name,
-			id,
-			message.TypeOf(env.Message),
-		))
-	}
-
 	if s.exists {
 		if c.history == nil {
 			c.history = map[string][]*envelope.Envelope{}

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -263,24 +263,6 @@ var _ = Describe("type Controller", func() {
 					},
 				))
 			})
-
-			It("panics if the instance is destroyed without recording an event", func() {
-				handler.HandleCommandFunc = func(
-					s dogma.AggregateCommandScope,
-					_ dogma.Message,
-				) {
-					s.Destroy()
-				}
-
-				Expect(func() {
-					ctrl.Handle(
-						context.Background(),
-						fact.Ignore,
-						time.Now(),
-						command,
-					)
-				}).To(Panic())
-			})
 		})
 
 		It("provides more context to UnexpectedMessage panics from RouteCommandToInstance()", func() {

--- a/engine/controller/aggregate/scope.go
+++ b/engine/controller/aggregate/scope.go
@@ -21,7 +21,6 @@ type scope struct {
 	root       dogma.AggregateRoot
 	now        time.Time
 	exists     bool
-	destroyed  bool // true if Destroy() returned true at least once
 	produced   message.TypeCollection
 	command    *envelope.Envelope
 	events     []*envelope.Envelope
@@ -38,7 +37,6 @@ func (s *scope) Destroy() {
 
 	s.root = s.config.Handler().New()
 	s.exists = false
-	s.destroyed = true
 
 	s.observer.Notify(fact.AggregateInstanceDestroyed{
 		HandlerName: s.config.Identity().Name,

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -207,7 +207,6 @@ var _ = Describe("type scope", func() {
 					s dogma.AggregateCommandScope,
 					_ dogma.Message,
 				) {
-					s.RecordEvent(MessageE1) // event must be recorded when destroying
 					s.Destroy()
 				}
 


### PR DESCRIPTION
This PR updates testkit to allow the behavior documented in [ADR-17](https://github.com/dogmatiq/dogma/blob/master/docs/adr/0017-recreate-aggregate-after-destruction.md), some of which was already allowed, but untested.