### PR TITLE
Panic when using invalid messages.

### DIFF
--- a/assert/message.go
+++ b/assert/message.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/dogmatiq/configkit/message"
@@ -14,6 +15,13 @@ import (
 // CommandExecuted returns an assertion that passes if m is executed as a
 // command.
 func CommandExecuted(m dogma.Message) Assertion {
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf(
+			"can not assert that this command will be executed, it is invalid: %s",
+			err,
+		))
+	}
+
 	return &messageAssertion{
 		expected: m,
 		role:     message.CommandRole,
@@ -22,6 +30,13 @@ func CommandExecuted(m dogma.Message) Assertion {
 
 // EventRecorded returns an assertion that passes if m is recorded as an event.
 func EventRecorded(m dogma.Message) Assertion {
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf(
+			"can not assert that this event will be recorded, it is invalid: %s",
+			err,
+		))
+	}
+
 	return &messageAssertion{
 		expected: m,
 		role:     message.EventRole,

--- a/assert/message_test.go
+++ b/assert/message_test.go
@@ -1,6 +1,8 @@
 package assert_test
 
 import (
+	"errors"
+
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/testkit"
@@ -8,6 +10,7 @@ import (
 	"github.com/dogmatiq/testkit/engine"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega"
 )
 
 var _ = Context("message assertions", func() {
@@ -46,6 +49,26 @@ var _ = Context("message assertions", func() {
 			expectReport,
 		)
 	}
+
+	Describe("func CommandExecuted()", func() {
+		It("panics if the message is invalid", func() {
+			gomega.Expect(func() {
+				CommandExecuted(MessageA{
+					Value: errors.New("<invalid>"),
+				})
+			}).To(gomega.PanicWith("can not assert that this command will be executed, it is invalid: <invalid>"))
+		})
+	})
+
+	Describe("func RecordEvent()", func() {
+		It("panics if the message is invalid", func() {
+			gomega.Expect(func() {
+				EventRecorded(MessageA{
+					Value: errors.New("<invalid>"),
+				})
+			}).To(gomega.PanicWith("can not assert that this event will be recorded, it is invalid: <invalid>"))
+		})
+	})
 
 	DescribeTable(
 		"func CommandExecuted()",

--- a/engine/controller/aggregate/scope.go
+++ b/engine/controller/aggregate/scope.go
@@ -56,6 +56,14 @@ func (s *scope) RecordEvent(m dogma.Message) {
 		))
 	}
 
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf(
+			"can not record event of type %T, it is invalid: %s",
+			m,
+			err,
+		))
+	}
+
 	if !s.exists {
 		s.observer.Notify(fact.AggregateInstanceCreated{
 			HandlerName: s.config.Identity().Name,

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -2,6 +2,7 @@ package aggregate_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/dogmatiq/configkit"
@@ -339,6 +340,27 @@ var _ = Describe("type scope", func() {
 						command,
 					)
 				}).To(PanicWith("the '<name>' handler is not configured to record events of type fixtures.MessageX"))
+			})
+
+			It("panics if the event is invalid", func() {
+				handler.HandleCommandFunc = func(
+					_ dogma.AggregateRoot,
+					s dogma.AggregateCommandScope,
+					_ dogma.Message,
+				) {
+					s.RecordEvent(MessageE{
+						Value: errors.New("<invalid>"),
+					})
+				}
+
+				Expect(func() {
+					ctrl.Handle(
+						context.Background(),
+						fact.Ignore,
+						time.Now(),
+						command,
+					)
+				}).To(PanicWith("can not record event of type fixtures.MessageE, it is invalid: <invalid>"))
 			})
 		})
 	})

--- a/engine/controller/integration/scope.go
+++ b/engine/controller/integration/scope.go
@@ -31,6 +31,14 @@ func (s *scope) RecordEvent(m dogma.Message) {
 		))
 	}
 
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf(
+			"can not record event of type %T, it is invalid: %s",
+			m,
+			err,
+		))
+	}
+
 	env := s.command.NewEvent(
 		s.messageIDs.Next(),
 		m,

--- a/engine/controller/integration/scope_test.go
+++ b/engine/controller/integration/scope_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/dogmatiq/configkit"
@@ -107,6 +108,28 @@ var _ = Describe("type scope", func() {
 					command,
 				)
 			}).To(PanicWith("the '<name>' handler is not configured to record events of type fixtures.MessageX"))
+		})
+
+		It("panics if the event is invalid", func() {
+			handler.HandleCommandFunc = func(
+				_ context.Context,
+				s dogma.IntegrationCommandScope,
+				_ dogma.Message,
+			) error {
+				s.RecordEvent(MessageE{
+					Value: errors.New("<invalid>"),
+				})
+				return nil
+			}
+
+			Expect(func() {
+				ctrl.Handle(
+					context.Background(),
+					fact.Ignore,
+					time.Now(),
+					command,
+				)
+			}).To(PanicWith("can not record event of type fixtures.MessageE, it is invalid: <invalid>"))
 		})
 	})
 

--- a/engine/controller/process/scope.go
+++ b/engine/controller/process/scope.go
@@ -89,6 +89,14 @@ func (s *scope) ExecuteCommand(m dogma.Message) {
 		))
 	}
 
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf(
+			"can not execute command of type %T, it is invalid: %s",
+			m,
+			err,
+		))
+	}
+
 	if !s.exists {
 		panic("can not execute command against non-existent instance")
 	}
@@ -126,6 +134,14 @@ func (s *scope) ScheduleTimeout(m dogma.Message, t time.Time) {
 			"the '%s' handler is not configured to schedule timeouts of type %T",
 			s.config.Identity().Name,
 			m,
+		))
+	}
+
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf(
+			"can not schedule timeout of type %T, it is invalid: %s",
+			m,
+			err,
 		))
 	}
 

--- a/engine/controller/process/scope_test.go
+++ b/engine/controller/process/scope_test.go
@@ -2,6 +2,7 @@ package process_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/dogmatiq/configkit"
@@ -441,6 +442,28 @@ var _ = Describe("type scope", func() {
 					)
 				}).To(PanicWith("the '<name>' handler is not configured to execute commands of type fixtures.MessageX"))
 			})
+
+			It("panics if the command is invalid", func() {
+				handler.HandleEventFunc = func(
+					_ context.Context,
+					s dogma.ProcessEventScope,
+					m dogma.Message,
+				) error {
+					s.ExecuteCommand(MessageC{
+						Value: errors.New("<invalid>"),
+					})
+					return nil
+				}
+
+				Expect(func() {
+					ctrl.Handle(
+						context.Background(),
+						fact.Ignore,
+						time.Now(),
+						event,
+					)
+				}).To(PanicWith("can not execute command of type fixtures.MessageC, it is invalid: <invalid>"))
+			})
 		})
 
 		Describe("func ScheduleTimeout()", func() {
@@ -513,6 +536,31 @@ var _ = Describe("type scope", func() {
 						event,
 					)
 				}).To(PanicWith("the '<name>' handler is not configured to schedule timeouts of type fixtures.MessageX"))
+			})
+
+			It("panics if the timeout is invalid", func() {
+				handler.HandleEventFunc = func(
+					_ context.Context,
+					s dogma.ProcessEventScope,
+					m dogma.Message,
+				) error {
+					s.ScheduleTimeout(
+						MessageT{
+							Value: errors.New("<invalid>"),
+						},
+						time.Now(),
+					)
+					return nil
+				}
+
+				Expect(func() {
+					ctrl.Handle(
+						context.Background(),
+						fact.Ignore,
+						time.Now(),
+						event,
+					)
+				}).To(PanicWith("can not schedule timeout of type fixtures.MessageT, it is invalid: <invalid>"))
 			})
 		})
 	})

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -161,11 +161,21 @@ func (e *Engine) tick(
 // Dispatch processes a message.
 //
 // It is not an error to process a message that is not routed to any handlers.
+//
+// It panics if the message is invalid.
 func (e *Engine) Dispatch(
 	ctx context.Context,
 	m dogma.Message,
 	options ...OperationOption,
 ) error {
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf(
+			"can not dispatch invalid %T message: %s",
+			m,
+			err,
+		))
+	}
+
 	oo := newOperationOptions(options)
 	t := message.TypeOf(m)
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine_test
 
 import (
 	"context"
+	"errors"
 
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
@@ -76,6 +77,14 @@ var _ = Describe("type Engine", func() {
 	})
 
 	Describe("func Dispatch()", func() {
+		It("panics if the message is invalid", func() {
+			Expect(func() {
+				engine.Dispatch(context.Background(), MessageA{
+					Value: errors.New("<invalid>"),
+				})
+			}).To(PanicWith("can not dispatch invalid fixtures.MessageA message: <invalid>"))
+		})
+
 		It("panics if the message type is unrecognized", func() {
 			Expect(func() {
 				engine.Dispatch(context.Background(), MessageX1)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dogmatiq/configkit v0.9.0
 	github.com/dogmatiq/cosyne v0.1.0
 	github.com/dogmatiq/dapper v0.4.0
-	github.com/dogmatiq/dogma v0.9.0
+	github.com/dogmatiq/dogma v0.10.0
 	github.com/dogmatiq/iago v0.4.0
 	github.com/dogmatiq/linger v0.2.1
 	github.com/onsi/ginkgo v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dogmatiq/dapper v0.4.0 h1:WshL6xcW56jxkh1XE/x7sXyzxOvjBFjMcxz1jdjwn60
 github.com/dogmatiq/dapper v0.4.0/go.mod h1:U32cRxzGYI5owhc/hMKjYLgBTVCdW/s3MdFJHwfDrLQ=
 github.com/dogmatiq/dogma v0.9.0 h1:PGRUqBPVI76HhkxulEEvzxe+693pq9cfQxJWBCpV730=
 github.com/dogmatiq/dogma v0.9.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
+github.com/dogmatiq/dogma v0.10.0 h1:2kLivwq72nr6yF3/jpIA5U57IOmPRxeO+I9lE06IebE=
+github.com/dogmatiq/dogma v0.10.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/dogmatiq/linger v0.2.1 h1:ecVwiFlTcQuQ7ygQXH5bUPkWNve8n5BmVnCYMGMQ3zc=


### PR DESCRIPTION
This PR updates testkit to validate messages using the `dogma.ValidateMessage()` function from Dogma v0.10.0

Testkit now panics if you attempt to use an invalid message when:

- Recording an event from an aggregate
- Recording an event from an integration
- Executing a command from a process
- Scheduling a timeout from a process
- Asserting that an invalid command was executed
- Asserting that an invalid event was recorded
- Dispatching an invalid message via the test engine, which in turn covers:
  - Executing a command via an `engine.CommandExecutor` (as returned by `Test.CommandExecutor()`)
  - Recording an event via an `engine.EventRecorder` (as returned by `Test.EventRecorder()`)
  - Executing a command via `Test.Prepare()`
  - Recording an event via `Test.Prepare()`
  - Executing a command via `Test.ExecuteCommand()`
  - Recording an event via `Test.RecordEvent()`