### PR TITLE
Compact projections every hour.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Changed
+
+- **[BC]** Updated to Dogma to v0.10.0
+
+### Added
+
+- Added support for projection compaction.
+
+### Fixed
+
+- Fix issue where engine operation options were not taking precedence over test options
+
 ## [0.9.0] - 2020-11-06
 
 ### Changed

--- a/engine/controller/projection/scope.go
+++ b/engine/controller/projection/scope.go
@@ -8,7 +8,8 @@ import (
 	"github.com/dogmatiq/testkit/engine/fact"
 )
 
-// scope is an implementation of dogma.ProjectionEventScope.
+// scope is an implementation of dogma.ProjectionEventScope and
+// dogma.ProjectionCompactScope.
 type scope struct {
 	config   configkit.RichProjection
 	observer fact.Observer
@@ -23,7 +24,7 @@ func (s *scope) Log(f string, v ...interface{}) {
 	s.observer.Notify(fact.MessageLoggedByProjection{
 		HandlerName:  s.config.Identity().Name,
 		Handler:      s.config.Handler(),
-		Envelope:     s.event,
+		Envelope:     s.event, // nil if compacting
 		LogFormat:    f,
 		LogArguments: v,
 	})

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -439,16 +439,23 @@ func (l *Logger) log(
 	icons []logging.Icon,
 	text ...string,
 ) {
+	var messageID, causationID, correlationID string
+	if env != nil {
+		messageID = env.MessageID
+		causationID = env.CausationID
+		correlationID = env.CorrelationID
+	}
+
 	l.Log(logging.String(
 		[]logging.IconWithLabel{
 			logging.MessageIDIcon.WithLabel(
-				formatMessageID(env.MessageID),
+				formatMessageID(messageID),
 			),
 			logging.CausationIDIcon.WithLabel(
-				formatMessageID(env.CausationID),
+				formatMessageID(causationID),
 			),
 			logging.CorrelationIDIcon.WithLabel(
-				formatMessageID(env.CorrelationID),
+				formatMessageID(correlationID),
 			),
 		},
 		icons,

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -73,6 +73,8 @@ func (l *Logger) Notify(f Fact) {
 		l.eventRecordedByIntegration(x)
 	case MessageLoggedByIntegration:
 		l.messageLoggedByIntegration(x)
+	case ProjectionCompactionCompleted:
+		l.projectionCompactionCompleted(x)
 	case MessageLoggedByProjection:
 		l.messageLoggedByProjection(x)
 	}
@@ -420,15 +422,48 @@ func (l *Logger) messageLoggedByIntegration(f MessageLoggedByIntegration) {
 	)
 }
 
+// projectionCompactionCompleted returns the log message for f.
+func (l *Logger) projectionCompactionCompleted(f ProjectionCompactionCompleted) {
+	if f.Error == nil {
+		l.log(
+			nil,
+			[]logging.Icon{
+				"",
+				logging.ProjectionIcon,
+				"",
+			},
+			f.HandlerName,
+			"compacted",
+		)
+	} else {
+		l.log(
+			nil,
+			[]logging.Icon{
+				"",
+				logging.ProjectionIcon,
+				logging.ErrorIcon,
+			},
+			f.HandlerName,
+			fmt.Sprintf("compaction failed: %s", f.Error),
+		)
+	}
+}
+
 // messageLoggedByProjection returns the log message for f.
 func (l *Logger) messageLoggedByProjection(f MessageLoggedByProjection) {
+	icons := []logging.Icon{
+		"",
+		logging.ProjectionIcon,
+		"",
+	}
+
+	if f.Envelope != nil {
+		icons[0] = logging.InboundIcon
+	}
+
 	l.log(
 		f.Envelope,
-		[]logging.Icon{
-			logging.InboundIcon,
-			logging.ProjectionIcon,
-			"",
-		},
+		icons,
 		f.HandlerName,
 		fmt.Sprintf(f.LogFormat, f.LogArguments...),
 	)

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
-
 	. "github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	. "github.com/dogmatiq/testkit/engine/fact"
@@ -389,6 +388,16 @@ var _ = Describe("type Logger", func() {
 				MessageLoggedByProjection{
 					HandlerName:  "<handler>",
 					Envelope:     command,
+					LogFormat:    "<%s>",
+					LogArguments: []interface{}{"message"},
+				},
+			),
+
+			Entry(
+				"MessageLoggedByProjection (compacting)",
+				"= ----  ∵ ----  ⋲ ----  ▼ Σ    <handler> ● <message>",
+				MessageLoggedByProjection{
+					HandlerName:  "<handler>",
 					LogFormat:    "<%s>",
 					LogArguments: []interface{}{"message"},
 				},

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -383,6 +383,29 @@ var _ = Describe("type Logger", func() {
 			// projections ...
 
 			Entry(
+				"ProjectionCompactionBegun",
+				"",
+				ProjectionCompactionBegun{},
+			),
+
+			Entry(
+				"ProjectionCompactionCompleted (success)",
+				"= ----  ∵ ----  ⋲ ----    Σ    <handler> ● compacted",
+				ProjectionCompactionCompleted{
+					HandlerName: "<handler>",
+				},
+			),
+
+			Entry(
+				"ProjectionCompactionCompleted (failure)",
+				"= ----  ∵ ----  ⋲ ----    Σ ✖  <handler> ● compaction failed: <error>",
+				ProjectionCompactionCompleted{
+					HandlerName: "<handler>",
+					Error:       errors.New("<error>"),
+				},
+			),
+
+			Entry(
 				"MessageLoggedByProjection",
 				"= 0100  ∵ 0100  ⋲ 0100  ▼ Σ    <handler> ● <message>",
 				MessageLoggedByProjection{
@@ -395,7 +418,7 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"MessageLoggedByProjection (compacting)",
-				"= ----  ∵ ----  ⋲ ----  ▼ Σ    <handler> ● <message>",
+				"= ----  ∵ ----  ⋲ ----    Σ    <handler> ● <message>",
 				MessageLoggedByProjection{
 					HandlerName:  "<handler>",
 					LogFormat:    "<%s>",

--- a/engine/fact/projection.go
+++ b/engine/fact/projection.go
@@ -5,6 +5,19 @@ import (
 	"github.com/dogmatiq/testkit/engine/envelope"
 )
 
+// ProjectionCompactionBegun indicates that a projection is about to be
+// compacted.
+type ProjectionCompactionBegun struct {
+	HandlerName string
+}
+
+// ProjectionCompactionCompleted indicates that projection compaction has been
+// performed, either successfully or unsuccessfully.
+type ProjectionCompactionCompleted struct {
+	HandlerName string
+	Error       error
+}
+
 // MessageLoggedByProjection indicates that a projection wrote a log message
 // while handling an event or compacting the projection.
 //

--- a/engine/fact/projection.go
+++ b/engine/fact/projection.go
@@ -6,7 +6,9 @@ import (
 )
 
 // MessageLoggedByProjection indicates that a projection wrote a log message
-// while handling an event.
+// while handling an event or compacting the projection.
+//
+// Envelope is nil if the message was logged during compaction.
 type MessageLoggedByProjection struct {
 	HandlerName  string
 	Handler      dogma.ProjectionMessageHandler

--- a/engine/run.go
+++ b/engine/run.go
@@ -37,7 +37,7 @@ func Run(
 //
 // Each tick is performed using a WithCurrentTime() option that scales time by a
 // factor of f. For example, if f is 2.0, the engine will see time progress by 2
-// for every 1 second of real time.
+// seconds for every 1 second of real time.
 //
 // t is the "epoch time", used as current time for the first tick. If t.IsZero()
 // is true, the current time is used.


### PR DESCRIPTION
This PR adds basic support for projection compaction (added in Dogma v0.10.0) to testkit's in-memory engine implementation. It does not address testing compaction.

It calls `Compact()` for each projection message handler one every hour of elapsed "engine time". 

