### PR TITLE
[api overhaul] Add the `Action` interface.

### DIFF
--- a/action.go
+++ b/action.go
@@ -1,0 +1,26 @@
+package testkit
+
+import (
+	"github.com/dogmatiq/testkit/assert"
+	"github.com/dogmatiq/testkit/engine"
+)
+
+// Action is an interface for any action that can be performed within a test.
+//
+// Actions always attempt to cause some state change within the engine or
+// application.
+type Action interface {
+	// Heading returns a human-readable description of the action, used as a
+	// heading within the test report.
+	//
+	// Any engine activity as a result of this action is logged beneath this
+	// heading.
+	Heading() string
+
+	// Apply performs the action within the context of a specific test.
+	Apply(
+		t *Test,
+		a assert.Assertion,
+		options []engine.OperationOption,
+	)
+}

--- a/test.go
+++ b/test.go
@@ -43,6 +43,20 @@ func (t *Test) PrepareX(messages ...interface{}) *Test {
 	return t
 }
 
+// Prepare performs a group of actions without making any assertions in order
+// to place the application into a particular state.
+func (t *Test) Prepare(actions ...Action) *Test {
+	if h, ok := t.t.(tHelper); ok {
+		h.Helper()
+	}
+
+	for _, act := range actions {
+		t.act(act, nil, assert.Nothing)
+	}
+
+	return t
+}
+
 // ExecuteCommand makes an assertion about the application's behavior when a
 // specific command is executed.
 func (t *Test) ExecuteCommand(
@@ -205,6 +219,24 @@ func (t *Test) tick(
 		t.t.Log(err)
 		t.t.FailNow()
 	}
+}
+
+func (t *Test) act(
+	act Action,
+	options []engine.OperationOption,
+	a assert.Assertion,
+) {
+	if h, ok := t.t.(tHelper); ok {
+		h.Helper()
+	}
+
+	t.logHeading(act.Heading())
+
+	act.Apply(
+		t,
+		a,
+		options,
+	)
 }
 
 // options returns the full set of operation options to use for given call to


### PR DESCRIPTION
<!------------------------------------------------------------------------------

A GOOD PULL REQUEST:

- Is small.
- Contains a single change that makes sense in isolation.
- Makes the code better.


A GOOD PULL REQUEST TITLE:

- Completes the sentence "If applied, this PR will ...".
- Is less than 50 characters.

Example: Allow for compaction of projections.


BEFORE YOU SUBMIT A PULL REQUEST:

- Read the contribution guidelines at https://github.com/dogmatiq/.github/CONTRIBUTING.md.
- Know what you are submitting.
- Review the entire diff line-by-line. If this is too hard, your PR is too big.

------------------------------------------------------------------------------->

#### What change does this introduce?

This PR adds the `Action` interface, which will be the common interface implemented by all actions that can be performed within the context of a `testkit.Test`, ultimately replacing the `ExecuteCommand()`, `RecordEvent()`, `AdvanceTime()` and `Call()` methods.

**Note: This PR targets the `api-overhaul` branch, not `master`.** The existing `Prepare()` method has already been renamed to `PrepareX()` on that branch to make way for this new implementation while retaining all of the old functionality/tests throughout the overhaul.
<!--

Briefly describe the change you've made in terms of the features or behavior it
introduces or modifies.

-- EXAMPLE:

This PR adds support for "projection compaction" which is an operation on
projections that can be invoked by the engine to clean up any "unused" or
"oversized" projection data.

-->

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127
<!--

Link to any GitHub issues that are relevant to these changes. Use the "fixes"
keyword if you believe an issue to be completely addressed by this PR.

-- EXAMPLE:

Fixes #123
Partially addresses #456

-->

#### Why make this change?

In preparation for moving test actions from methods on `Test` to objects that can be used either in `Prepare()` or a future `Assert()` method.
<!--

Briefly describe the rationale behind making this change.

-- EXAMPLE

By making this a first-class feature we encourage the developer to think about
the lifetime of their projection data, which might otherwise go unaddressed.

-->

#### Is there anything you are unsure about?

No
<!--

This is a place to ask any specific questions about the changes you've made that
you'd like to see addressed by the project's maintainers before they begin
reviewing.

Consider submitting a draft PR if you require feedback about incomplete changes.

-- EXAMPLE

Should `Compact()` implementations be required to impose their own timeout?

-->
