### PR TITLE
Api overhaul expect

### DIFF
--- a/expectation.go
+++ b/expectation.go
@@ -1,0 +1,14 @@
+package testkit
+
+import (
+	"github.com/dogmatiq/testkit/assert"
+	"github.com/dogmatiq/testkit/engine"
+)
+
+// An Expectation is a predicate for determining whether some specific criteria
+// was met while performing an action.
+type Expectation = assert.Assertion
+
+// ExpectOption is an option that changes the behavior of engine during a call
+// to Test.Expect().
+type ExpectOption = engine.OperationOption

--- a/test.go
+++ b/test.go
@@ -57,6 +57,15 @@ func (t *Test) Prepare(actions ...Action) *Test {
 	return t
 }
 
+// Expect ensures that a single action results in some expected behavior.
+func (t *Test) Expect(act Action, e Expectation, options ...ExpectOption) {
+	if h, ok := t.t.(tHelper); ok {
+		h.Helper()
+	}
+
+	t.act(act, nil, e)
+}
+
 // ExecuteCommand makes an assertion about the application's behavior when a
 // specific command is executed.
 func (t *Test) ExecuteCommand(


### PR DESCRIPTION
#### What change does this introduce?

This PR adds the `Expectation` interface and the related `Test.Expect()` method.

At the moment these are both aliases for existing types that will be refactored through the overhaul. I chose the name `Expectation` instead of sticking with `Assertion` mostly because we use`onsi/gomega` widely, and it has an existing `Assertion` type that conflicts when we "dot import" both `testkit` and `gomega`.

**Note: This PR targets the `api-overhaul` branch, not `master`.** 

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

To allow the use of any `Action` with any assertion (`Expectation`).

#### Is there anything you are unsure about?

I'm not 100% sure about the name `Expectation`, though I do think `Test.Expect()` is a better name than `Test.Assert()` for the method.