### PR TITLE
Replace operation enumeration with expectation options.

### DIFF
--- a/action.go
+++ b/action.go
@@ -16,6 +16,6 @@ type Action interface {
 	Apply(
 		t *Test,
 		e Expectation,
-		options []ExpectOption,
+		o ExpectOptionSet,
 	)
 }

--- a/advancetime.go
+++ b/advancetime.go
@@ -3,8 +3,6 @@ package testkit
 import (
 	"fmt"
 	"time"
-
-	"github.com/dogmatiq/testkit/assert"
 )
 
 // AdvanceTime returns an Action that simulates the passage of time by advancing
@@ -67,7 +65,7 @@ func (act advanceTime) Heading() string {
 func (act advanceTime) Apply(
 	t *Test,
 	e Expectation,
-	options []ExpectOption,
+	o ExpectOptionSet,
 ) {
 	now := act.adj.Step(t.now)
 
@@ -80,8 +78,8 @@ func (act advanceTime) Apply(
 
 	t.now = now
 
-	t.begin(assert.AdvanceTimeOperation, e)
-	t.tick(options, e)
+	t.begin(o, e)
+	t.tick(nil, e)
 	t.end(e)
 }
 

--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -6,26 +6,19 @@ import (
 	"github.com/dogmatiq/testkit/render"
 )
 
-// Operation is an enumeration of the test operations that can make assertions.
-type Operation int
+// ExpectOptionSet is a set of options that dictate the behavior of the
+// Test.Expect() method.
+type ExpectOptionSet struct {
+	// MessageComparator compares two messages for equality.
+	MessageComparator compare.Comparator
 
-const (
-	// ExecuteCommandOperation is an operation that makes assertions about what
-	// happens when a command is executed.
-	ExecuteCommandOperation Operation = iota
-
-	// RecordEventOperation is an operation that makes assertions about what
-	// happens when an event is recorded.
-	RecordEventOperation
-
-	// AdvanceTimeOperation is an operation that makes assertions about what
-	// happens when the engine time advances.
-	AdvanceTimeOperation
-
-	// CallOperation is an operation that makes assertions about what happens
-	// when a user-defined function is invoked.
-	CallOperation
-)
+	// MatchMessagesInDispatchCycle controls whether expectations should match
+	// messages from the start of a dispatch cycle.
+	//
+	// If it is false, only messages produced by handlers within the application
+	// are matched.
+	MatchMessagesInDispatchCycle bool
+}
 
 // An Assertion is a predicate for determining whether some specific criteria
 // was met during a test.
@@ -33,10 +26,7 @@ type Assertion interface {
 	fact.Observer
 
 	// Begin is called to prepare the assertion for a new test.
-	//
-	// op is the operation that is making the assertion. c is the comparator
-	// used to compare messages and other entities.
-	Begin(op Operation, c compare.Comparator)
+	Begin(o ExpectOptionSet)
 
 	// End is called once the test is complete.
 	End()
@@ -57,10 +47,10 @@ var Nothing Assertion = nothingAssertion{}
 
 type nothingAssertion struct{}
 
-func (nothingAssertion) Notify(fact.Fact)                    {}
-func (nothingAssertion) Begin(Operation, compare.Comparator) {}
-func (nothingAssertion) End()                                {}
-func (nothingAssertion) Ok() bool                            { return true }
+func (nothingAssertion) Notify(fact.Fact)      {}
+func (nothingAssertion) Begin(ExpectOptionSet) {}
+func (nothingAssertion) End()                  {}
+func (nothingAssertion) Ok() bool              { return true }
 func (nothingAssertion) BuildReport(ok bool, _ render.Renderer) *Report {
 	return &Report{
 		TreeOk:   ok,

--- a/assert/composite.go
+++ b/assert/composite.go
@@ -3,7 +3,6 @@ package assert
 import (
 	"fmt"
 
-	"github.com/dogmatiq/testkit/compare"
 	"github.com/dogmatiq/testkit/engine/fact"
 	"github.com/dogmatiq/testkit/render"
 )
@@ -131,15 +130,12 @@ func (a *compositeAssertion) Notify(f fact.Fact) {
 }
 
 // Begin is called to prepare the assertion for a new test.
-//
-// op is the operation that is making the assertion. c is the comparator
-// used to compare messages and other entities.
-func (a *compositeAssertion) Begin(op Operation, c compare.Comparator) {
+func (a *compositeAssertion) Begin(o ExpectOptionSet) {
 	a.ok = nil
 	a.outcome = ""
 
 	for _, sub := range a.SubAssertions {
-		sub.Begin(op, c)
+		sub.Begin(o)
 	}
 }
 

--- a/assert/composite_test.go
+++ b/assert/composite_test.go
@@ -5,7 +5,6 @@ import (
 	. "github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/testkit"
 	. "github.com/dogmatiq/testkit/assert"
-	"github.com/dogmatiq/testkit/compare"
 	"github.com/dogmatiq/testkit/engine/fact"
 	"github.com/dogmatiq/testkit/render"
 	. "github.com/onsi/ginkgo"
@@ -213,10 +212,10 @@ const (
 	fail constAssertion = false
 )
 
-func (a constAssertion) Begin(Operation, compare.Comparator) {}
-func (a constAssertion) End()                                {}
-func (a constAssertion) Ok() bool                            { return bool(a) }
-func (a constAssertion) Notify(fact.Fact)                    {}
+func (a constAssertion) Begin(ExpectOptionSet) {}
+func (a constAssertion) End()                  {}
+func (a constAssertion) Ok() bool              { return bool(a) }
+func (a constAssertion) Notify(fact.Fact)      {}
 func (a constAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 	c := "<always fail>"
 	if a {

--- a/assert/message.go
+++ b/assert/message.go
@@ -79,18 +79,15 @@ type messageAssertion struct {
 }
 
 // Begin is called to prepare the assertion for a new test.
-//
-// op is the operation that is making the assertion. c is the comparator used to
-// compare messages and other entities.
-func (a *messageAssertion) Begin(op Operation, c compare.Comparator) {
+func (a *messageAssertion) Begin(o ExpectOptionSet) {
 	// reset everything
 	*a = messageAssertion{
 		expected: a.expected,
 		role:     a.role,
-		cmp:      c,
+		cmp:      o.MessageComparator,
 		tracker: tracker{
 			role:               a.role,
-			matchDispatchCycle: op == CallOperation,
+			matchDispatchCycle: o.MatchMessagesInDispatchCycle,
 		},
 	}
 }

--- a/assert/messagetype.go
+++ b/assert/messagetype.go
@@ -55,17 +55,14 @@ type messageTypeAssertion struct {
 }
 
 // Begin is called to prepare the assertion for a new test.
-//
-// op is the operation that is making the assertion. c is the comparator used to
-// compare messages and other entities.
-func (a *messageTypeAssertion) Begin(op Operation, c compare.Comparator) {
+func (a *messageTypeAssertion) Begin(o ExpectOptionSet) {
 	// reset everything
 	*a = messageTypeAssertion{
 		expected: a.expected,
 		role:     a.role,
 		tracker: tracker{
 			role:               a.role,
-			matchDispatchCycle: op == CallOperation,
+			matchDispatchCycle: o.MatchMessagesInDispatchCycle,
 		},
 	}
 }

--- a/assert/user.go
+++ b/assert/user.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/dogmatiq/testkit/compare"
 	"github.com/dogmatiq/testkit/engine/fact"
 	"github.com/dogmatiq/testkit/render"
 )
@@ -43,12 +42,8 @@ func (a *userAssertion) Notify(f fact.Fact) {
 }
 
 // Begin is called to prepare the assertion for a new test.
-//
-// op is the operation that is making the assertion. c is the comparator
-// used to compare messages and other entities.
-func (a *userAssertion) Begin(op Operation, c compare.Comparator) {
-	a.s.Operation = op
-	a.s.Comparator = c
+func (a *userAssertion) Begin(o ExpectOptionSet) {
+	a.s.Options = o
 }
 
 // End is called once the test is complete.
@@ -113,11 +108,9 @@ func (a *userAssertion) BuildReport(ok bool, r render.Renderer) *Report {
 // criteria to be enforced. It is analogous the *testing.T type that is passed
 // to tests in the native Go test runner.
 type S struct {
-	// Operation is the test operation that made the assertion.
-	Operation Operation
-
-	// Comparator provides logic for comparing messages and application state.
-	compare.Comparator
+	// Options contains the set of options that dictate the behavior of the
+	// expectation.
+	Options ExpectOptionSet
 
 	// Facts is an ordered slice of the facts that occurred.
 	Facts []fact.Fact

--- a/expectation.go
+++ b/expectation.go
@@ -2,13 +2,28 @@ package testkit
 
 import (
 	"github.com/dogmatiq/testkit/assert"
-	"github.com/dogmatiq/testkit/engine"
+	"github.com/dogmatiq/testkit/compare"
 )
 
 // An Expectation is a predicate for determining whether some specific criteria
 // was met while performing an action.
 type Expectation = assert.Assertion
 
-// ExpectOption is an option that changes the behavior of engine during a call
-// to Test.Expect().
-type ExpectOption = engine.OperationOption
+// ExpectOptionSet is a set of options that dictate the behavior of the
+// Test.Expect() method.
+type ExpectOptionSet = assert.ExpectOptionSet
+
+// ExpectOption is an option that changes the behavior the Test.Expect() method.
+type ExpectOption func(*ExpectOptionSet)
+
+func newExpectOptions(options []ExpectOption) ExpectOptionSet {
+	o := ExpectOptionSet{
+		MessageComparator: compare.DefaultComparator{},
+	}
+
+	for _, opt := range options {
+		opt(&o)
+	}
+
+	return o
+}


### PR DESCRIPTION
#### What change does this introduce?

This PR replaces the `assert.Operation` enumeration, which was used so that assertions (now called "expectations") could change their behavior based on what test operation was being performed. It has been replaced with the `ExpectOptionSet` struct which models these behavioral changes directly.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

To decouple of expectations from the actions they run under.

#### Is there anything you are unsure about?

No