### PR TITLE
Decouple actions from expectations.

### DIFF
--- a/action.go
+++ b/action.go
@@ -1,5 +1,11 @@
 package testkit
 
+import (
+	"context"
+
+	"github.com/dogmatiq/testkit/engine"
+)
+
 // Action is an interface for any action that can be performed within a test.
 //
 // Actions always attempt to cause some state change within the engine or
@@ -12,10 +18,19 @@ type Action interface {
 	// heading.
 	Heading() string
 
+	// ConfigureExpect updates the options that dictate the behavior of
+	// expectations.
+	//
+	// It is called before Apply() when the action is used with the
+	// Test.Expect() method.
+	//
+	// It is not called when the action is used with Test.Prepare().
+	ConfigureExpect(*ExpectOptionSet)
+
 	// Apply performs the action within the context of a specific test.
 	Apply(
+		ctx context.Context,
 		t *Test,
-		e Expectation,
-		o ExpectOptionSet,
-	)
+		options []engine.OperationOption,
+	) error
 }

--- a/advancetime_test.go
+++ b/advancetime_test.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
-
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit"
@@ -31,7 +30,12 @@ var _ = Describe("func AdvanceTime()", func() {
 			},
 		}
 
-		t = &testingmock.T{}
+		GinkgoT()
+
+		t = &testingmock.T{
+			FailSilently: true,
+		}
+
 		startTime = time.Now()
 		buf = &fact.Buffer{}
 
@@ -64,13 +68,16 @@ var _ = Describe("func AdvanceTime()", func() {
 	})
 
 	It("panics if the mutation produces a time in the past", func() {
-		Expect(func() {
-			test.Prepare(
-				AdvanceTime(
-					ByDuration(-1 * time.Second),
-				),
-			)
-		}).To(PanicWith("changing the clock by -1s results in a time earlier than the current time"))
+		test.Prepare(
+			AdvanceTime(
+				ByDuration(-1 * time.Second),
+			),
+		)
+
+		Expect(t.Failed).To(BeTrue())
+		Expect(t.Logs).To(ContainElement(
+			"changing the clock by -1s results in a time earlier than the current time",
+		))
 	})
 
 	When("passed a ToTime() mutation", func() {

--- a/expectation.go
+++ b/expectation.go
@@ -2,7 +2,6 @@ package testkit
 
 import (
 	"github.com/dogmatiq/testkit/assert"
-	"github.com/dogmatiq/testkit/compare"
 )
 
 // An Expectation is a predicate for determining whether some specific criteria
@@ -15,15 +14,3 @@ type ExpectOptionSet = assert.ExpectOptionSet
 
 // ExpectOption is an option that changes the behavior the Test.Expect() method.
 type ExpectOption func(*ExpectOptionSet)
-
-func newExpectOptions(options []ExpectOption) ExpectOptionSet {
-	o := ExpectOptionSet{
-		MessageComparator: compare.DefaultComparator{},
-	}
-
-	for _, opt := range options {
-		opt(&o)
-	}
-
-	return o
-}


### PR DESCRIPTION
#### What change does this introduce?

This PR changes the `Action` interface so that it does not require any knowledge of the expectation being performed.

Instead of an expectation being passed to `Action.Apply()`, the `Action.ConfigureExpect()` method is called when there *is* an expectation being performed, allowing the action to setup the default expectation option.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

This allows actions to be applied without any expectation, eventually eliminating the need for `assert.Nothing`.

#### Is there anything you are unsure about?

No