### PR TITLE
Encapsulate parameters to `Action.Apply()` with an `ActionScope` struct.

### DIFF
--- a/action.go
+++ b/action.go
@@ -3,6 +3,7 @@ package testkit
 import (
 	"context"
 
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/testkit/engine"
 )
 
@@ -23,9 +24,13 @@ type Action interface {
 	ExpectOptions() []ExpectOption
 
 	// Apply performs the action within the context of a specific test.
-	Apply(
-		ctx context.Context,
-		t *Test,
-		options []engine.OperationOption,
-	) error
+	Apply(ctx context.Context, s ActionScope) error
+}
+
+// ActionScope encapsulates the state that an action can inspect and manipulate.
+type ActionScope struct {
+	App              configkit.RichApplication
+	Test             *Test
+	Engine           *engine.Engine
+	OperationOptions []engine.OperationOption
 }

--- a/runner.go
+++ b/runner.go
@@ -11,6 +11,7 @@ import (
 
 // A Runner executes tests.
 type Runner struct {
+	app    configkit.RichApplication
 	engine *engine.Engine
 }
 
@@ -23,6 +24,7 @@ func New(
 	ro := newRunnerOptions(options)
 
 	return &Runner{
+		cfg,
 		engine.MustNew(cfg, ro.engineOptions...),
 	}
 }
@@ -45,6 +47,7 @@ func (r *Runner) BeginContext(ctx context.Context, t TestingT, options ...TestOp
 	return &Test{
 		ctx:    ctx,
 		t:      t,
+		app:    r.app,
 		engine: r.engine,
 		now:    to.time,
 		operationOptions: append(


### PR DESCRIPTION
#### What change does this introduce?

This PR moves the parameters of `Action.Apply()` into a new struct called `ActionScope`.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

- To prevent breaking changes to the `Action` interface as more features that actions can control are added or changed.
- To expose explicitly only the values that the actions are allowed to manipulate. This is now complete yet, for example `AdvanceTime()` directly manipulates the unexported `.now` field of `Test`.

#### Is there anything you are unsure about?

No