### PR TITLE
Construct engines from a `configkit.RichApplication` instead of `dogm…

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -30,10 +30,7 @@ type Engine struct {
 }
 
 // New returns a new engine that uses the given app configuration.
-func New(app dogma.Application, options ...Option) (_ *Engine, err error) {
-	defer configkit.Recover(&err)
-	cfg := configkit.FromApplication(app)
-
+func New(app configkit.RichApplication, options ...Option) (_ *Engine, err error) {
 	eo := newEngineOptions(options)
 
 	e := &Engine{
@@ -50,7 +47,7 @@ func New(app dogma.Application, options ...Option) (_ *Engine, err error) {
 
 	ctx := context.Background()
 
-	if err := cfg.AcceptRichVisitor(ctx, cfgr); err != nil {
+	if err := app.AcceptRichVisitor(ctx, cfgr); err != nil {
 		return nil, err
 	}
 
@@ -59,7 +56,7 @@ func New(app dogma.Application, options ...Option) (_ *Engine, err error) {
 
 // MustNew returns a new engine that uses the given app configuration, or panics
 // if unable to do so.
-func MustNew(app dogma.Application, options ...Option) *Engine {
+func MustNew(app configkit.RichApplication, options ...Option) *Engine {
 	e, err := New(app, options...)
 	if err != nil {
 		panic(err)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/engine"
@@ -71,9 +72,9 @@ var _ = Describe("type Engine", func() {
 			},
 		}
 
-		var err error
-		engine, err = New(app)
-		Expect(err).ShouldNot(HaveOccurred())
+		engine = MustNew(
+			configkit.FromApplication(app),
+		)
 	})
 
 	Describe("func Dispatch()", func() {

--- a/engine/executor_test.go
+++ b/engine/executor_test.go
@@ -3,6 +3,7 @@ package engine_test
 import (
 	"context"
 
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/engine"
@@ -37,9 +38,9 @@ var _ = Describe("type CommandExecutor", func() {
 			},
 		}
 
-		var err error
-		engine, err = New(app)
-		Expect(err).ShouldNot(HaveOccurred())
+		engine = MustNew(
+			configkit.FromApplication(app),
+		)
 
 		executor = &CommandExecutor{
 			Engine: engine,

--- a/engine/recorder_test.go
+++ b/engine/recorder_test.go
@@ -3,6 +3,7 @@ package engine_test
 import (
 	"context"
 
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/engine"
@@ -33,9 +34,9 @@ var _ = Describe("type EventRecorder", func() {
 			},
 		}
 
-		var err error
-		engine, err = New(app)
-		Expect(err).ShouldNot(HaveOccurred())
+		engine = MustNew(
+			configkit.FromApplication(app),
+		)
 
 		recorder = &EventRecorder{
 			Engine: engine,

--- a/engine/run_test.go
+++ b/engine/run_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/engine"
@@ -25,9 +26,9 @@ var _ = Describe("func Run()", func() {
 			},
 		}
 
-		var err error
-		engine, err = New(app)
-		Expect(err).ShouldNot(HaveOccurred())
+		engine = MustNew(
+			configkit.FromApplication(app),
+		)
 	})
 
 	It("calls tick repeatedly", func() {
@@ -90,9 +91,9 @@ var _ = Describe("func RunTimeScaled()", func() {
 			},
 		}
 
-		var err error
-		engine, err = New(app)
-		Expect(err).ShouldNot(HaveOccurred())
+		engine = MustNew(
+			configkit.FromApplication(app),
+		)
 	})
 
 	It("scales type by the given factor", func() {

--- a/runner.go
+++ b/runner.go
@@ -3,6 +3,7 @@ package testkit
 import (
 	"context"
 
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine"
 	"github.com/dogmatiq/testkit/engine/fact"
@@ -18,14 +19,12 @@ func New(
 	app dogma.Application,
 	options ...RunnerOption,
 ) *Runner {
+	cfg := configkit.FromApplication(app)
 	ro := newRunnerOptions(options)
 
-	e, err := engine.New(app, ro.engineOptions...)
-	if err != nil {
-		panic(err)
+	return &Runner{
+		engine.MustNew(cfg, ro.engineOptions...),
 	}
-
-	return &Runner{e}
 }
 
 // Begin starts a new test.


### PR DESCRIPTION
#### What change does this introduce?

This PR changes `engine.New()` and `engine.MustNew()` to construct the in-memory engine from a `configkit.RichApplication` instead of from a `dogma.Application`.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

It expresses the dependencies of the engine more directly - it needs the `configkit.RichApplication` to initialize itself. 

This change is also done in preparation for changes to `Test` that depend on a `RichApplication`, avoiding constructing it twice.

#### Is there anything you are unsure about?

No