### PR TITLE
Add `RecordEvent()` action.

### DIFF
--- a/dispatchcommand_test.go
+++ b/dispatchcommand_test.go
@@ -36,7 +36,9 @@ var _ = Describe("func ExecuteCommand()", func() {
 						c.ConsumesCommandType(MessageC{})
 						c.ProducesEventType(MessageE{})
 					},
-					RouteCommandToInstanceFunc: func(m dogma.Message) string {
+					RouteCommandToInstanceFunc: func(
+						dogma.Message,
+					) string {
 						return "<instance>"
 					},
 				})
@@ -92,7 +94,7 @@ var _ = Describe("func ExecuteCommand()", func() {
 
 		Expect(t.Failed).To(BeTrue())
 		Expect(t.Logs).To(ContainElement(
-			"can not execute fixtures.MessageX as a command, it is a not a recognized message type",
+			"can not execute command, fixtures.MessageX is a not a recognized message type",
 		))
 	})
 
@@ -105,7 +107,7 @@ var _ = Describe("func ExecuteCommand()", func() {
 
 		Expect(t.Failed).To(BeTrue())
 		Expect(t.Logs).To(ContainElement(
-			"can not execute fixtures.MessageE as a command, it is configured as an event",
+			"can not execute command, fixtures.MessageE is configured as an event",
 		))
 	})
 

--- a/dispatchevent_test.go
+++ b/dispatchevent_test.go
@@ -1,0 +1,125 @@
+package testkit_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/configkit"
+	. "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/testkit"
+	"github.com/dogmatiq/testkit/engine"
+	"github.com/dogmatiq/testkit/engine/envelope"
+	"github.com/dogmatiq/testkit/engine/fact"
+	"github.com/dogmatiq/testkit/internal/testingmock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func RecordEvent()", func() {
+	var (
+		app       *Application
+		t         *testingmock.T
+		startTime time.Time
+		buf       *fact.Buffer
+		test      *Test
+	)
+
+	BeforeEach(func() {
+		app = &Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+				c.RegisterProcess(&ProcessMessageHandler{
+					ConfigureFunc: func(c dogma.ProcessConfigurer) {
+						c.Identity("<process>", "<process-key>")
+						c.ConsumesEventType(MessageE{})
+						c.ProducesCommandType(MessageC{})
+					},
+					RouteEventToInstanceFunc: func(
+						context.Context,
+						dogma.Message,
+					) (string, bool, error) {
+						return "<instance>", true, nil
+					},
+				})
+			},
+		}
+
+		t = &testingmock.T{}
+		startTime = time.Now()
+		buf = &fact.Buffer{}
+
+		test = New(app).Begin(
+			t,
+			WithStartTime(startTime),
+			WithOperationOptions(
+				engine.WithObserver(buf),
+			),
+		)
+	})
+
+	It("dispatches the message", func() {
+		test.Prepare(
+			RecordEvent(MessageE1),
+		)
+
+		Expect(buf.Facts()).To(ContainElement(
+			fact.DispatchCycleBegun{
+				Envelope: &envelope.Envelope{
+					MessageID:     "1",
+					CausationID:   "1",
+					CorrelationID: "1",
+					Message:       MessageE1,
+					Type:          MessageEType,
+					Role:          message.EventRole,
+					CreatedAt:     startTime,
+				},
+				EngineTime: startTime,
+				EnabledHandlers: map[configkit.HandlerType]bool{
+					configkit.AggregateHandlerType:   true,
+					configkit.IntegrationHandlerType: false,
+					configkit.ProcessHandlerType:     true,
+					configkit.ProjectionHandlerType:  false,
+				},
+			},
+		))
+	})
+
+	It("fails the test if the message type is unrecognized", func() {
+		t.FailSilently = true
+
+		test.Prepare(
+			RecordEvent(MessageX1),
+		)
+
+		Expect(t.Failed).To(BeTrue())
+		Expect(t.Logs).To(ContainElement(
+			"can not record event, fixtures.MessageX is a not a recognized message type",
+		))
+	})
+
+	It("fails the test if the message type is not an event", func() {
+		t.FailSilently = true
+
+		test.Prepare(
+			RecordEvent(MessageC1),
+		)
+
+		Expect(t.Failed).To(BeTrue())
+		Expect(t.Logs).To(ContainElement(
+			"can not record event, fixtures.MessageC is configured as a command",
+		))
+	})
+
+	It("logs a suitable heading", func() {
+		test.Prepare(
+			RecordEvent(MessageE1),
+		)
+
+		Expect(t.Logs).To(ContainElement(
+			"--- PREPARE: RECORDING TEST EVENT (fixtures.MessageE) ---",
+		))
+	})
+})

--- a/internal/inflect/inflect.go
+++ b/internal/inflect/inflect.go
@@ -8,31 +8,49 @@ import (
 	"github.com/dogmatiq/configkit/message"
 )
 
+var substitutions = map[message.Role]map[string]string{
+	message.CommandRole: {
+		"<message>":    "command",
+		"<messages>":   "commands",
+		"<produce>":    "execute",
+		"<produced>":   "executed",
+		"<producing>":  "executing",
+		"<dispatcher>": "dogma.CommandExecutor",
+	},
+	message.EventRole: {
+		"<message>":    "event",
+		"<messages>":   "events",
+		"<produce>":    "record",
+		"<produced>":   "recorded",
+		"<producing>":  "recording",
+		"<dispatcher>": "dogma.EventRecorder",
+	},
+	message.TimeoutRole: {
+		"<message>":   "timeout",
+		"<messages>":  "timeouts",
+		"<produce>":   "schedule",
+		"<produced>":  "scheduled",
+		"<producing>": "scheduling",
+	},
+}
+
+var corrections = map[string]string{
+	"an command": "a command",
+	"a event":    "an event",
+	"an timeout": "a timeout",
+}
+
 // Sprint formats a string, inflecting words in s match the message role r.
 func Sprint(r message.Role, s string) string {
-	switch r {
-	case message.CommandRole:
-		s = strings.ReplaceAll(s, "<message>", "command")
-		s = strings.ReplaceAll(s, "<messages>", "commands")
-		s = strings.ReplaceAll(s, "<produce>", "execute")
-		s = strings.ReplaceAll(s, "<produced>", "executed")
-		s = strings.ReplaceAll(s, "<dispatcher>", "dogma.CommandExecutor")
-	case message.EventRole:
-		s = strings.ReplaceAll(s, "<message>", "event")
-		s = strings.ReplaceAll(s, "<messages>", "events")
-		s = strings.ReplaceAll(s, "<produce>", "record")
-		s = strings.ReplaceAll(s, "<produced>", "recorded")
-		s = strings.ReplaceAll(s, "<dispatcher>", "dogma.EventRecorder")
-	case message.TimeoutRole:
-		s = strings.ReplaceAll(s, "<message>", "timeout")
-		s = strings.ReplaceAll(s, "<messages>", "timeouts")
-		s = strings.ReplaceAll(s, "<produce>", "schedule")
-		s = strings.ReplaceAll(s, "<produced>", "scheduled")
+	for k, v := range substitutions[r] {
+		s = strings.ReplaceAll(s, k, v)
+		s = strings.ReplaceAll(s, strings.ToUpper(k), strings.ToUpper(v))
 	}
 
-	s = strings.ReplaceAll(s, "an command", "a command")
-	s = strings.ReplaceAll(s, "a event", "an event")
-	s = strings.ReplaceAll(s, "an timeout", "a timeout")
+	for k, v := range corrections {
+		s = strings.ReplaceAll(s, k, v)
+		s = strings.ReplaceAll(s, strings.ToUpper(k), strings.ToUpper(v))
+	}
 
 	return s
 }

--- a/internal/inflect/inflect_test.go
+++ b/internal/inflect/inflect_test.go
@@ -1,6 +1,8 @@
 package inflect_test
 
 import (
+	"strings"
+
 	"github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/internal/inflect"
@@ -22,6 +24,10 @@ var _ = Describe("func Sprint()", func() {
 	DescribeTable(
 		"returns a properly inflected string",
 		func(r message.Role, in, out string) {
+			Expect(Sprint(r, in)).To(Equal(out))
+
+			in = strings.ToUpper(in)
+			out = strings.ToUpper(out)
 			Expect(Sprint(r, in)).To(Equal(out))
 		},
 		entry(message.CommandRole, "a <message>", "a command"),


### PR DESCRIPTION
#### What change does this introduce?

This PR adds the `RecordEvent()` action.

It shares a common underlying `Action` implementation with `ExecuteCommand()`.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

Part of porting `Test` methods to `Action` implementations.

#### Is there anything you are unsure about?

No