### PR TITLE
Add the `Call()` action.

### DIFF
--- a/call.go
+++ b/call.go
@@ -1,0 +1,69 @@
+package testkit
+
+import "context"
+
+// Call is an Action that invokes a user-defined function within the context of
+// a test.
+//
+// It is intended to execute application code that makes use of the
+// dogma.CommandExecutor or dogma.EventRecorder interfaces.
+//
+// Test implementations of these interfaces can be OBTAINED via the
+// Test.CommandExecutor() and Test.EventRecorder() methods at any time; however,
+// they may only be USED within a function invoked by a Call() action.
+//
+// When Call() is used with Test.Expect() the expectation will match the
+// messages dispatched via the test's executor and recorder, as well as those
+// produced by handlers within the Dogma application.
+func Call(fn func()) Action {
+	if fn == nil {
+		panic("Call(): function must not be nil")
+	}
+
+	return call{fn}
+}
+
+// call is an implementation of Action that invokes a user-defined function.
+type call struct {
+	fn func()
+}
+
+// Heading returns a human-readable description of the action, used as a
+// heading within the test report.
+//
+// Any engine activity as a result of this action is logged beneath this
+// heading.
+func (a call) Heading() string {
+	return "CALLING USER-DEFINED FUNCTION"
+}
+
+// ExpectOptions returns the options to use by default when this action is
+// used with Test.Expect().
+func (a call) ExpectOptions() []ExpectOption {
+	return []ExpectOption{
+		func(o *ExpectOptionSet) {
+			o.MatchMessagesInDispatchCycle = true
+		},
+	}
+}
+
+// Apply performs the action within the context of a specific test.
+func (a call) Apply(ctx context.Context, s ActionScope) error {
+	s.Test.executor.Engine = s.Engine
+	s.Test.recorder.Engine = s.Engine
+	s.Test.executor.Options = s.OperationOptions
+	s.Test.recorder.Options = s.OperationOptions
+
+	defer func() {
+		// Reset the engine and options to nil so that the executor and recorder
+		// can not be used after this Call() action ends.
+		s.Test.executor.Engine = nil
+		s.Test.recorder.Engine = nil
+		s.Test.executor.Options = nil
+		s.Test.recorder.Options = nil
+	}()
+
+	a.fn()
+
+	return nil
+}

--- a/dispatchcommand_test.go
+++ b/dispatchcommand_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit"
+	"github.com/dogmatiq/testkit/assert"
 	"github.com/dogmatiq/testkit/engine"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	"github.com/dogmatiq/testkit/engine/fact"
@@ -109,6 +110,17 @@ var _ = Describe("func ExecuteCommand()", func() {
 		Expect(t.Logs).To(ContainElement(
 			"can not execute command, fixtures.MessageE is configured as an event",
 		))
+	})
+
+	It("does not satisfy its own expectations", func() {
+		t.FailSilently = true
+
+		test.Expect(
+			ExecuteCommand(MessageC1),
+			assert.CommandExecuted(MessageC1),
+		)
+
+		Expect(t.Failed).To(BeTrue())
 	})
 
 	It("logs a suitable heading", func() {


### PR DESCRIPTION
#### What change does this introduce?

This PR adds the `Call()` action.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

Part of porting `Test` methods to `Action` implementations.

#### Is there anything you are unsure about?

No