### PR TITLE
Remove `assert.Nothing`.

### DIFF
--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -41,20 +41,3 @@ type Assertion interface {
 	// sub-assertion inside a composite.
 	BuildReport(ok bool, r render.Renderer) *Report
 }
-
-// Nothing is an assertion that has no requirements.
-var Nothing Assertion = nothingAssertion{}
-
-type nothingAssertion struct{}
-
-func (nothingAssertion) Notify(fact.Fact)      {}
-func (nothingAssertion) Begin(ExpectOptionSet) {}
-func (nothingAssertion) End()                  {}
-func (nothingAssertion) Ok() bool              { return true }
-func (nothingAssertion) BuildReport(ok bool, _ render.Renderer) *Report {
-	return &Report{
-		TreeOk:   ok,
-		Ok:       true,
-		Criteria: "no requirement",
-	}
-}


### PR DESCRIPTION
#### What change does this introduce?

This PR removes `assert.Nothing`, a no-op assertion.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

All actions can now be performed via `Prepare()` if an assertion (expectation) is not needed, so there is no longer a need for a no-op assertion.

#### Is there anything you are unsure about?

No