### PR TITLE
Avoid using `Test` internals in actions.

### DIFF
--- a/action.go
+++ b/action.go
@@ -2,6 +2,7 @@ package testkit
 
 import (
 	"context"
+	"time"
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/testkit/engine"
@@ -24,7 +25,9 @@ type Action interface {
 type ActionScope struct {
 	App              configkit.RichApplication
 	TestingT         TestingT
-	Test             *Test
+	VirtualClock     *time.Time
+	Executor         *engine.CommandExecutor
+	Recorder         *engine.EventRecorder
 	Engine           *engine.Engine
 	OperationOptions []engine.OperationOption
 }

--- a/advancetime.go
+++ b/advancetime.go
@@ -74,19 +74,19 @@ func (a advanceTime) ExpectOptions() []ExpectOption {
 
 // Apply performs the action within the context of a specific test.
 func (a advanceTime) Apply(ctx context.Context, s ActionScope) error {
-	now := a.adj.Step(s.Test.now)
+	now := a.adj.Step(*s.VirtualClock)
 
-	if now.Before(s.Test.now) {
+	if now.Before(*s.VirtualClock) {
 		return fmt.Errorf(
 			"adjusting the clock %s would reverse time",
 			a.adj.Description(),
 		)
 	}
 
-	s.Test.now = now
+	*s.VirtualClock = now
 
-	// There is already an engine.WithCurrentTime() based on t.now in the
-	// options slice. Because we have just updated s.Test.now we need to
+	// There is already an engine.WithCurrentTime() based on the virtual clock
+	// in options slice. Because we have just updated the clock we need to
 	// override it for this one engine tick.
 	s.OperationOptions = append(
 		s.OperationOptions,

--- a/call.go
+++ b/call.go
@@ -40,18 +40,18 @@ func (a call) ExpectOptions() []ExpectOption {
 
 // Apply performs the action within the context of a specific test.
 func (a call) Apply(ctx context.Context, s ActionScope) error {
-	s.Test.executor.Engine = s.Engine
-	s.Test.recorder.Engine = s.Engine
-	s.Test.executor.Options = s.OperationOptions
-	s.Test.recorder.Options = s.OperationOptions
+	s.Executor.Engine = s.Engine
+	s.Recorder.Engine = s.Engine
+	s.Executor.Options = s.OperationOptions
+	s.Recorder.Options = s.OperationOptions
 
 	defer func() {
 		// Reset the engine and options to nil so that the executor and recorder
 		// can not be used after this Call() action ends.
-		s.Test.executor.Engine = nil
-		s.Test.recorder.Engine = nil
-		s.Test.executor.Options = nil
-		s.Test.recorder.Options = nil
+		s.Executor.Engine = nil
+		s.Recorder.Engine = nil
+		s.Executor.Options = nil
+		s.Recorder.Options = nil
 	}()
 
 	log(

--- a/test.go
+++ b/test.go
@@ -37,10 +37,12 @@ func (t *Test) Prepare(actions ...Action) *Test {
 
 	for _, act := range actions {
 		s := ActionScope{
-			App:      t.app,
-			TestingT: t.t,
-			Test:     t,
-			Engine:   t.engine,
+			App:          t.app,
+			TestingT:     t.t,
+			VirtualClock: &t.now,
+			Executor:     &t.executor,
+			Recorder:     &t.recorder,
+			Engine:       t.engine,
 		}
 
 		s.OperationOptions = append(s.OperationOptions, t.operationOptions...)
@@ -78,10 +80,12 @@ func (t *Test) Expect(act Action, e Expectation, options ...ExpectOption) {
 	e.Begin(o)
 
 	s := ActionScope{
-		App:      t.app,
-		TestingT: t.t,
-		Test:     t,
-		Engine:   t.engine,
+		App:          t.app,
+		TestingT:     t.t,
+		VirtualClock: &t.now,
+		Executor:     &t.executor,
+		Recorder:     &t.recorder,
+		Engine:       t.engine,
 	}
 
 	s.OperationOptions = append(s.OperationOptions, t.operationOptions...)


### PR DESCRIPTION
#### What change does this introduce?

This PR removes the `Test` object from `ActionScope` and replaces it with values that are allowed to be manipulated by actions.

#### What issues does this relate to?

https://github.com/dogmatiq/testkit/issues/127

#### Why make this change?

Removes the need to manipulate the unexported internals of `Test` in actions.

#### Is there anything you are unsure about?

No