### PR TITLE
Remove the `tHelper` interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ migrate tests from prior versions.
 - Add `Test.Expect()` method and associated `ExpectOption` and `ExpectOptionSet` types
 - Add `testkit.ExecuteCommand()`, `RecordEvent()`, `AdvanceTime()` and `Call()`
 - Add `TimeAdjuster` interface, for use with `AdvanceTime()`
-- **[BC]** Add `TestingT.Failed()` and `Fatal()` methods
+- **[BC]** Add `TestingT.Failed()`, `Fatal()` and `Helper()` methods
 
 ### Changed
 

--- a/interface.go
+++ b/interface.go
@@ -10,18 +10,5 @@ type TestingT interface {
 	Logf(f string, args ...interface{})
 	Fatal(args ...interface{})
 	FailNow()
-}
-
-// tHelper is an interface satisfied by T implementations that can mark
-// functions as test helpers.
-//
-// This is separated from T itself largely because Ginkgo's GinkgoTInterface
-// does not yet include this method.
-//
-// See https://github.com/dogmatiq/testkit/issues/61
-// See https://github.com/onsi/ginkgo/pull/585
-type tHelper interface {
-	TestingT
-
 	Helper()
 }

--- a/test.go
+++ b/test.go
@@ -31,9 +31,7 @@ type Test struct {
 // Prepare performs a group of actions without making any assertions in order
 // to place the application into a particular state.
 func (t *Test) Prepare(actions ...Action) *Test {
-	if h, ok := t.t.(tHelper); ok {
-		h.Helper()
-	}
+	t.t.Helper()
 
 	for _, act := range actions {
 		s := ActionScope{
@@ -61,9 +59,7 @@ func (t *Test) Prepare(actions ...Action) *Test {
 
 // Expect ensures that a single action results in some expected behavior.
 func (t *Test) Expect(act Action, e Expectation, options ...ExpectOption) {
-	if h, ok := t.t.(tHelper); ok {
-		h.Helper()
-	}
+	t.t.Helper()
 
 	o := ExpectOptionSet{
 		MessageComparator: compare.DefaultComparator{},
@@ -121,9 +117,7 @@ func (t *Test) EventRecorder() dogma.EventRecorder {
 }
 
 func (t *Test) buildReport(e Expectation) {
-	if h, ok := t.t.(tHelper); ok {
-		h.Helper()
-	}
+	t.t.Helper()
 
 	r := t.renderer
 	if r == nil {


### PR DESCRIPTION
#### What change does this introduce?

This PR removes the `tHelper` interface.

#### What issues does this relate to?

Fixes #149 

#### Why make this change?

This interface was present largely because `ginkgo.GinkgoTInterface` did not provide the `Helper()` method, which has since been added.

#### Is there anything you are unsure about?

No