### PR TITLE
Use configkit interfaces in facts.

### DIFF
--- a/assert/message.go
+++ b/assert/message.go
@@ -200,7 +200,7 @@ func (a *messageAssertion) buildResultExpectedRole(r render.Renderer, rep *Repor
 			rep.Explanation = inflect.Sprintf(
 				a.role,
 				"a similar <message> was <produced> by the '%s' %s message handler",
-				a.best.Origin.HandlerName,
+				a.best.Origin.Handler.Identity().Name,
 				a.best.Origin.HandlerType,
 			)
 		}
@@ -216,7 +216,7 @@ func (a *messageAssertion) buildResultExpectedRole(r render.Renderer, rep *Repor
 			rep.Explanation = inflect.Sprintf(
 				a.role,
 				"a <message> of a similar type was <produced> by the '%s' %s message handler",
-				a.best.Origin.HandlerName,
+				a.best.Origin.Handler.Identity().Name,
 				a.best.Origin.HandlerType,
 			)
 		}
@@ -253,7 +253,7 @@ func (a *messageAssertion) buildResultUnexpectedRole(r render.Renderer, rep *Rep
 		s.AppendListItem(inflect.Sprintf(
 			a.best.Role,
 			"verify that the '%s' %s message handler intended to <produce> a <message> of this type",
-			a.best.Origin.HandlerName,
+			a.best.Origin.Handler.Identity().Name,
 			a.best.Origin.HandlerType,
 		))
 	}
@@ -276,7 +276,7 @@ func (a *messageAssertion) buildResultUnexpectedRole(r render.Renderer, rep *Rep
 			rep.Explanation = inflect.Sprintf(
 				a.best.Role,
 				"the expected message was <produced> as a <message> by the '%s' %s message handler",
-				a.best.Origin.HandlerName,
+				a.best.Origin.Handler.Identity().Name,
 				a.best.Origin.HandlerType,
 			)
 		}
@@ -294,7 +294,7 @@ func (a *messageAssertion) buildResultUnexpectedRole(r render.Renderer, rep *Rep
 			rep.Explanation = inflect.Sprintf(
 				a.best.Role,
 				"a similar message was <produced> as a <message> by the '%s' %s message handler",
-				a.best.Origin.HandlerName,
+				a.best.Origin.Handler.Identity().Name,
 				a.best.Origin.HandlerType,
 			)
 		}
@@ -308,7 +308,7 @@ func (a *messageAssertion) buildResultUnexpectedRole(r render.Renderer, rep *Rep
 			rep.Explanation = inflect.Sprintf(
 				a.best.Role,
 				"a message of a similar type was <produced> as a <message> by the '%s' %s message handler",
-				a.best.Origin.HandlerName,
+				a.best.Origin.Handler.Identity().Name,
 				a.best.Origin.HandlerType,
 			)
 		}

--- a/assert/messagetype.go
+++ b/assert/messagetype.go
@@ -171,7 +171,7 @@ func (a *messageTypeAssertion) buildResultExpectedRole(r render.Renderer, rep *R
 		rep.Explanation = inflect.Sprintf(
 			a.role,
 			"a <message> of a similar type was <produced> by the '%s' %s message handler",
-			a.best.Origin.HandlerName,
+			a.best.Origin.Handler.Identity().Name,
 			a.best.Origin.HandlerType,
 		)
 	}
@@ -197,7 +197,7 @@ func (a *messageTypeAssertion) buildResultUnexpectedRole(r render.Renderer, rep 
 		s.AppendListItem(inflect.Sprintf(
 			a.best.Role,
 			"verify that the '%s' %s message handler intended to <produce> a <message> of this type",
-			a.best.Origin.HandlerName,
+			a.best.Origin.Handler.Identity().Name,
 			a.best.Origin.HandlerType,
 		))
 	}
@@ -218,7 +218,7 @@ func (a *messageTypeAssertion) buildResultUnexpectedRole(r render.Renderer, rep 
 			rep.Explanation = inflect.Sprintf(
 				a.best.Role,
 				"a message of this type was <produced> as a <message> by the '%s' %s message handler",
-				a.best.Origin.HandlerName,
+				a.best.Origin.Handler.Identity().Name,
 				a.best.Origin.HandlerType,
 			)
 		}
@@ -232,7 +232,7 @@ func (a *messageTypeAssertion) buildResultUnexpectedRole(r render.Renderer, rep 
 			rep.Explanation = inflect.Sprintf(
 				a.best.Role,
 				"a message of a similar type was <produced> as a <message> by the '%s' %s message handler",
-				a.best.Origin.HandlerName,
+				a.best.Origin.Handler.Identity().Name,
 				a.best.Origin.HandlerType,
 			)
 		}

--- a/assert/tracker.go
+++ b/assert/tracker.go
@@ -53,7 +53,10 @@ func (t *tracker) Notify(f fact.Fact) {
 		t.cycleBegun = true
 		t.enabled = x.EnabledHandlers
 	case fact.HandlingBegun:
-		t.updateEngaged(x.HandlerIdentity.Name, x.HandlerType)
+		t.updateEngaged(
+			x.Handler.Identity().Name,
+			x.Handler.HandlerType(),
+		)
 	case fact.EventRecordedByAggregate:
 		t.messageProduced(x.EventEnvelope.Role)
 	case fact.EventRecordedByIntegration:

--- a/assert/tracker.go
+++ b/assert/tracker.go
@@ -53,7 +53,7 @@ func (t *tracker) Notify(f fact.Fact) {
 		t.cycleBegun = true
 		t.enabled = x.EnabledHandlers
 	case fact.HandlingBegun:
-		t.updateEngaged(x.HandlerName, x.HandlerType)
+		t.updateEngaged(x.HandlerIdentity.Name, x.HandlerType)
 	case fact.EventRecordedByAggregate:
 		t.messageProduced(x.EventEnvelope.Role)
 	case fact.EventRecordedByIntegration:

--- a/engine/configurer.go
+++ b/engine/configurer.go
@@ -79,7 +79,7 @@ func (c *configurer) registerController(
 	ctrl controller.Controller,
 	types map[message.Type]message.Role,
 ) {
-	c.engine.controllers[ctrl.Identity().Name] = ctrl
+	c.engine.controllers[ctrl.HandlerConfig().Identity().Name] = ctrl
 
 	for t := range types {
 		c.engine.routes[t] = append(c.engine.routes[t], ctrl)

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -21,15 +21,10 @@ type Controller struct {
 	history map[string][]*envelope.Envelope
 }
 
-// Identity returns the identity of the handler that is managed by this
+// HandlerConfig returns the config of the handler that is managed by this
 // controller.
-func (c *Controller) Identity() configkit.Identity {
-	return c.Config.Identity()
-}
-
-// Type returns configkit.AggregateHandlerType.
-func (c *Controller) Type() configkit.HandlerType {
-	return configkit.AggregateHandlerType
+func (c *Controller) HandlerConfig() configkit.RichHandler {
+	return c.Config
 }
 
 // Tick does nothing.

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -197,10 +197,9 @@ var _ = Describe("type Controller", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.AggregateInstanceNotFound{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance-C1>",
-						Envelope:    command,
+						Handler:    config,
+						InstanceID: "<instance-C1>",
+						Envelope:   command,
 					},
 				))
 			})
@@ -274,9 +273,8 @@ var _ = Describe("type Controller", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.AggregateInstanceLoaded{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance-C1>",
+						Handler:    config,
+						InstanceID: "<instance-C1>",
 						Root: &AggregateRoot{
 							AppliedEvents: []dogma.Message{
 								MessageE1,

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -66,17 +66,9 @@ var _ = Describe("type Controller", func() {
 		messageIDs.Reset() // reset after setup for a predictable ID.
 	})
 
-	Describe("func Identity()", func() {
-		It("returns the handler identity", func() {
-			Expect(ctrl.Identity()).To(Equal(
-				configkit.MustNewIdentity("<name>", "<key>"),
-			))
-		})
-	})
-
-	Describe("func Type()", func() {
-		It("returns configkit.AggregateHandlerType", func() {
-			Expect(ctrl.Type()).To(Equal(configkit.AggregateHandlerType))
+	Describe("func HandlerConfig()", func() {
+		It("returns the handler config", func() {
+			Expect(ctrl.HandlerConfig()).To(BeIdenticalTo(config))
 		})
 	})
 

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -151,7 +151,7 @@ var _ = Describe("type Controller", func() {
 					MessageE1,
 					now,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.AggregateHandlerType,
 						InstanceID:  "<instance-C1>",
 					},
@@ -161,7 +161,7 @@ var _ = Describe("type Controller", func() {
 					MessageE2,
 					now,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.AggregateHandlerType,
 						InstanceID:  "<instance-C1>",
 					},

--- a/engine/controller/aggregate/scope.go
+++ b/engine/controller/aggregate/scope.go
@@ -37,11 +37,10 @@ func (s *scope) Destroy() {
 	s.exists = false
 
 	s.observer.Notify(fact.AggregateInstanceDestroyed{
-		HandlerName: s.config.Identity().Name,
-		Handler:     s.config.Handler(),
-		InstanceID:  s.instanceID,
-		Root:        s.root,
-		Envelope:    s.command,
+		Handler:    s.config,
+		InstanceID: s.instanceID,
+		Root:       s.root,
+		Envelope:   s.command,
 	})
 }
 
@@ -64,11 +63,10 @@ func (s *scope) RecordEvent(m dogma.Message) {
 
 	if !s.exists {
 		s.observer.Notify(fact.AggregateInstanceCreated{
-			HandlerName: s.config.Identity().Name,
-			Handler:     s.config.Handler(),
-			InstanceID:  s.instanceID,
-			Root:        s.root,
-			Envelope:    s.command,
+			Handler:    s.config,
+			InstanceID: s.instanceID,
+			Root:       s.root,
+			Envelope:   s.command,
 		})
 
 		s.exists = true
@@ -98,8 +96,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 	s.events = append(s.events, env)
 
 	s.observer.Notify(fact.EventRecordedByAggregate{
-		HandlerName:   s.config.Identity().Name,
-		Handler:       s.config.Handler(),
+		Handler:       s.config,
 		InstanceID:    s.instanceID,
 		Root:          s.root,
 		Envelope:      s.command,
@@ -109,8 +106,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 
 func (s *scope) Log(f string, v ...interface{}) {
 	s.observer.Notify(fact.MessageLoggedByAggregate{
-		HandlerName:  s.config.Identity().Name,
-		Handler:      s.config.Handler(),
+		Handler:      s.config,
 		InstanceID:   s.instanceID,
 		Root:         s.root,
 		Envelope:     s.command,

--- a/engine/controller/aggregate/scope.go
+++ b/engine/controller/aggregate/scope.go
@@ -87,7 +87,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 		m,
 		s.now,
 		envelope.Origin{
-			HandlerName: s.config.Identity().Name,
+			Handler:     s.config,
 			HandlerType: configkit.AggregateHandlerType,
 			InstanceID:  s.instanceID,
 		},

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -19,6 +19,7 @@ var _ = Describe("type scope", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *AggregateMessageHandler
+		config     configkit.RichAggregate
 		ctrl       *Controller
 		command    *envelope.Envelope
 	)
@@ -46,8 +47,10 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
+		config = configkit.FromAggregate(handler)
+
 		ctrl = &Controller{
-			Config:     configkit.FromAggregate(handler),
+			Config:     config,
 			MessageIDs: &messageIDs,
 		}
 
@@ -102,9 +105,8 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.AggregateInstanceCreated{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
+						Handler:    config,
+						InstanceID: "<instance>",
 						Root: &AggregateRoot{
 							AppliedEvents: []dogma.Message{
 								MessageE1,
@@ -115,9 +117,8 @@ var _ = Describe("type scope", func() {
 				))
 				Expect(buf.Facts()).To(ContainElement(
 					fact.EventRecordedByAggregate{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
+						Handler:    config,
+						InstanceID: "<instance>",
 						Root: &AggregateRoot{
 							AppliedEvents: []dogma.Message{
 								MessageE1,
@@ -187,11 +188,10 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.AggregateInstanceDestroyed{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
-						Root:        &AggregateRoot{},
-						Envelope:    command,
+						Handler:    config,
+						InstanceID: "<instance>",
+						Root:       &AggregateRoot{},
+						Envelope:   command,
 					},
 				))
 			})
@@ -223,9 +223,8 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.EventRecordedByAggregate{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
+						Handler:    config,
+						InstanceID: "<instance>",
 						Root: &AggregateRoot{
 							AppliedEvents: []dogma.Message{
 								MessageE1,
@@ -284,9 +283,8 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.AggregateInstanceCreated{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
+						Handler:    config,
+						InstanceID: "<instance>",
 						Root: &AggregateRoot{
 							AppliedEvents: []dogma.Message{
 								MessageE1,
@@ -297,9 +295,8 @@ var _ = Describe("type scope", func() {
 				))
 				Expect(buf.Facts()).To(ContainElement(
 					fact.EventRecordedByAggregate{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
+						Handler:    config,
+						InstanceID: "<instance>",
 						Root: &AggregateRoot{
 							AppliedEvents: []dogma.Message{
 								MessageE1,
@@ -409,12 +406,11 @@ var _ = Describe("type scope", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buf.Facts()).To(ContainElement(
 				fact.MessageLoggedByAggregate{
-					HandlerName: "<name>",
-					Handler:     handler,
-					InstanceID:  "<instance>",
-					Root:        &AggregateRoot{},
-					Envelope:    command,
-					LogFormat:   "<format>",
+					Handler:    config,
+					InstanceID: "<instance>",
+					Root:       &AggregateRoot{},
+					Envelope:   command,
+					LogFormat:  "<format>",
 					LogArguments: []interface{}{
 						"<arg-1>",
 						"<arg-2>",

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -130,7 +130,7 @@ var _ = Describe("type scope", func() {
 							MessageE1,
 							now,
 							envelope.Origin{
-								HandlerName: "<name>",
+								Handler:     config,
 								HandlerType: configkit.AggregateHandlerType,
 								InstanceID:  "<instance>",
 							},
@@ -237,7 +237,7 @@ var _ = Describe("type scope", func() {
 							MessageE1,
 							now,
 							envelope.Origin{
-								HandlerName: "<name>",
+								Handler:     config,
 								HandlerType: configkit.AggregateHandlerType,
 								InstanceID:  "<instance>",
 							},
@@ -308,7 +308,7 @@ var _ = Describe("type scope", func() {
 							MessageE1,
 							now,
 							envelope.Origin{
-								HandlerName: "<name>",
+								Handler:     config,
 								HandlerType: configkit.AggregateHandlerType,
 								InstanceID:  "<instance>",
 							},

--- a/engine/controller/controller.go
+++ b/engine/controller/controller.go
@@ -11,12 +11,9 @@ import (
 
 // Controller orchestrates the handling of a message by Dogma message handler.
 type Controller interface {
-	// Identity returns the identity of the handler that is managed by this
+	// HandlerConfig returns the config of the handler that is managed by this
 	// controller.
-	Identity() configkit.Identity
-
-	// Type returns the name of the handler that is managed by this controller.
-	Type() configkit.HandlerType
+	HandlerConfig() configkit.RichHandler
 
 	// Tick instructs the controller to perform an implementation-defined
 	// "tick".

--- a/engine/controller/integration/controller.go
+++ b/engine/controller/integration/controller.go
@@ -18,15 +18,10 @@ type Controller struct {
 	MessageIDs *envelope.MessageIDGenerator
 }
 
-// Identity returns the identity of the handler that is managed by this
+// HandlerConfig returns the config of the handler that is managed by this
 // controller.
-func (c *Controller) Identity() configkit.Identity {
-	return c.Config.Identity()
-}
-
-// Type returns configkit.IntegrationHandlerType.
-func (c *Controller) Type() configkit.HandlerType {
-	return configkit.IntegrationHandlerType
+func (c *Controller) HandlerConfig() configkit.RichHandler {
+	return c.Config
 }
 
 // Tick does nothing.

--- a/engine/controller/integration/controller.go
+++ b/engine/controller/integration/controller.go
@@ -47,8 +47,6 @@ func (c *Controller) Handle(
 ) ([]*envelope.Envelope, error) {
 	env.Role.MustBe(message.CommandRole)
 
-	handler := c.Config.Handler()
-
 	var t time.Duration
 	controller.ConvertUnexpectedMessagePanic(
 		c.Config,
@@ -56,7 +54,7 @@ func (c *Controller) Handle(
 		"TimeoutHint",
 		env.Message,
 		func() {
-			t = handler.TimeoutHint(env.Message)
+			t = c.Config.Handler().TimeoutHint(env.Message)
 		},
 	)
 
@@ -81,7 +79,7 @@ func (c *Controller) Handle(
 		"HandleCommand",
 		env.Message,
 		func() {
-			err = handler.HandleCommand(ctx, s, env.Message)
+			err = c.Config.Handler().HandleCommand(ctx, s, env.Message)
 		},
 	)
 

--- a/engine/controller/integration/controller_test.go
+++ b/engine/controller/integration/controller_test.go
@@ -140,7 +140,7 @@ var _ = Describe("type Controller", func() {
 					MessageE1,
 					now,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.IntegrationHandlerType,
 					},
 				),
@@ -149,7 +149,7 @@ var _ = Describe("type Controller", func() {
 					MessageE2,
 					now,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.IntegrationHandlerType,
 					},
 				),

--- a/engine/controller/integration/controller_test.go
+++ b/engine/controller/integration/controller_test.go
@@ -53,17 +53,9 @@ var _ = Describe("type Controller", func() {
 		messageIDs.Reset() // reset after setup for a predictable ID.
 	})
 
-	Describe("func Identity()", func() {
-		It("returns the handler identity", func() {
-			Expect(ctrl.Identity()).To(Equal(
-				configkit.MustNewIdentity("<name>", "<key>"),
-			))
-		})
-	})
-
-	Describe("func Type()", func() {
-		It("returns configkit.IntegrationHandlerType", func() {
-			Expect(ctrl.Type()).To(Equal(configkit.IntegrationHandlerType))
+	Describe("func HandlerConfig()", func() {
+		It("returns the handler config", func() {
+			Expect(ctrl.HandlerConfig()).To(BeIdenticalTo(config))
 		})
 	})
 

--- a/engine/controller/integration/scope.go
+++ b/engine/controller/integration/scope.go
@@ -50,8 +50,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 	s.events = append(s.events, env)
 
 	s.observer.Notify(fact.EventRecordedByIntegration{
-		HandlerName:   s.config.Identity().Name,
-		Handler:       s.config.Handler(),
+		Handler:       s.config,
 		Envelope:      s.command,
 		EventEnvelope: env,
 	})
@@ -59,8 +58,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 
 func (s *scope) Log(f string, v ...interface{}) {
 	s.observer.Notify(fact.MessageLoggedByIntegration{
-		HandlerName:  s.config.Identity().Name,
-		Handler:      s.config.Handler(),
+		Handler:      s.config,
 		Envelope:     s.command,
 		LogFormat:    f,
 		LogArguments: v,

--- a/engine/controller/integration/scope.go
+++ b/engine/controller/integration/scope.go
@@ -42,7 +42,7 @@ func (s *scope) RecordEvent(m dogma.Message) {
 		m,
 		s.now,
 		envelope.Origin{
-			HandlerName: s.config.Identity().Name,
+			Handler:     s.config,
 			HandlerType: configkit.IntegrationHandlerType,
 		},
 	)

--- a/engine/controller/integration/scope_test.go
+++ b/engine/controller/integration/scope_test.go
@@ -19,6 +19,7 @@ var _ = Describe("type scope", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *IntegrationMessageHandler
+		config     configkit.RichIntegration
 		ctrl       *Controller
 		command    *envelope.Envelope
 	)
@@ -38,8 +39,10 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
+		config = configkit.FromIntegration(handler)
+
 		ctrl = &Controller{
-			Config:     configkit.FromIntegration(handler),
+			Config:     config,
 			MessageIDs: &messageIDs,
 		}
 
@@ -71,9 +74,8 @@ var _ = Describe("type scope", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buf.Facts()).To(ContainElement(
 				fact.EventRecordedByIntegration{
-					HandlerName: "<name>",
-					Handler:     handler,
-					Envelope:    command,
+					Handler:  config,
+					Envelope: command,
 					EventEnvelope: command.NewEvent(
 						"1",
 						MessageE1,
@@ -154,10 +156,9 @@ var _ = Describe("type scope", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buf.Facts()).To(ContainElement(
 				fact.MessageLoggedByIntegration{
-					HandlerName: "<name>",
-					Handler:     handler,
-					Envelope:    command,
-					LogFormat:   "<format>",
+					Handler:   config,
+					Envelope:  command,
+					LogFormat: "<format>",
 					LogArguments: []interface{}{
 						"<arg-1>",
 						"<arg-2>",

--- a/engine/controller/integration/scope_test.go
+++ b/engine/controller/integration/scope_test.go
@@ -81,7 +81,7 @@ var _ = Describe("type scope", func() {
 						MessageE1,
 						now,
 						envelope.Origin{
-							HandlerName: "<name>",
+							Handler:     config,
 							HandlerType: configkit.IntegrationHandlerType,
 						},
 					),

--- a/engine/controller/process/controller.go
+++ b/engine/controller/process/controller.go
@@ -70,9 +70,6 @@ func (c *Controller) Handle(
 ) ([]*envelope.Envelope, error) {
 	env.Role.MustBe(message.EventRole, message.TimeoutRole)
 
-	ident := c.Config.Identity()
-	handler := c.Config.Handler()
-
 	var t time.Duration
 	controller.ConvertUnexpectedMessagePanic(
 		c.Config,
@@ -80,7 +77,7 @@ func (c *Controller) Handle(
 		"TimeoutHint",
 		env.Message,
 		func() {
-			t = handler.TimeoutHint(env.Message)
+			t = c.Config.Handler().TimeoutHint(env.Message)
 		},
 	)
 
@@ -99,26 +96,24 @@ func (c *Controller) Handle(
 
 	if exists {
 		obs.Notify(fact.ProcessInstanceLoaded{
-			HandlerName: ident.Name,
-			Handler:     handler,
-			InstanceID:  id,
-			Root:        r,
-			Envelope:    env,
+			Handler:    c.Config,
+			InstanceID: id,
+			Root:       r,
+			Envelope:   env,
 		})
 	} else {
 		obs.Notify(fact.ProcessInstanceNotFound{
-			HandlerName: ident.Name,
-			Handler:     handler,
-			InstanceID:  id,
-			Envelope:    env,
+			Handler:    c.Config,
+			InstanceID: id,
+			Envelope:   env,
 		})
 
-		r = handler.New()
+		r = c.Config.Handler().New()
 
 		if r == nil {
 			panic(fmt.Sprintf(
 				"the '%s' process message handler returned a nil root from New()",
-				ident.Name,
+				c.Config.Identity().Name,
 			))
 		}
 	}
@@ -206,9 +201,8 @@ func (c *Controller) routeEvent(
 	}
 
 	obs.Notify(fact.ProcessEventIgnored{
-		HandlerName: ident.Name,
-		Handler:     handler,
-		Envelope:    env,
+		Handler:  c.Config,
+		Envelope: env,
 	})
 
 	return "", false, nil
@@ -225,10 +219,9 @@ func (c *Controller) routeTimeout(
 	}
 
 	obs.Notify(fact.ProcessTimeoutIgnored{
-		HandlerName: c.Config.Identity().Name,
-		Handler:     c.Config.Handler(),
-		InstanceID:  env.Origin.InstanceID,
-		Envelope:    env,
+		Handler:    c.Config,
+		InstanceID: env.Origin.InstanceID,
+		Envelope:   env,
 	})
 
 	return "", false, nil

--- a/engine/controller/process/controller.go
+++ b/engine/controller/process/controller.go
@@ -24,15 +24,10 @@ type Controller struct {
 	timeouts  []*envelope.Envelope
 }
 
-// Identity returns the identity of the handler that is managed by this
+// HandlerConfig returns the config of the handler that is managed by this
 // controller.
-func (c *Controller) Identity() configkit.Identity {
-	return c.Config.Identity()
-}
-
-// Type returns configkit.ProcessHandlerType.
-func (c *Controller) Type() configkit.HandlerType {
-	return configkit.ProcessHandlerType
+func (c *Controller) HandlerConfig() configkit.RichHandler {
+	return c.Config
 }
 
 // Tick returns the timeout messages that are ready to be handled.

--- a/engine/controller/process/controller_test.go
+++ b/engine/controller/process/controller_test.go
@@ -472,9 +472,8 @@ var _ = Describe("type Controller", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(buf.Facts()).To(ContainElement(
 						fact.ProcessEventIgnored{
-							HandlerName: "<name>",
-							Handler:     handler,
-							Envelope:    event,
+							Handler:  config,
+							Envelope: event,
 						},
 					))
 				})
@@ -720,10 +719,9 @@ var _ = Describe("type Controller", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(buf.Facts()).To(ContainElement(
 						fact.ProcessTimeoutIgnored{
-							HandlerName: "<name>",
-							Handler:     handler,
-							InstanceID:  "<instance-E1>",
-							Envelope:    timeout,
+							Handler:    config,
+							InstanceID: "<instance-E1>",
+							Envelope:   timeout,
 						},
 					))
 				})
@@ -783,10 +781,9 @@ var _ = Describe("type Controller", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.ProcessInstanceNotFound{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance-E1>",
-						Envelope:    event,
+						Handler:    config,
+						InstanceID: "<instance-E1>",
+						Envelope:   event,
 					},
 				))
 			})
@@ -842,11 +839,10 @@ var _ = Describe("type Controller", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.ProcessInstanceLoaded{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance-E1>",
-						Root:        &ProcessRoot{},
-						Envelope:    event,
+						Handler:    config,
+						InstanceID: "<instance-E1>",
+						Root:       &ProcessRoot{},
+						Envelope:   event,
 					},
 				))
 			})

--- a/engine/controller/process/controller_test.go
+++ b/engine/controller/process/controller_test.go
@@ -85,17 +85,9 @@ var _ = Describe("type Controller", func() {
 		messageIDs.Reset() // reset after setup for a predictable ID.
 	})
 
-	Describe("func Identity()", func() {
-		It("returns the handler identity", func() {
-			Expect(ctrl.Identity()).To(Equal(
-				configkit.MustNewIdentity("<name>", "<key>"),
-			))
-		})
-	})
-
-	Describe("func Type()", func() {
-		It("returns configkit.ProcessHandlerType", func() {
-			Expect(ctrl.Type()).To(Equal(configkit.ProcessHandlerType))
+	Describe("func HandlerConfig()", func() {
+		It("returns the handler config", func() {
+			Expect(ctrl.HandlerConfig()).To(BeIdenticalTo(config))
 		})
 	})
 

--- a/engine/controller/process/controller_test.go
+++ b/engine/controller/process/controller_test.go
@@ -43,7 +43,7 @@ var _ = Describe("type Controller", func() {
 			time.Now(),
 			time.Now(),
 			envelope.Origin{
-				HandlerName: "<name>",
+				Handler:     config,
 				HandlerType: configkit.ProcessHandlerType,
 				InstanceID:  "<instance-E1>",
 			},
@@ -155,7 +155,7 @@ var _ = Describe("type Controller", func() {
 					createdTime,
 					t1Time,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.ProcessHandlerType,
 						InstanceID:  "<instance-E1>",
 					},
@@ -166,7 +166,7 @@ var _ = Describe("type Controller", func() {
 					createdTime,
 					t2Time,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.ProcessHandlerType,
 						InstanceID:  "<instance-E1>",
 					},
@@ -242,7 +242,7 @@ var _ = Describe("type Controller", func() {
 					createdTime,
 					t1Time,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.ProcessHandlerType,
 						InstanceID:  "<instance-E2>", // E2, not E1!
 					},
@@ -253,7 +253,7 @@ var _ = Describe("type Controller", func() {
 					createdTime,
 					t2Time,
 					envelope.Origin{
-						HandlerName: "<name>",
+						Handler:     config,
 						HandlerType: configkit.ProcessHandlerType,
 						InstanceID:  "<instance-E2>", // E2, not E1!
 					},
@@ -336,7 +336,7 @@ var _ = Describe("type Controller", func() {
 						MessageC1,
 						now,
 						envelope.Origin{
-							HandlerName: "<name>",
+							Handler:     config,
 							HandlerType: configkit.ProcessHandlerType,
 							InstanceID:  "<instance-E1>",
 						},
@@ -347,7 +347,7 @@ var _ = Describe("type Controller", func() {
 						now,
 						now,
 						envelope.Origin{
-							HandlerName: "<name>",
+							Handler:     config,
 							HandlerType: configkit.ProcessHandlerType,
 							InstanceID:  "<instance-E1>",
 						},
@@ -573,7 +573,7 @@ var _ = Describe("type Controller", func() {
 						MessageC1,
 						now,
 						envelope.Origin{
-							HandlerName: "<name>",
+							Handler:     config,
 							HandlerType: configkit.ProcessHandlerType,
 							InstanceID:  "<instance-E1>",
 						},
@@ -584,7 +584,7 @@ var _ = Describe("type Controller", func() {
 						now,
 						now,
 						envelope.Origin{
-							HandlerName: "<name>",
+							Handler:     config,
 							HandlerType: configkit.ProcessHandlerType,
 							InstanceID:  "<instance-E1>",
 						},

--- a/engine/controller/process/scope.go
+++ b/engine/controller/process/scope.go
@@ -43,11 +43,10 @@ func (s *scope) Begin() bool {
 	s.exists = true
 
 	s.observer.Notify(fact.ProcessInstanceBegun{
-		HandlerName: s.config.Identity().Name,
-		Handler:     s.config.Handler(),
-		InstanceID:  s.instanceID,
-		Root:        s.root,
-		Envelope:    s.env,
+		Handler:    s.config,
+		InstanceID: s.instanceID,
+		Root:       s.root,
+		Envelope:   s.env,
 	})
 
 	return true
@@ -63,11 +62,10 @@ func (s *scope) End() {
 	s.pending = nil
 
 	s.observer.Notify(fact.ProcessInstanceEnded{
-		HandlerName: s.config.Identity().Name,
-		Handler:     s.config.Handler(),
-		InstanceID:  s.instanceID,
-		Root:        s.root,
-		Envelope:    s.env,
+		Handler:    s.config,
+		InstanceID: s.instanceID,
+		Root:       s.root,
+		Envelope:   s.env,
 	})
 }
 
@@ -114,8 +112,7 @@ func (s *scope) ExecuteCommand(m dogma.Message) {
 	s.commands = append(s.commands, env)
 
 	s.observer.Notify(fact.CommandExecutedByProcess{
-		HandlerName:     s.config.Identity().Name,
-		Handler:         s.config.Handler(),
+		Handler:         s.config,
 		InstanceID:      s.instanceID,
 		Root:            s.root,
 		Envelope:        s.env,
@@ -167,8 +164,7 @@ func (s *scope) ScheduleTimeout(m dogma.Message, t time.Time) {
 	}
 
 	s.observer.Notify(fact.TimeoutScheduledByProcess{
-		HandlerName:     s.config.Identity().Name,
-		Handler:         s.config.Handler(),
+		Handler:         s.config,
 		InstanceID:      s.instanceID,
 		Root:            s.root,
 		Envelope:        s.env,
@@ -182,8 +178,7 @@ func (s *scope) ScheduledFor() time.Time {
 
 func (s *scope) Log(f string, v ...interface{}) {
 	s.observer.Notify(fact.MessageLoggedByProcess{
-		HandlerName:  s.config.Identity().Name,
-		Handler:      s.config.Handler(),
+		Handler:      s.config,
 		InstanceID:   s.instanceID,
 		Root:         s.root,
 		Envelope:     s.env,

--- a/engine/controller/process/scope.go
+++ b/engine/controller/process/scope.go
@@ -103,7 +103,7 @@ func (s *scope) ExecuteCommand(m dogma.Message) {
 		m,
 		s.now,
 		envelope.Origin{
-			HandlerName: s.config.Identity().Name,
+			Handler:     s.config,
 			HandlerType: configkit.ProcessHandlerType,
 			InstanceID:  s.instanceID,
 		},
@@ -151,7 +151,7 @@ func (s *scope) ScheduleTimeout(m dogma.Message, t time.Time) {
 		s.now,
 		t,
 		envelope.Origin{
-			HandlerName: s.config.Identity().Name,
+			Handler:     s.config,
 			HandlerType: configkit.ProcessHandlerType,
 			InstanceID:  s.instanceID,
 		},

--- a/engine/controller/process/scope_test.go
+++ b/engine/controller/process/scope_test.go
@@ -411,7 +411,7 @@ var _ = Describe("type scope", func() {
 							MessageC1,
 							now,
 							envelope.Origin{
-								HandlerName: "<name>",
+								Handler:     config,
 								HandlerType: configkit.ProcessHandlerType,
 								InstanceID:  "<instance>",
 							},
@@ -505,7 +505,7 @@ var _ = Describe("type scope", func() {
 							now,
 							t,
 							envelope.Origin{
-								HandlerName: "<name>",
+								Handler:     config,
 								HandlerType: configkit.ProcessHandlerType,
 								InstanceID:  "<instance>",
 							},

--- a/engine/controller/process/scope_test.go
+++ b/engine/controller/process/scope_test.go
@@ -19,6 +19,7 @@ var _ = Describe("type scope", func() {
 	var (
 		messageIDs envelope.MessageIDGenerator
 		handler    *ProcessMessageHandler
+		config     configkit.RichProcess
 		ctrl       *Controller
 		event      *envelope.Envelope
 	)
@@ -50,8 +51,10 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
+		config = configkit.FromProcess(handler)
+
 		ctrl = &Controller{
-			Config:     configkit.FromProcess(handler),
+			Config:     config,
 			MessageIDs: &messageIDs,
 		}
 
@@ -145,11 +148,10 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.ProcessInstanceBegun{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
-						Root:        &ProcessRoot{},
-						Envelope:    event,
+						Handler:    config,
+						InstanceID: "<instance>",
+						Root:       &ProcessRoot{},
+						Envelope:   event,
 					},
 				))
 			})
@@ -361,11 +363,10 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.ProcessInstanceEnded{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
-						Root:        &ProcessRoot{},
-						Envelope:    event,
+						Handler:    config,
+						InstanceID: "<instance>",
+						Root:       &ProcessRoot{},
+						Envelope:   event,
 					},
 				))
 			})
@@ -401,11 +402,10 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.CommandExecutedByProcess{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
-						Root:        &ProcessRoot{},
-						Envelope:    event,
+						Handler:    config,
+						InstanceID: "<instance>",
+						Root:       &ProcessRoot{},
+						Envelope:   event,
 						CommandEnvelope: event.NewCommand(
 							"1",
 							MessageC1,
@@ -495,11 +495,10 @@ var _ = Describe("type scope", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
 					fact.TimeoutScheduledByProcess{
-						HandlerName: "<name>",
-						Handler:     handler,
-						InstanceID:  "<instance>",
-						Root:        &ProcessRoot{},
-						Envelope:    event,
+						Handler:    config,
+						InstanceID: "<instance>",
+						Root:       &ProcessRoot{},
+						Envelope:   event,
 						TimeoutEnvelope: event.NewTimeout(
 							"1",
 							MessageT1,
@@ -611,12 +610,11 @@ var _ = Describe("type scope", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buf.Facts()).To(ContainElement(
 				fact.MessageLoggedByProcess{
-					HandlerName: "<name>",
-					Handler:     handler,
-					InstanceID:  "<instance>",
-					Root:        &ProcessRoot{},
-					Envelope:    event,
-					LogFormat:   "<format>",
+					Handler:    config,
+					InstanceID: "<instance>",
+					Root:       &ProcessRoot{},
+					Envelope:   event,
+					LogFormat:  "<format>",
 					LogArguments: []interface{}{
 						"<arg-1>",
 						"<arg-2>",

--- a/engine/controller/projection/controller.go
+++ b/engine/controller/projection/controller.go
@@ -47,7 +47,7 @@ func (c *Controller) Tick(
 		c.lastCompact = now
 
 		obs.Notify(fact.ProjectionCompactionBegun{
-			HandlerName: c.Config.Identity().Name,
+			Handler: c.Config,
 		})
 
 		err := c.Config.Handler().Compact(
@@ -59,8 +59,8 @@ func (c *Controller) Tick(
 		)
 
 		obs.Notify(fact.ProjectionCompactionCompleted{
-			HandlerName: c.Config.Identity().Name,
-			Error:       err,
+			Handler: c.Config,
+			Error:   err,
 		})
 
 		return nil, err
@@ -130,7 +130,7 @@ func (c *Controller) Handle(
 		// Ensure that notification of facts occurs in the main goroutine as
 		// observers aren't required to be thread-safe.
 		obs.Notify(fact.ProjectionCompactionBegun{
-			HandlerName: c.Config.Identity().Name,
+			Handler: c.Config,
 		})
 
 		// Start a goroutine so that compaction happens in parallel with
@@ -171,8 +171,8 @@ func (c *Controller) Handle(
 
 	if c.CompactDuringHandling {
 		obs.Notify(fact.ProjectionCompactionCompleted{
-			HandlerName: c.Config.Identity().Name,
-			Error:       compactErr,
+			Handler: c.Config,
+			Error:   compactErr,
 		})
 	}
 

--- a/engine/controller/projection/controller.go
+++ b/engine/controller/projection/controller.go
@@ -26,15 +26,10 @@ type Controller struct {
 	lastCompact time.Time
 }
 
-// Identity returns the identity of the handler that is managed by this
+// HandlerConfig returns the config of the handler that is managed by this
 // controller.
-func (c *Controller) Identity() configkit.Identity {
-	return c.Config.Identity()
-}
-
-// Type returns configkit.ProjectionHandlerType.
-func (c *Controller) Type() configkit.HandlerType {
-	return configkit.ProjectionHandlerType
+func (c *Controller) HandlerConfig() configkit.RichHandler {
+	return c.Config
 }
 
 // Tick always performs projection compaction.

--- a/engine/controller/projection/controller_test.go
+++ b/engine/controller/projection/controller_test.go
@@ -91,11 +91,11 @@ var _ = Describe("type Controller", func() {
 			Expect(buf.Facts()).To(Equal(
 				[]fact.Fact{
 					fact.ProjectionCompactionBegun{
-						HandlerName: "<name>",
+						Handler: config,
 					},
 					fact.ProjectionCompactionCompleted{
-						HandlerName: "<name>",
-						Error:       expect,
+						Handler: config,
+						Error:   expect,
 					},
 				},
 			))
@@ -439,11 +439,11 @@ var _ = Describe("type Controller", func() {
 				Expect(buf.Facts()).To(Equal(
 					[]fact.Fact{
 						fact.ProjectionCompactionBegun{
-							HandlerName: "<name>",
+							Handler: config,
 						},
 						fact.ProjectionCompactionCompleted{
-							HandlerName: "<name>",
-							Error:       expect,
+							Handler: config,
+							Error:   expect,
 						},
 					},
 				))

--- a/engine/controller/projection/controller_test.go
+++ b/engine/controller/projection/controller_test.go
@@ -46,17 +46,9 @@ var _ = Describe("type Controller", func() {
 		}
 	})
 
-	Describe("func Identity()", func() {
-		It("returns the handler identity", func() {
-			Expect(ctrl.Identity()).To(Equal(
-				configkit.MustNewIdentity("<name>", "<key>"),
-			))
-		})
-	})
-
-	Describe("func Type()", func() {
-		It("returns configkit.ProjectionHandlerType", func() {
-			Expect(ctrl.Type()).To(Equal(configkit.ProjectionHandlerType))
+	Describe("func HandlerConfig()", func() {
+		It("returns the handler config", func() {
+			Expect(ctrl.HandlerConfig()).To(BeIdenticalTo(config))
 		})
 	})
 

--- a/engine/controller/projection/scope.go
+++ b/engine/controller/projection/scope.go
@@ -22,8 +22,7 @@ func (s *scope) RecordedAt() time.Time {
 
 func (s *scope) Log(f string, v ...interface{}) {
 	s.observer.Notify(fact.MessageLoggedByProjection{
-		HandlerName:  s.config.Identity().Name,
-		Handler:      s.config.Handler(),
+		Handler:      s.config,
 		Envelope:     s.event, // nil if compacting
 		LogFormat:    f,
 		LogArguments: v,

--- a/engine/controller/projection/scope_test.go
+++ b/engine/controller/projection/scope_test.go
@@ -17,6 +17,7 @@ import (
 var _ = Describe("type scope", func() {
 	var (
 		handler *ProjectionMessageHandler
+		config  configkit.RichProjection
 		ctrl    *Controller
 		event   = envelope.NewEvent(
 			"1000",
@@ -33,8 +34,10 @@ var _ = Describe("type scope", func() {
 			},
 		}
 
+		config = configkit.FromProjection(handler)
+
 		ctrl = &Controller{
-			Config: configkit.FromProjection(handler),
+			Config: config,
 		}
 	})
 
@@ -87,10 +90,9 @@ var _ = Describe("type scope", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(buf.Facts()).To(ContainElement(
 				fact.MessageLoggedByProjection{
-					HandlerName: "<name>",
-					Handler:     handler,
-					Envelope:    event,
-					LogFormat:   "<format>",
+					Handler:   config,
+					Envelope:  event,
+					LogFormat: "<format>",
 					LogArguments: []interface{}{
 						"<arg-1>",
 						"<arg-2>",

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -123,13 +123,13 @@ func (e *Engine) tick(
 		queue []*envelope.Envelope
 	)
 
-	for n, c := range e.controllers {
+	for _, c := range e.controllers {
 		t := c.Type()
 
 		oo.observers.Notify(
 			fact.TickBegun{
-				HandlerName: n,
-				HandlerType: t,
+				HandlerIdentity: c.Identity(),
+				HandlerType:     t,
 			},
 		)
 
@@ -139,9 +139,9 @@ func (e *Engine) tick(
 
 		oo.observers.Notify(
 			fact.TickCompleted{
-				HandlerName: n,
-				HandlerType: t,
-				Error:       cerr,
+				HandlerIdentity: c.Identity(),
+				HandlerType:     t,
+				Error:           cerr,
 			},
 		)
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -124,12 +124,9 @@ func (e *Engine) tick(
 	)
 
 	for _, c := range e.controllers {
-		t := c.HandlerConfig().HandlerType()
-
 		oo.observers.Notify(
 			fact.TickBegun{
-				HandlerIdentity: c.HandlerConfig().Identity(),
-				HandlerType:     t,
+				Handler: c.HandlerConfig(),
 			},
 		)
 
@@ -139,9 +136,8 @@ func (e *Engine) tick(
 
 		oo.observers.Notify(
 			fact.TickCompleted{
-				HandlerIdentity: c.HandlerConfig().Identity(),
-				HandlerType:     t,
-				Error:           cerr,
+				Handler: c.HandlerConfig(),
+				Error:   cerr,
 			},
 		)
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -124,11 +124,11 @@ func (e *Engine) tick(
 	)
 
 	for _, c := range e.controllers {
-		t := c.Type()
+		t := c.HandlerConfig().HandlerType()
 
 		oo.observers.Notify(
 			fact.TickBegun{
-				HandlerIdentity: c.Identity(),
+				HandlerIdentity: c.HandlerConfig().Identity(),
 				HandlerType:     t,
 			},
 		)
@@ -139,7 +139,7 @@ func (e *Engine) tick(
 
 		oo.observers.Notify(
 			fact.TickCompleted{
-				HandlerIdentity: c.Identity(),
+				HandlerIdentity: c.HandlerConfig().Identity(),
 				HandlerType:     t,
 				Error:           cerr,
 			},
@@ -284,12 +284,11 @@ func (e *Engine) handle(
 	env *envelope.Envelope,
 	c controller.Controller,
 ) ([]*envelope.Envelope, error) {
-	if !oo.enabledHandlers[c.Type()] {
+	if !oo.enabledHandlers[c.HandlerConfig().HandlerType()] {
 		oo.observers.Notify(
 			fact.HandlingSkipped{
-				HandlerIdentity: c.Identity(),
-				HandlerType:     c.Type(),
-				Envelope:        env,
+				Handler:  c.HandlerConfig(),
+				Envelope: env,
 			},
 		)
 
@@ -298,9 +297,8 @@ func (e *Engine) handle(
 
 	oo.observers.Notify(
 		fact.HandlingBegun{
-			HandlerIdentity: c.Identity(),
-			HandlerType:     c.Type(),
-			Envelope:        env,
+			Handler:  c.HandlerConfig(),
+			Envelope: env,
 		},
 	)
 
@@ -308,10 +306,9 @@ func (e *Engine) handle(
 
 	oo.observers.Notify(
 		fact.HandlingCompleted{
-			HandlerIdentity: c.Identity(),
-			HandlerType:     c.Type(),
-			Envelope:        env,
-			Error:           err,
+			Handler:  c.HandlerConfig(),
+			Envelope: env,
+			Error:    err,
 		},
 	)
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -237,7 +237,7 @@ func (e *Engine) dispatch(
 		if env.Role == message.TimeoutRole {
 			// always dispatch timeouts back to their origin handler
 			controllers = []controller.Controller{
-				e.controllers[env.Origin.HandlerName],
+				e.controllers[env.Origin.Handler.Identity().Name],
 			}
 		} else {
 			// for all other message types check to see the role matches the

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -284,15 +284,12 @@ func (e *Engine) handle(
 	env *envelope.Envelope,
 	c controller.Controller,
 ) ([]*envelope.Envelope, error) {
-	i := c.Identity()
-	t := c.Type()
-
-	if !oo.enabledHandlers[t] {
+	if !oo.enabledHandlers[c.Type()] {
 		oo.observers.Notify(
 			fact.HandlingSkipped{
-				HandlerName: i.Name,
-				HandlerType: c.Type(),
-				Envelope:    env,
+				HandlerIdentity: c.Identity(),
+				HandlerType:     c.Type(),
+				Envelope:        env,
 			},
 		)
 
@@ -301,9 +298,9 @@ func (e *Engine) handle(
 
 	oo.observers.Notify(
 		fact.HandlingBegun{
-			HandlerName: i.Name,
-			HandlerType: t,
-			Envelope:    env,
+			HandlerIdentity: c.Identity(),
+			HandlerType:     c.Type(),
+			Envelope:        env,
 		},
 	)
 
@@ -311,10 +308,10 @@ func (e *Engine) handle(
 
 	oo.observers.Notify(
 		fact.HandlingCompleted{
-			HandlerName: i.Name,
-			HandlerType: t,
-			Envelope:    env,
-			Error:       err,
+			HandlerIdentity: c.Identity(),
+			HandlerType:     c.Type(),
+			Envelope:        env,
+			Error:           err,
 		},
 	)
 

--- a/engine/envelope/envelope_test.go
+++ b/engine/envelope/envelope_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dogmatiq/configkit"
 	. "github.com/dogmatiq/configkit/fixtures"
 	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/engine/envelope"
 	. "github.com/onsi/ginkgo"
@@ -60,6 +61,14 @@ var _ = Describe("type Envelope", func() {
 	})
 
 	Describe("func NewCommand()", func() {
+		handler := configkit.FromProcess(&ProcessMessageHandler{
+			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+				c.Identity("<handler>", "<handler-key>")
+				c.ConsumesEventType(MessageE{})
+				c.ProducesCommandType(MessageC{})
+			},
+		})
+
 		It("returns the expected envelope", func() {
 			parent := NewEvent(
 				"100",
@@ -67,7 +76,7 @@ var _ = Describe("type Envelope", func() {
 				time.Now(),
 			)
 			origin := Origin{
-				HandlerName: "<handler>",
+				Handler:     handler,
 				HandlerType: configkit.ProcessHandlerType,
 				InstanceID:  "<instance>",
 			}
@@ -95,6 +104,14 @@ var _ = Describe("type Envelope", func() {
 	})
 
 	Describe("func NewEvent()", func() {
+		handler := configkit.FromAggregate(&AggregateMessageHandler{
+			ConfigureFunc: func(c dogma.AggregateConfigurer) {
+				c.Identity("<handler>", "<handler-key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageE{})
+			},
+		})
+
 		It("returns the expected envelope", func() {
 			parent := NewCommand(
 				"100",
@@ -102,7 +119,7 @@ var _ = Describe("type Envelope", func() {
 				time.Now(),
 			)
 			origin := Origin{
-				HandlerName: "<handler>",
+				Handler:     handler,
 				HandlerType: configkit.AggregateHandlerType,
 				InstanceID:  "<instance>",
 			}
@@ -130,6 +147,15 @@ var _ = Describe("type Envelope", func() {
 	})
 
 	Describe("func NewTimeout()", func() {
+		handler := configkit.FromProcess(&ProcessMessageHandler{
+			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+				c.Identity("<handler>", "<handler-key>")
+				c.ConsumesEventType(MessageE{})
+				c.ProducesCommandType(MessageC{})
+				c.SchedulesTimeoutType(MessageT{})
+			},
+		})
+
 		It("returns the expected envelope", func() {
 			parent := NewCommand(
 				"100",
@@ -137,7 +163,7 @@ var _ = Describe("type Envelope", func() {
 				time.Now(),
 			)
 			origin := Origin{
-				HandlerName: "<handler>",
+				Handler:     handler,
 				HandlerType: configkit.ProcessHandlerType,
 				InstanceID:  "<instance>",
 			}

--- a/engine/envelope/origin.go
+++ b/engine/envelope/origin.go
@@ -4,8 +4,8 @@ import "github.com/dogmatiq/configkit"
 
 // Origin describes the handler that produced a message in an envelope.
 type Origin struct {
-	// HandlerName is the name of the handler that produced this message.
-	HandlerName string
+	// Handler is the handler that produced this message.
+	Handler configkit.RichHandler
 
 	// HandlerType is the type of the handler that produced this message.
 	HandlerType configkit.HandlerType

--- a/engine/fact/aggregate.go
+++ b/engine/fact/aggregate.go
@@ -1,6 +1,7 @@
 package fact
 
 import (
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/envelope"
 )
@@ -8,47 +9,42 @@ import (
 // AggregateInstanceLoaded indicates that an aggregate message handler has
 // loaded an existing instance in order to handle a command.
 type AggregateInstanceLoaded struct {
-	HandlerName string
-	Handler     dogma.AggregateMessageHandler
-	InstanceID  string
-	Root        dogma.AggregateRoot
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichAggregate
+	InstanceID string
+	Root       dogma.AggregateRoot
+	Envelope   *envelope.Envelope
 }
 
 // AggregateInstanceNotFound indicates that an aggregate message handler was
 // unable to load an existing instance while handling a command.
 type AggregateInstanceNotFound struct {
-	HandlerName string
-	Handler     dogma.AggregateMessageHandler
-	InstanceID  string
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichAggregate
+	InstanceID string
+	Envelope   *envelope.Envelope
 }
 
 // AggregateInstanceCreated indicates that an aggregate message handler created
 // an aggregate instance while handling a command.
 type AggregateInstanceCreated struct {
-	HandlerName string
-	Handler     dogma.AggregateMessageHandler
-	InstanceID  string
-	Root        dogma.AggregateRoot
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichAggregate
+	InstanceID string
+	Root       dogma.AggregateRoot
+	Envelope   *envelope.Envelope
 }
 
 // AggregateInstanceDestroyed indicates that an aggregate message handler
 // destroyed an aggregate instance while handling a command.
 type AggregateInstanceDestroyed struct {
-	HandlerName string
-	Handler     dogma.AggregateMessageHandler
-	InstanceID  string
-	Root        dogma.AggregateRoot
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichAggregate
+	InstanceID string
+	Root       dogma.AggregateRoot
+	Envelope   *envelope.Envelope
 }
 
 // EventRecordedByAggregate indicates that an aggregate recorded an event while
 // handling a command.
 type EventRecordedByAggregate struct {
-	HandlerName   string
-	Handler       dogma.AggregateMessageHandler
+	Handler       configkit.RichAggregate
 	InstanceID    string
 	Root          dogma.AggregateRoot
 	Envelope      *envelope.Envelope
@@ -58,8 +54,7 @@ type EventRecordedByAggregate struct {
 // MessageLoggedByAggregate indicates that an aggregate wrote a log message
 // while handling a command.
 type MessageLoggedByAggregate struct {
-	HandlerName  string
-	Handler      dogma.AggregateMessageHandler
+	Handler      configkit.RichAggregate
 	InstanceID   string
 	Root         dogma.AggregateRoot
 	Envelope     *envelope.Envelope

--- a/engine/fact/dispatch.go
+++ b/engine/fact/dispatch.go
@@ -37,24 +37,24 @@ type DispatchCompleted struct {
 // HandlingBegun indicates that a message is about to be handled by a specific
 // handler.
 type HandlingBegun struct {
-	HandlerName string
-	HandlerType configkit.HandlerType
-	Envelope    *envelope.Envelope
+	HandlerIdentity configkit.Identity
+	HandlerType     configkit.HandlerType
+	Envelope        *envelope.Envelope
 }
 
 // HandlingCompleted indicates that a message has been handled by a specific
 // handler, either successfully or unsuccessfully.
 type HandlingCompleted struct {
-	HandlerName string
-	HandlerType configkit.HandlerType
-	Envelope    *envelope.Envelope
-	Error       error
+	HandlerIdentity configkit.Identity
+	HandlerType     configkit.HandlerType
+	Envelope        *envelope.Envelope
+	Error           error
 }
 
 // HandlingSkipped indicates that a message has been not been handled by a
 // specific handler, because handlers of that type are disabled.
 type HandlingSkipped struct {
-	HandlerName string
-	HandlerType configkit.HandlerType
-	Envelope    *envelope.Envelope
+	HandlerIdentity configkit.Identity
+	HandlerType     configkit.HandlerType
+	Envelope        *envelope.Envelope
 }

--- a/engine/fact/dispatch.go
+++ b/engine/fact/dispatch.go
@@ -37,24 +37,21 @@ type DispatchCompleted struct {
 // HandlingBegun indicates that a message is about to be handled by a specific
 // handler.
 type HandlingBegun struct {
-	HandlerIdentity configkit.Identity
-	HandlerType     configkit.HandlerType
-	Envelope        *envelope.Envelope
+	Handler  configkit.RichHandler
+	Envelope *envelope.Envelope
 }
 
 // HandlingCompleted indicates that a message has been handled by a specific
 // handler, either successfully or unsuccessfully.
 type HandlingCompleted struct {
-	HandlerIdentity configkit.Identity
-	HandlerType     configkit.HandlerType
-	Envelope        *envelope.Envelope
-	Error           error
+	Handler  configkit.RichHandler
+	Envelope *envelope.Envelope
+	Error    error
 }
 
 // HandlingSkipped indicates that a message has been not been handled by a
 // specific handler, because handlers of that type are disabled.
 type HandlingSkipped struct {
-	HandlerIdentity configkit.Identity
-	HandlerType     configkit.HandlerType
-	Envelope        *envelope.Envelope
+	Handler  configkit.RichHandler
+	Envelope *envelope.Envelope
 }

--- a/engine/fact/integration.go
+++ b/engine/fact/integration.go
@@ -1,15 +1,14 @@
 package fact
 
 import (
-	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/testkit/engine/envelope"
 )
 
 // EventRecordedByIntegration indicates that an integration recorded an event
 // while handling a command.
 type EventRecordedByIntegration struct {
-	HandlerName   string
-	Handler       dogma.IntegrationMessageHandler
+	Handler       configkit.RichIntegration
 	Envelope      *envelope.Envelope
 	EventEnvelope *envelope.Envelope
 }
@@ -17,8 +16,7 @@ type EventRecordedByIntegration struct {
 // MessageLoggedByIntegration indicates that an integration wrote a log message
 // while handling a command.
 type MessageLoggedByIntegration struct {
-	HandlerName  string
-	Handler      dogma.IntegrationMessageHandler
+	Handler      configkit.RichIntegration
 	Envelope     *envelope.Envelope
 	LogFormat    string
 	LogArguments []interface{}

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -116,10 +116,10 @@ func (l *Logger) handlingCompleted(f HandlingCompleted) {
 			f.Envelope,
 			[]logging.Icon{
 				logging.InboundErrorIcon,
-				logging.HandlerTypeIcon(f.HandlerType),
+				logging.HandlerTypeIcon(f.Handler.HandlerType()),
 				logging.ErrorIcon,
 			},
-			f.HandlerIdentity.Name,
+			f.Handler.Identity().Name,
 			f.Error.Error(),
 		)
 	}
@@ -131,13 +131,13 @@ func (l *Logger) handlingSkipped(f HandlingSkipped) {
 		f.Envelope,
 		[]logging.Icon{
 			logging.InboundIcon,
-			logging.HandlerTypeIcon(f.HandlerType),
+			logging.HandlerTypeIcon(f.Handler.HandlerType()),
 			"",
 		},
-		f.HandlerIdentity.Name,
+		f.Handler.Identity().Name,
 		fmt.Sprintf(
 			"handler skipped because %s handlers are disabled",
-			f.HandlerType,
+			f.Handler.HandlerType(),
 		),
 	)
 }

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -401,7 +401,7 @@ func (l *Logger) eventRecordedByIntegration(f EventRecordedByIntegration) {
 			logging.IntegrationIcon,
 			"",
 		},
-		f.HandlerName,
+		f.Handler.Identity().Name,
 		"recorded an event",
 		f.EventEnvelope.Type.String()+f.EventEnvelope.Role.Marker(),
 		dogma.DescribeMessage(f.EventEnvelope.Message),
@@ -417,7 +417,7 @@ func (l *Logger) messageLoggedByIntegration(f MessageLoggedByIntegration) {
 			logging.IntegrationIcon,
 			"",
 		},
-		f.HandlerName,
+		f.Handler.Identity().Name,
 		fmt.Sprintf(f.LogFormat, f.LogArguments...),
 	)
 }

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -119,7 +119,7 @@ func (l *Logger) handlingCompleted(f HandlingCompleted) {
 				logging.HandlerTypeIcon(f.HandlerType),
 				logging.ErrorIcon,
 			},
-			f.HandlerName,
+			f.HandlerIdentity.Name,
 			f.Error.Error(),
 		)
 	}
@@ -134,7 +134,7 @@ func (l *Logger) handlingSkipped(f HandlingSkipped) {
 			logging.HandlerTypeIcon(f.HandlerType),
 			"",
 		},
-		f.HandlerName,
+		f.HandlerIdentity.Name,
 		fmt.Sprintf(
 			"handler skipped because %s handlers are disabled",
 			f.HandlerType,

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -432,7 +432,7 @@ func (l *Logger) projectionCompactionCompleted(f ProjectionCompactionCompleted) 
 				logging.ProjectionIcon,
 				"",
 			},
-			f.HandlerName,
+			f.Handler.Identity().Name,
 			"compacted",
 		)
 	} else {
@@ -443,7 +443,7 @@ func (l *Logger) projectionCompactionCompleted(f ProjectionCompactionCompleted) 
 				logging.ProjectionIcon,
 				logging.ErrorIcon,
 			},
-			f.HandlerName,
+			f.Handler.Identity().Name,
 			fmt.Sprintf("compaction failed: %s", f.Error),
 		)
 	}
@@ -464,7 +464,7 @@ func (l *Logger) messageLoggedByProjection(f MessageLoggedByProjection) {
 	l.log(
 		f.Envelope,
 		icons,
-		f.HandlerName,
+		f.Handler.Identity().Name,
 		fmt.Sprintf(f.LogFormat, f.LogArguments...),
 	)
 }

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -268,7 +268,7 @@ func (l *Logger) processInstanceLoaded(f ProcessInstanceLoaded) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"loaded an existing instance",
 	)
 }
@@ -282,7 +282,7 @@ func (l *Logger) processEventIgnored(f ProcessEventIgnored) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName,
+		f.Handler.Identity().Name,
 		"event ignored because it was not routed to any instance",
 	)
 }
@@ -296,7 +296,7 @@ func (l *Logger) processTimeoutIgnored(f ProcessTimeoutIgnored) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"timeout ignored because the target instance no longer exists",
 	)
 }
@@ -310,7 +310,7 @@ func (l *Logger) processInstanceNotFound(f ProcessInstanceNotFound) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"instance does not yet exist",
 	)
 }
@@ -324,7 +324,7 @@ func (l *Logger) processInstanceBegun(f ProcessInstanceBegun) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"instance begun",
 	)
 }
@@ -338,7 +338,7 @@ func (l *Logger) processInstanceEnded(f ProcessInstanceEnded) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"instance ended",
 	)
 }
@@ -352,7 +352,7 @@ func (l *Logger) commandExecutedByProcess(f CommandExecutedByProcess) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"executed a command",
 		f.CommandEnvelope.Type.String()+f.CommandEnvelope.Role.Marker(),
 		dogma.DescribeMessage(f.CommandEnvelope.Message),
@@ -368,7 +368,7 @@ func (l *Logger) timeoutScheduledByProcess(f TimeoutScheduledByProcess) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		fmt.Sprintf(
 			"scheduled a timeout for %s",
 			f.TimeoutEnvelope.ScheduledFor.Format(time.RFC3339),
@@ -387,7 +387,7 @@ func (l *Logger) messageLoggedByProcess(f MessageLoggedByProcess) {
 			logging.ProcessIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		fmt.Sprintf(f.LogFormat, f.LogArguments...),
 	)
 }

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -167,7 +167,7 @@ func (l *Logger) tickCompleted(f TickCompleted) {
 				logging.HandlerTypeIcon(f.HandlerType),
 				logging.ErrorIcon,
 			},
-			f.HandlerName,
+			f.HandlerIdentity.Name,
 			f.Error.Error(),
 		)
 	}

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -164,10 +164,10 @@ func (l *Logger) tickCompleted(f TickCompleted) {
 			&envelope.Envelope{},
 			[]logging.Icon{
 				"",
-				logging.HandlerTypeIcon(f.HandlerType),
+				logging.HandlerTypeIcon(f.Handler.HandlerType()),
 				logging.ErrorIcon,
 			},
-			f.HandlerIdentity.Name,
+			f.Handler.Identity().Name,
 			f.Error.Error(),
 		)
 	}

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -182,7 +182,7 @@ func (l *Logger) aggregateInstanceLoaded(f AggregateInstanceLoaded) {
 			logging.AggregateIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"loaded an existing instance",
 	)
 }
@@ -196,7 +196,7 @@ func (l *Logger) aggregateInstanceNotFound(f AggregateInstanceNotFound) {
 			logging.AggregateIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"instance does not yet exist",
 	)
 }
@@ -210,7 +210,7 @@ func (l *Logger) aggregateInstanceCreated(f AggregateInstanceCreated) {
 			logging.AggregateIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"instance created",
 	)
 }
@@ -224,7 +224,7 @@ func (l *Logger) aggregateInstanceDestroyed(f AggregateInstanceDestroyed) {
 			logging.AggregateIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"instance destroyed",
 	)
 }
@@ -238,7 +238,7 @@ func (l *Logger) eventRecordedByAggregate(f EventRecordedByAggregate) {
 			logging.AggregateIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		"recorded an event",
 		f.EventEnvelope.Type.String()+f.EventEnvelope.Role.Marker(),
 		dogma.DescribeMessage(f.EventEnvelope.Message),
@@ -254,7 +254,7 @@ func (l *Logger) messageLoggedByAggregate(f MessageLoggedByAggregate) {
 			logging.AggregateIcon,
 			"",
 		},
-		f.HandlerName+" "+f.InstanceID,
+		f.Handler.Identity().Name+" "+f.InstanceID,
 		fmt.Sprintf(f.LogFormat, f.LogArguments...),
 	)
 }

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -134,19 +134,19 @@ var _ = Describe("type Logger", func() {
 				"HandlingCompleted (failure)",
 				"= 0100  ∵ 0100  ⋲ 0100  ▽ ∴ ✖  <handler> ● <error>",
 				HandlingCompleted{
-					HandlerName: "<handler>",
-					HandlerType: configkit.AggregateHandlerType,
-					Envelope:    command,
-					Error:       errors.New("<error>"),
+					HandlerIdentity: configkit.MustNewIdentity("<handler>", "<handler-key>"),
+					HandlerType:     configkit.AggregateHandlerType,
+					Envelope:        command,
+					Error:           errors.New("<error>"),
 				},
 			),
 			Entry(
 				"HandlingSkipped",
 				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <handler> ● handler skipped because aggregate handlers are disabled",
 				HandlingSkipped{
-					HandlerName: "<handler>",
-					HandlerType: configkit.AggregateHandlerType,
-					Envelope:    command,
+					HandlerIdentity: configkit.MustNewIdentity("<handler>", "<handler-key>"),
+					HandlerType:     configkit.AggregateHandlerType,
+					Envelope:        command,
 				},
 			),
 

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -213,9 +213,9 @@ var _ = Describe("type Logger", func() {
 				"TickCompleted (failure)",
 				"= ----  ∵ ----  ⋲ ----    ∴ ✖  <handler> ● <error>",
 				TickCompleted{
-					HandlerName: "<handler>",
-					HandlerType: configkit.AggregateHandlerType,
-					Error:       errors.New("<error>"),
+					HandlerIdentity: configkit.MustNewIdentity("<handler>", "<handler-key>"),
+					HandlerType:     configkit.AggregateHandlerType,
+					Error:           errors.New("<error>"),
 				},
 			),
 

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -57,6 +57,13 @@ var _ = Describe("type Logger", func() {
 			},
 		})
 
+		projection := configkit.FromProjection(&ProjectionMessageHandler{
+			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+				c.Identity("<projection>", "<projection-key>")
+				c.ConsumesEventType(MessageE{})
+			},
+		})
+
 		DescribeTable(
 			"logs the expected message",
 			func(m string, f Fact) {
@@ -415,26 +422,26 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"ProjectionCompactionCompleted (success)",
-				"= ----  ∵ ----  ⋲ ----    Σ    <handler> ● compacted",
+				"= ----  ∵ ----  ⋲ ----    Σ    <projection> ● compacted",
 				ProjectionCompactionCompleted{
-					HandlerName: "<handler>",
+					Handler: projection,
 				},
 			),
 
 			Entry(
 				"ProjectionCompactionCompleted (failure)",
-				"= ----  ∵ ----  ⋲ ----    Σ ✖  <handler> ● compaction failed: <error>",
+				"= ----  ∵ ----  ⋲ ----    Σ ✖  <projection> ● compaction failed: <error>",
 				ProjectionCompactionCompleted{
-					HandlerName: "<handler>",
-					Error:       errors.New("<error>"),
+					Handler: projection,
+					Error:   errors.New("<error>"),
 				},
 			),
 
 			Entry(
 				"MessageLoggedByProjection",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ Σ    <handler> ● <message>",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ Σ    <projection> ● <message>",
 				MessageLoggedByProjection{
-					HandlerName:  "<handler>",
+					Handler:      projection,
 					Envelope:     command,
 					LogFormat:    "<%s>",
 					LogArguments: []interface{}{"message"},
@@ -443,9 +450,9 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"MessageLoggedByProjection (compacting)",
-				"= ----  ∵ ----  ⋲ ----    Σ    <handler> ● <message>",
+				"= ----  ∵ ----  ⋲ ----    Σ    <projection> ● <message>",
 				MessageLoggedByProjection{
-					HandlerName:  "<handler>",
+					Handler:      projection,
 					LogFormat:    "<%s>",
 					LogArguments: []interface{}{"message"},
 				},

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -366,7 +366,7 @@ var _ = Describe("type Logger", func() {
 						time.Now(),
 						now,
 						envelope.Origin{
-							HandlerName: "<process>",
+							Handler:     process,
 							HandlerType: configkit.ProcessHandlerType,
 							InstanceID:  "<instance>",
 						},

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -49,6 +49,14 @@ var _ = Describe("type Logger", func() {
 			},
 		})
 
+		process := configkit.FromProcess(&ProcessMessageHandler{
+			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+				c.Identity("<process>", "<process-key>")
+				c.ConsumesEventType(MessageE{})
+				c.ProducesCommandType(MessageC{})
+			},
+		})
+
 		DescribeTable(
 			"logs the expected message",
 			func(m string, f Fact) {
@@ -273,64 +281,64 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"ProcessInstanceLoaded",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <handler> <instance> ● loaded an existing instance",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <process> <instance> ● loaded an existing instance",
 				ProcessInstanceLoaded{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    event,
+					Handler:    process,
+					InstanceID: "<instance>",
+					Envelope:   event,
 				},
 			),
 			Entry(
 				"ProcessEventIgnored",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <handler> ● event ignored because it was not routed to any instance",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <process> ● event ignored because it was not routed to any instance",
 				ProcessEventIgnored{
-					HandlerName: "<handler>",
-					Envelope:    event,
+					Handler:  process,
+					Envelope: event,
 				},
 			),
 			Entry(
 				"ProcessTimeoutIgnored",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <handler> <instance> ● timeout ignored because the target instance no longer exists",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <process> <instance> ● timeout ignored because the target instance no longer exists",
 				ProcessTimeoutIgnored{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    event,
+					Handler:    process,
+					InstanceID: "<instance>",
+					Envelope:   event,
 				},
 			),
 			Entry(
 				"ProcessInstanceNotFound",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <handler> <instance> ● instance does not yet exist",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <process> <instance> ● instance does not yet exist",
 				ProcessInstanceNotFound{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    event,
+					Handler:    process,
+					InstanceID: "<instance>",
+					Envelope:   event,
 				},
 			),
 			Entry(
 				"ProcessInstanceBegun",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <handler> <instance> ● instance begun",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <process> <instance> ● instance begun",
 				ProcessInstanceBegun{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    event,
+					Handler:    process,
+					InstanceID: "<instance>",
+					Envelope:   event,
 				},
 			),
 			Entry(
 				"ProcessInstanceEnded",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <handler> <instance> ● instance ended",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <process> <instance> ● instance ended",
 				ProcessInstanceEnded{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    event,
+					Handler:    process,
+					InstanceID: "<instance>",
+					Envelope:   event,
 				},
 			),
 			Entry(
 				"CommandExecutedByProcess",
-				"= 0200  ∵ 0100  ⋲ 0100  ▲ ≡    <handler> <instance> ● executed a command ● fixtures.MessageC? ● {C1}",
+				"= 0200  ∵ 0100  ⋲ 0100  ▲ ≡    <process> <instance> ● executed a command ● fixtures.MessageC? ● {C1}",
 				CommandExecutedByProcess{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    event,
+					Handler:    process,
+					InstanceID: "<instance>",
+					Envelope:   event,
 					CommandEnvelope: event.NewCommand(
 						"200",
 						MessageC1,
@@ -341,17 +349,17 @@ var _ = Describe("type Logger", func() {
 			),
 			Entry(
 				"TimeoutScheduledByProcess",
-				"= 0200  ∵ 0100  ⋲ 0100  ▲ ≡    <handler> <instance> ● scheduled a timeout for 2006-01-02T15:04:05+07:00 ● fixtures.MessageT@ ● {T1}",
+				"= 0200  ∵ 0100  ⋲ 0100  ▲ ≡    <process> <instance> ● scheduled a timeout for 2006-01-02T15:04:05+07:00 ● fixtures.MessageT@ ● {T1}",
 				TimeoutScheduledByProcess{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
+					Handler:    process,
+					InstanceID: "<instance>",
 					TimeoutEnvelope: event.NewTimeout(
 						"200",
 						MessageT1,
 						time.Now(),
 						now,
 						envelope.Origin{
-							HandlerName: "<handler>",
+							HandlerName: "<process>",
 							HandlerType: configkit.ProcessHandlerType,
 							InstanceID:  "<instance>",
 						},
@@ -360,9 +368,9 @@ var _ = Describe("type Logger", func() {
 			),
 			Entry(
 				"MessageLoggedByProcess",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <handler> <instance> ● <message>",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ≡    <process> <instance> ● <message>",
 				MessageLoggedByProcess{
-					HandlerName:  "<handler>",
+					Handler:      process,
 					InstanceID:   "<instance>",
 					Envelope:     event,
 					LogFormat:    "<%s>",

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	. "github.com/dogmatiq/testkit/engine/fact"
@@ -31,6 +32,14 @@ var _ = Describe("type Logger", func() {
 			MessageE1,
 			time.Now(),
 		)
+
+		aggregate := configkit.FromAggregate(&AggregateMessageHandler{
+			ConfigureFunc: func(c dogma.AggregateConfigurer) {
+				c.Identity("<aggregate>", "<aggregate-key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageE{})
+			},
+		})
 
 		DescribeTable(
 			"logs the expected message",
@@ -191,47 +200,47 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"AggregateInstanceLoaded",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <handler> <instance> ● loaded an existing instance",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <aggregate> <instance> ● loaded an existing instance",
 				AggregateInstanceLoaded{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    command,
+					Handler:    aggregate,
+					InstanceID: "<instance>",
+					Envelope:   command,
 				},
 			),
 			Entry(
 				"AggregateInstanceNotFound",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <handler> <instance> ● instance does not yet exist",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <aggregate> <instance> ● instance does not yet exist",
 				AggregateInstanceNotFound{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    command,
+					Handler:    aggregate,
+					InstanceID: "<instance>",
+					Envelope:   command,
 				},
 			),
 			Entry(
 				"AggregateInstanceCreated",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <handler> <instance> ● instance created",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <aggregate> <instance> ● instance created",
 				AggregateInstanceCreated{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    command,
+					Handler:    aggregate,
+					InstanceID: "<instance>",
+					Envelope:   command,
 				},
 			),
 			Entry(
 				"AggregateInstanceDestroyed",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <handler> <instance> ● instance destroyed",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <aggregate> <instance> ● instance destroyed",
 				AggregateInstanceDestroyed{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    command,
+					Handler:    aggregate,
+					InstanceID: "<instance>",
+					Envelope:   command,
 				},
 			),
 			Entry(
 				"EventRecordedByAggregate",
-				"= 0200  ∵ 0100  ⋲ 0100  ▲ ∴    <handler> <instance> ● recorded an event ● fixtures.MessageE! ● {E1}",
+				"= 0200  ∵ 0100  ⋲ 0100  ▲ ∴    <aggregate> <instance> ● recorded an event ● fixtures.MessageE! ● {E1}",
 				EventRecordedByAggregate{
-					HandlerName: "<handler>",
-					InstanceID:  "<instance>",
-					Envelope:    command,
+					Handler:    aggregate,
+					InstanceID: "<instance>",
+					Envelope:   command,
 					EventEnvelope: command.NewEvent(
 						"200",
 						MessageE1,
@@ -242,9 +251,9 @@ var _ = Describe("type Logger", func() {
 			),
 			Entry(
 				"MessageLoggedByAggregate",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <handler> <instance> ● <message>",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <aggregate> <instance> ● <message>",
 				MessageLoggedByAggregate{
-					HandlerName:  "<handler>",
+					Handler:      aggregate,
 					InstanceID:   "<instance>",
 					Envelope:     command,
 					LogFormat:    "<%s>",

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -209,11 +209,10 @@ var _ = Describe("type Logger", func() {
 			),
 			Entry(
 				"TickCompleted (failure)",
-				"= ----  ∵ ----  ⋲ ----    ∴ ✖  <handler> ● <error>",
+				"= ----  ∵ ----  ⋲ ----    ∴ ✖  <aggregate> ● <error>",
 				TickCompleted{
-					HandlerIdentity: configkit.MustNewIdentity("<handler>", "<handler-key>"),
-					HandlerType:     configkit.AggregateHandlerType,
-					Error:           errors.New("<error>"),
+					Handler: aggregate,
+					Error:   errors.New("<error>"),
 				},
 			),
 

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -41,6 +41,14 @@ var _ = Describe("type Logger", func() {
 			},
 		})
 
+		integration := configkit.FromIntegration(&IntegrationMessageHandler{
+			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+				c.Identity("<integration>", "<integration-key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageE{})
+			},
+		})
+
 		DescribeTable(
 			"logs the expected message",
 			func(m string, f Fact) {
@@ -366,10 +374,10 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"EventRecordedByIntegration",
-				"= 0200  ∵ 0100  ⋲ 0100  ▲ ⨝    <handler> ● recorded an event ● fixtures.MessageE! ● {E1}",
+				"= 0200  ∵ 0100  ⋲ 0100  ▲ ⨝    <integration> ● recorded an event ● fixtures.MessageE! ● {E1}",
 				EventRecordedByIntegration{
-					HandlerName: "<handler>",
-					Envelope:    command,
+					Handler:  integration,
+					Envelope: command,
 					EventEnvelope: command.NewEvent(
 						"200",
 						MessageE1,
@@ -380,9 +388,9 @@ var _ = Describe("type Logger", func() {
 			),
 			Entry(
 				"MessageLoggedByIntegration",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ⨝    <handler> ● <message>",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ⨝    <integration> ● <message>",
 				MessageLoggedByIntegration{
-					HandlerName:  "<handler>",
+					Handler:      integration,
 					Envelope:     command,
 					LogFormat:    "<%s>",
 					LogArguments: []interface{}{"message"},

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -155,21 +155,19 @@ var _ = Describe("type Logger", func() {
 			),
 			Entry(
 				"HandlingCompleted (failure)",
-				"= 0100  ∵ 0100  ⋲ 0100  ▽ ∴ ✖  <handler> ● <error>",
+				"= 0100  ∵ 0100  ⋲ 0100  ▽ ∴ ✖  <aggregate> ● <error>",
 				HandlingCompleted{
-					HandlerIdentity: configkit.MustNewIdentity("<handler>", "<handler-key>"),
-					HandlerType:     configkit.AggregateHandlerType,
-					Envelope:        command,
-					Error:           errors.New("<error>"),
+					Handler:  aggregate,
+					Envelope: command,
+					Error:    errors.New("<error>"),
 				},
 			),
 			Entry(
 				"HandlingSkipped",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <handler> ● handler skipped because aggregate handlers are disabled",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ∴    <aggregate> ● handler skipped because aggregate handlers are disabled",
 				HandlingSkipped{
-					HandlerIdentity: configkit.MustNewIdentity("<handler>", "<handler-key>"),
-					HandlerType:     configkit.AggregateHandlerType,
-					Envelope:        command,
+					Handler:  aggregate,
+					Envelope: command,
 				},
 			),
 

--- a/engine/fact/observer_test.go
+++ b/engine/fact/observer_test.go
@@ -1,7 +1,8 @@
 package fact_test
 
 import (
-	"github.com/dogmatiq/configkit"
+	"time"
+
 	. "github.com/dogmatiq/testkit/engine/fact"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,9 +11,8 @@ import (
 var _ = Describe("type ObserverGroup", func() {
 	Describe("func Notify()", func() {
 		It("notifies each of the observers in the group", func() {
-			f := HandlingBegun{
-				HandlerIdentity: configkit.MustNewIdentity("<handler-1>", "<handler-1-key>"),
-			}
+			f := TickCycleBegun{}
+
 			n := 0
 			g := ObserverGroup{
 				ObserverFunc(func(of Fact) {
@@ -35,11 +35,11 @@ var _ = Describe("type ObserverGroup", func() {
 var _ = Describe("type Buffer", func() {
 	Describe("func Notify()", func() {
 		It("appends the fact to the buffer", func() {
-			f1 := HandlingBegun{
-				HandlerIdentity: configkit.MustNewIdentity("<handler-1>", "<handler-1-key>"),
+			f1 := TickCycleBegun{
+				EngineTime: time.Now(),
 			}
-			f2 := HandlingBegun{
-				HandlerIdentity: configkit.MustNewIdentity("<handler-2>", "<handler-2-key>"),
+			f2 := TickCycleBegun{
+				EngineTime: time.Now().Add(1 * time.Second),
 			}
 			b := &Buffer{}
 
@@ -57,9 +57,7 @@ var _ = Describe("type Buffer", func() {
 var _ = Describe("var Ignore", func() {
 	Describe("func Notify()", func() {
 		It("does nothing", func() {
-			Ignore.Notify(HandlingBegun{
-				HandlerIdentity: configkit.MustNewIdentity("<handler-1>", "<handler-1-key>"),
-			})
+			Ignore.Notify(TickCycleBegun{})
 		})
 	})
 })

--- a/engine/fact/observer_test.go
+++ b/engine/fact/observer_test.go
@@ -1,6 +1,7 @@
 package fact_test
 
 import (
+	"github.com/dogmatiq/configkit"
 	. "github.com/dogmatiq/testkit/engine/fact"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,7 +11,7 @@ var _ = Describe("type ObserverGroup", func() {
 	Describe("func Notify()", func() {
 		It("notifies each of the observers in the group", func() {
 			f := HandlingBegun{
-				HandlerName: "<handler-1>",
+				HandlerIdentity: configkit.MustNewIdentity("<handler-1>", "<handler-1-key>"),
 			}
 			n := 0
 			g := ObserverGroup{
@@ -35,10 +36,10 @@ var _ = Describe("type Buffer", func() {
 	Describe("func Notify()", func() {
 		It("appends the fact to the buffer", func() {
 			f1 := HandlingBegun{
-				HandlerName: "<handler-1>",
+				HandlerIdentity: configkit.MustNewIdentity("<handler-1>", "<handler-1-key>"),
 			}
 			f2 := HandlingBegun{
-				HandlerName: "<handler-2>",
+				HandlerIdentity: configkit.MustNewIdentity("<handler-2>", "<handler-2-key>"),
 			}
 			b := &Buffer{}
 
@@ -57,7 +58,7 @@ var _ = Describe("var Ignore", func() {
 	Describe("func Notify()", func() {
 		It("does nothing", func() {
 			Ignore.Notify(HandlingBegun{
-				HandlerName: "<handler-1>",
+				HandlerIdentity: configkit.MustNewIdentity("<handler-1>", "<handler-1-key>"),
 			})
 		})
 	})

--- a/engine/fact/process.go
+++ b/engine/fact/process.go
@@ -1,6 +1,7 @@
 package fact
 
 import (
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/envelope"
 )
@@ -8,64 +9,57 @@ import (
 // ProcessInstanceLoaded indicates that a process message handler has loaded an
 // existing instance in order to handle an event or timeout.
 type ProcessInstanceLoaded struct {
-	HandlerName string
-	Handler     dogma.ProcessMessageHandler
-	InstanceID  string
-	Root        dogma.ProcessRoot
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichProcess
+	InstanceID string
+	Root       dogma.ProcessRoot
+	Envelope   *envelope.Envelope
 }
 
 // ProcessEventIgnored indicates that a process message handler chose not to
 // route an event to any instance.
 type ProcessEventIgnored struct {
-	HandlerName string
-	Handler     dogma.ProcessMessageHandler
-	Envelope    *envelope.Envelope
+	Handler  configkit.RichProcess
+	Envelope *envelope.Envelope
 }
 
 // ProcessTimeoutIgnored indicates that a process message handler ignored a
 // timeout message because its instance no longer exists.
 type ProcessTimeoutIgnored struct {
-	HandlerName string
-	Handler     dogma.ProcessMessageHandler
-	InstanceID  string
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichProcess
+	InstanceID string
+	Envelope   *envelope.Envelope
 }
 
 // ProcessInstanceNotFound indicates that a process message handler was unable
 // to load an existing instance while handling an event or timeout.
 type ProcessInstanceNotFound struct {
-	HandlerName string
-	Handler     dogma.ProcessMessageHandler
-	InstanceID  string
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichProcess
+	InstanceID string
+	Envelope   *envelope.Envelope
 }
 
 // ProcessInstanceBegun indicates that a process message handler began a process
 // instance while handling an event.
 type ProcessInstanceBegun struct {
-	HandlerName string
-	Handler     dogma.ProcessMessageHandler
-	InstanceID  string
-	Root        dogma.ProcessRoot
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichProcess
+	InstanceID string
+	Root       dogma.ProcessRoot
+	Envelope   *envelope.Envelope
 }
 
 // ProcessInstanceEnded indicates that a process message handler destroyed a
 // process instance while handling an event or timeout.
 type ProcessInstanceEnded struct {
-	HandlerName string
-	Handler     dogma.ProcessMessageHandler
-	InstanceID  string
-	Root        dogma.ProcessRoot
-	Envelope    *envelope.Envelope
+	Handler    configkit.RichProcess
+	InstanceID string
+	Root       dogma.ProcessRoot
+	Envelope   *envelope.Envelope
 }
 
 // CommandExecutedByProcess indicates that a process executed a command while
 // handling an event or timeout.
 type CommandExecutedByProcess struct {
-	HandlerName     string
-	Handler         dogma.ProcessMessageHandler
+	Handler         configkit.RichProcess
 	InstanceID      string
 	Root            dogma.ProcessRoot
 	Envelope        *envelope.Envelope
@@ -75,8 +69,7 @@ type CommandExecutedByProcess struct {
 // TimeoutScheduledByProcess indicates that a process scheduled a timeout while
 // handling an event or timeout.
 type TimeoutScheduledByProcess struct {
-	HandlerName     string
-	Handler         dogma.ProcessMessageHandler
+	Handler         configkit.RichProcess
 	InstanceID      string
 	Root            dogma.ProcessRoot
 	Envelope        *envelope.Envelope
@@ -86,8 +79,7 @@ type TimeoutScheduledByProcess struct {
 // MessageLoggedByProcess indicates that a process wrote a log message while
 // handling an event or timeout.
 type MessageLoggedByProcess struct {
-	HandlerName  string
-	Handler      dogma.ProcessMessageHandler
+	Handler      configkit.RichProcess
 	InstanceID   string
 	Root         dogma.ProcessRoot
 	Envelope     *envelope.Envelope

--- a/engine/fact/projection.go
+++ b/engine/fact/projection.go
@@ -1,21 +1,21 @@
 package fact
 
 import (
-	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/testkit/engine/envelope"
 )
 
 // ProjectionCompactionBegun indicates that a projection is about to be
 // compacted.
 type ProjectionCompactionBegun struct {
-	HandlerName string
+	Handler configkit.RichProjection
 }
 
 // ProjectionCompactionCompleted indicates that projection compaction has been
 // performed, either successfully or unsuccessfully.
 type ProjectionCompactionCompleted struct {
-	HandlerName string
-	Error       error
+	Handler configkit.RichProjection
+	Error   error
 }
 
 // MessageLoggedByProjection indicates that a projection wrote a log message
@@ -23,8 +23,7 @@ type ProjectionCompactionCompleted struct {
 //
 // Envelope is nil if the message was logged during compaction.
 type MessageLoggedByProjection struct {
-	HandlerName  string
-	Handler      dogma.ProjectionMessageHandler
+	Handler      configkit.RichProjection
 	Envelope     *envelope.Envelope
 	LogFormat    string
 	LogArguments []interface{}

--- a/engine/fact/tick.go
+++ b/engine/fact/tick.go
@@ -20,13 +20,13 @@ type TickCycleCompleted struct {
 
 // TickBegun indicates that a call to Controller.Tick() is being made.
 type TickBegun struct {
-	HandlerName string
-	HandlerType configkit.HandlerType
+	HandlerIdentity configkit.Identity
+	HandlerType     configkit.HandlerType
 }
 
 // TickCompleted indicates that a call to Controller.Tick() has completed.
 type TickCompleted struct {
-	HandlerName string
-	HandlerType configkit.HandlerType
-	Error       error
+	HandlerIdentity configkit.Identity
+	HandlerType     configkit.HandlerType
+	Error           error
 }

--- a/engine/fact/tick.go
+++ b/engine/fact/tick.go
@@ -20,13 +20,11 @@ type TickCycleCompleted struct {
 
 // TickBegun indicates that a call to Controller.Tick() is being made.
 type TickBegun struct {
-	HandlerIdentity configkit.Identity
-	HandlerType     configkit.HandlerType
+	Handler configkit.RichHandler
 }
 
 // TickCompleted indicates that a call to Controller.Tick() has completed.
 type TickCompleted struct {
-	HandlerIdentity configkit.Identity
-	HandlerType     configkit.HandlerType
-	Error           error
+	Handler configkit.RichHandler
+	Error   error
 }

--- a/satisfy.go
+++ b/satisfy.go
@@ -301,7 +301,7 @@ func (t *SatisfyT) logf(format string, args []interface{}) {
 	t.messages = append(t.messages, m)
 }
 
-// skip marks the test as skipped. 
+// skip marks the test as skipped.
 // fn is the name of the function that was called to skip the test.
 func (t *SatisfyT) skip(fn string) {
 	t.skipped = true
@@ -309,7 +309,7 @@ func (t *SatisfyT) skip(fn string) {
 	panic(abortSentinel{})
 }
 
-// fail marks the test as failed. 
+// fail marks the test as failed.
 // fn is the name of the function that was called to indicate failure.
 func (t *SatisfyT) fail(fn string) {
 	t.failed = true


### PR DESCRIPTION
#### What change does this introduce?

This PR adds `configkick.RichHandler` interfaces to facts and the `envelope.Origin` type. 

#### What issues does this relate to?

Fixes #116 
Fixes #165 

#### Why make this change?


The `RichHandler` interface encapsulates several pieces of information that were previously represented as separate fields in each fact.

#### Is there anything you are unsure about?

No