### PR TITLE
Allow enabling/disabling handlers individually.

### DIFF
--- a/advancetime_test.go
+++ b/advancetime_test.go
@@ -60,6 +60,7 @@ var _ = Describe("func AdvanceTime()", func() {
 					configkit.ProcessHandlerType:     true,
 					configkit.ProjectionHandlerType:  false,
 				},
+				EnabledHandlers: map[string]bool{},
 			},
 		))
 	})
@@ -107,6 +108,7 @@ var _ = Describe("func AdvanceTime()", func() {
 						configkit.ProcessHandlerType:     true,
 						configkit.ProjectionHandlerType:  false,
 					},
+					EnabledHandlers: map[string]bool{},
 				},
 			))
 		})
@@ -137,6 +139,7 @@ var _ = Describe("func AdvanceTime()", func() {
 						configkit.ProcessHandlerType:     true,
 						configkit.ProjectionHandlerType:  false,
 					},
+					EnabledHandlers: map[string]bool{},
 				},
 			))
 		})

--- a/advancetime_test.go
+++ b/advancetime_test.go
@@ -54,7 +54,7 @@ var _ = Describe("func AdvanceTime()", func() {
 		Expect(buf.Facts()).To(ContainElement(
 			fact.TickCycleBegun{
 				EngineTime: startTime.Add(2 * time.Second),
-				EnabledHandlers: map[configkit.HandlerType]bool{
+				EnabledHandlerTypes: map[configkit.HandlerType]bool{
 					configkit.AggregateHandlerType:   true,
 					configkit.IntegrationHandlerType: false,
 					configkit.ProcessHandlerType:     true,
@@ -101,7 +101,7 @@ var _ = Describe("func AdvanceTime()", func() {
 			Expect(buf.Facts()).To(ContainElement(
 				fact.TickCycleBegun{
 					EngineTime: targetTime,
-					EnabledHandlers: map[configkit.HandlerType]bool{
+					EnabledHandlerTypes: map[configkit.HandlerType]bool{
 						configkit.AggregateHandlerType:   true,
 						configkit.IntegrationHandlerType: false,
 						configkit.ProcessHandlerType:     true,
@@ -131,7 +131,7 @@ var _ = Describe("func AdvanceTime()", func() {
 			Expect(buf.Facts()).To(ContainElement(
 				fact.TickCycleBegun{
 					EngineTime: startTime.Add(3 * time.Second),
-					EnabledHandlers: map[configkit.HandlerType]bool{
+					EnabledHandlerTypes: map[configkit.HandlerType]bool{
 						configkit.AggregateHandlerType:   true,
 						configkit.IntegrationHandlerType: false,
 						configkit.ProcessHandlerType:     true,

--- a/assert/tracker.go
+++ b/assert/tracker.go
@@ -45,13 +45,13 @@ func (t *tracker) Notify(f fact.Fact) {
 	switch x := f.(type) {
 	case fact.DispatchCycleBegun:
 		t.cycleBegun = true
-		t.enabled = x.EnabledHandlers
+		t.enabled = x.EnabledHandlerTypes
 		if t.matchDispatchCycle {
 			t.messageProduced(x.Envelope.Role)
 		}
 	case fact.TickCycleBegun:
 		t.cycleBegun = true
-		t.enabled = x.EnabledHandlers
+		t.enabled = x.EnabledHandlerTypes
 	case fact.HandlingBegun:
 		t.updateEngaged(
 			x.Handler.Identity().Name,

--- a/call_test.go
+++ b/call_test.go
@@ -104,6 +104,7 @@ var _ = Describe("func Call()", func() {
 					configkit.ProcessHandlerType:     true,
 					configkit.ProjectionHandlerType:  false,
 				},
+				EnabledHandlers: map[string]bool{},
 			},
 		))
 	})
@@ -138,6 +139,7 @@ var _ = Describe("func Call()", func() {
 					configkit.ProcessHandlerType:     true,
 					configkit.ProjectionHandlerType:  false,
 				},
+				EnabledHandlers: map[string]bool{},
 			},
 		))
 	})

--- a/call_test.go
+++ b/call_test.go
@@ -98,7 +98,7 @@ var _ = Describe("func Call()", func() {
 					CreatedAt:     startTime,
 				},
 				EngineTime: startTime,
-				EnabledHandlers: map[configkit.HandlerType]bool{
+				EnabledHandlerTypes: map[configkit.HandlerType]bool{
 					configkit.AggregateHandlerType:   true,
 					configkit.IntegrationHandlerType: false,
 					configkit.ProcessHandlerType:     true,
@@ -132,7 +132,7 @@ var _ = Describe("func Call()", func() {
 					CreatedAt:     startTime,
 				},
 				EngineTime: startTime,
-				EnabledHandlers: map[configkit.HandlerType]bool{
+				EnabledHandlerTypes: map[configkit.HandlerType]bool{
 					configkit.AggregateHandlerType:   true,
 					configkit.IntegrationHandlerType: false,
 					configkit.ProcessHandlerType:     true,

--- a/dispatchcommand_test.go
+++ b/dispatchcommand_test.go
@@ -77,7 +77,7 @@ var _ = Describe("func ExecuteCommand()", func() {
 					CreatedAt:     startTime,
 				},
 				EngineTime: startTime,
-				EnabledHandlers: map[configkit.HandlerType]bool{
+				EnabledHandlerTypes: map[configkit.HandlerType]bool{
 					configkit.AggregateHandlerType:   true,
 					configkit.IntegrationHandlerType: false,
 					configkit.ProcessHandlerType:     true,

--- a/dispatchcommand_test.go
+++ b/dispatchcommand_test.go
@@ -83,6 +83,7 @@ var _ = Describe("func ExecuteCommand()", func() {
 					configkit.ProcessHandlerType:     true,
 					configkit.ProjectionHandlerType:  false,
 				},
+				EnabledHandlers: map[string]bool{},
 			},
 		))
 	})

--- a/dispatchevent_test.go
+++ b/dispatchevent_test.go
@@ -85,6 +85,7 @@ var _ = Describe("func RecordEvent()", func() {
 					configkit.ProcessHandlerType:     true,
 					configkit.ProjectionHandlerType:  false,
 				},
+				EnabledHandlers: map[string]bool{},
 			},
 		))
 	})

--- a/dispatchevent_test.go
+++ b/dispatchevent_test.go
@@ -79,7 +79,7 @@ var _ = Describe("func RecordEvent()", func() {
 					CreatedAt:     startTime,
 				},
 				EngineTime: startTime,
-				EnabledHandlers: map[configkit.HandlerType]bool{
+				EnabledHandlerTypes: map[configkit.HandlerType]bool{
 					configkit.AggregateHandlerType:   true,
 					configkit.IntegrationHandlerType: false,
 					configkit.ProcessHandlerType:     true,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -93,8 +93,8 @@ func (e *Engine) Tick(
 
 	oo.observers.Notify(
 		fact.TickCycleBegun{
-			EngineTime:      oo.now,
-			EnabledHandlers: oo.enabledHandlers,
+			EngineTime:          oo.now,
+			EnabledHandlerTypes: oo.enabledHandlerTypes,
 		},
 	)
 
@@ -106,8 +106,8 @@ func (e *Engine) Tick(
 
 	oo.observers.Notify(
 		fact.TickCycleCompleted{
-			Error:           err,
-			EnabledHandlers: oo.enabledHandlers,
+			Error:               err,
+			EnabledHandlerTypes: oo.enabledHandlerTypes,
 		},
 	)
 
@@ -194,9 +194,9 @@ func (e *Engine) Dispatch(
 
 	oo.observers.Notify(
 		fact.DispatchCycleBegun{
-			Envelope:        env,
-			EngineTime:      oo.now,
-			EnabledHandlers: oo.enabledHandlers,
+			Envelope:            env,
+			EngineTime:          oo.now,
+			EnabledHandlerTypes: oo.enabledHandlerTypes,
 		},
 	)
 
@@ -208,9 +208,9 @@ func (e *Engine) Dispatch(
 
 	oo.observers.Notify(
 		fact.DispatchCycleCompleted{
-			Envelope:        env,
-			Error:           err,
-			EnabledHandlers: oo.enabledHandlers,
+			Envelope:            env,
+			Error:               err,
+			EnabledHandlerTypes: oo.enabledHandlerTypes,
 		},
 	)
 
@@ -280,7 +280,7 @@ func (e *Engine) handle(
 	env *envelope.Envelope,
 	c controller.Controller,
 ) ([]*envelope.Envelope, error) {
-	if !oo.enabledHandlers[c.HandlerConfig().HandlerType()] {
+	if !oo.enabledHandlerTypes[c.HandlerConfig().HandlerType()] {
 		oo.observers.Notify(
 			fact.HandlingSkipped{
 				Handler:  c.HandlerConfig(),

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -116,7 +116,7 @@ var _ = Describe("type Engine", func() {
 						Role:          message.CommandRole,
 						CreatedAt:     now,
 					},
-					Explicit: false,
+					Reason: fact.HandlerTypeDisabled,
 				},
 			))
 		})
@@ -154,7 +154,7 @@ var _ = Describe("type Engine", func() {
 						Role:          message.CommandRole,
 						CreatedAt:     now,
 					},
-					Explicit: true,
+					Reason: fact.IndividualHandlerDisabled,
 				},
 			))
 		})
@@ -210,8 +210,8 @@ var _ = Describe("type Engine", func() {
 			h, _ := config.RichHandlers().ByName("<aggregate>")
 			Expect(buf.Facts()).To(ContainElement(
 				fact.TickSkipped{
-					Handler:  h,
-					Explicit: false,
+					Handler: h,
+					Reason:  fact.HandlerTypeDisabled,
 				},
 			))
 		})
@@ -228,8 +228,8 @@ var _ = Describe("type Engine", func() {
 			h, _ := config.RichHandlers().ByName("<aggregate>")
 			Expect(buf.Facts()).To(ContainElement(
 				fact.TickSkipped{
-					Handler:  h,
-					Explicit: true,
+					Handler: h,
+					Reason:  fact.IndividualHandlerDisabled,
 				},
 			))
 		})

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3,11 +3,16 @@ package engine_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/dogmatiq/configkit"
+	. "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/engine"
+	"github.com/dogmatiq/testkit/engine/envelope"
+	"github.com/dogmatiq/testkit/engine/fact"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -19,6 +24,7 @@ var _ = Describe("type Engine", func() {
 		integration *IntegrationMessageHandler
 		projection  *ProjectionMessageHandler
 		app         *Application
+		config      configkit.RichApplication
 		engine      *Engine
 	)
 
@@ -72,17 +78,115 @@ var _ = Describe("type Engine", func() {
 			},
 		}
 
-		engine = MustNew(
-			configkit.FromApplication(app),
-		)
+		config = configkit.FromApplication(app)
+		engine = MustNew(config)
 	})
 
 	Describe("func Dispatch()", func() {
+		It("skips handlers that are disabled by type", func() {
+			aggregate.HandleCommandFunc = func(
+				dogma.AggregateRoot,
+				dogma.AggregateCommandScope,
+				dogma.Message,
+			) {
+				Fail("unexpected call")
+			}
+
+			now := time.Now()
+			buf := &fact.Buffer{}
+			err := engine.Dispatch(
+				context.Background(),
+				MessageA1,
+				WithCurrentTime(now),
+				WithObserver(buf),
+				EnableAggregates(false),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			h, _ := config.RichHandlers().ByName("<aggregate>")
+			Expect(buf.Facts()).To(ContainElement(
+				fact.HandlingSkipped{
+					Handler: h,
+					Envelope: &envelope.Envelope{
+						MessageID:     "1",
+						CausationID:   "1",
+						CorrelationID: "1",
+						Message:       MessageA1,
+						Type:          MessageAType,
+						Role:          message.CommandRole,
+						CreatedAt:     now,
+					},
+					Explicit: false,
+				},
+			))
+		})
+
+		It("skips handlers that are disabled by name", func() {
+			aggregate.HandleCommandFunc = func(
+				dogma.AggregateRoot,
+				dogma.AggregateCommandScope,
+				dogma.Message,
+			) {
+				Fail("unexpected call")
+			}
+
+			now := time.Now()
+			buf := &fact.Buffer{}
+			err := engine.Dispatch(
+				context.Background(),
+				MessageA1,
+				WithCurrentTime(now),
+				WithObserver(buf),
+				EnableHandler("<aggregate>", false),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			h, _ := config.RichHandlers().ByName("<aggregate>")
+			Expect(buf.Facts()).To(ContainElement(
+				fact.HandlingSkipped{
+					Handler: h,
+					Envelope: &envelope.Envelope{
+						MessageID:     "1",
+						CausationID:   "1",
+						CorrelationID: "1",
+						Message:       MessageA1,
+						Type:          MessageAType,
+						Role:          message.CommandRole,
+						CreatedAt:     now,
+					},
+					Explicit: true,
+				},
+			))
+		})
+
+		It("does not skip handlers that are enabled by name", func() {
+			called := false
+			aggregate.HandleCommandFunc = func(
+				dogma.AggregateRoot,
+				dogma.AggregateCommandScope,
+				dogma.Message,
+			) {
+				called = true
+			}
+
+			err := engine.Dispatch(
+				context.Background(),
+				MessageA1,
+				EnableHandler("<aggregate>", false),
+				EnableHandler("<aggregate>", true),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(called).To(BeTrue())
+		})
+
 		It("panics if the message is invalid", func() {
 			Expect(func() {
-				engine.Dispatch(context.Background(), MessageA{
-					Value: errors.New("<invalid>"),
-				})
+				engine.Dispatch(
+					context.Background(),
+					MessageA{
+						Value: errors.New("<invalid>"),
+					},
+				)
 			}).To(PanicWith("can not dispatch invalid fixtures.MessageA message: <invalid>"))
 		})
 
@@ -90,6 +194,62 @@ var _ = Describe("type Engine", func() {
 			Expect(func() {
 				engine.Dispatch(context.Background(), MessageX1)
 			}).To(PanicWith("the fixtures.MessageX message type is not consumed by any handlers"))
+		})
+	})
+
+	Describe("func Tick()", func() {
+		It("skips handlers that are disabled by type", func() {
+			buf := &fact.Buffer{}
+			err := engine.Tick(
+				context.Background(),
+				WithObserver(buf),
+				EnableAggregates(false),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			h, _ := config.RichHandlers().ByName("<aggregate>")
+			Expect(buf.Facts()).To(ContainElement(
+				fact.TickSkipped{
+					Handler:  h,
+					Explicit: false,
+				},
+			))
+		})
+
+		It("skips handlers that are disabled by name", func() {
+			buf := &fact.Buffer{}
+			err := engine.Tick(
+				context.Background(),
+				WithObserver(buf),
+				EnableHandler("<aggregate>", false),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			h, _ := config.RichHandlers().ByName("<aggregate>")
+			Expect(buf.Facts()).To(ContainElement(
+				fact.TickSkipped{
+					Handler:  h,
+					Explicit: true,
+				},
+			))
+		})
+
+		It("does not skip handlers that are enabled by name", func() {
+			buf := &fact.Buffer{}
+			err := engine.Tick(
+				context.Background(),
+				WithObserver(buf),
+				EnableHandler("<aggregate>", false),
+				EnableHandler("<aggregate>", true),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			h, _ := config.RichHandlers().ByName("<aggregate>")
+			Expect(buf.Facts()).To(ContainElement(
+				fact.TickBegun{
+					Handler: h,
+				},
+			))
 		})
 	})
 })

--- a/engine/fact/dispatch.go
+++ b/engine/fact/dispatch.go
@@ -13,6 +13,7 @@ type DispatchCycleBegun struct {
 	Envelope            *envelope.Envelope
 	EngineTime          time.Time
 	EnabledHandlerTypes map[configkit.HandlerType]bool
+	EnabledHandlers     map[string]bool
 }
 
 // DispatchCycleCompleted indicates that a call Engine.Dispatch() has completed.
@@ -20,6 +21,7 @@ type DispatchCycleCompleted struct {
 	Envelope            *envelope.Envelope
 	Error               error
 	EnabledHandlerTypes map[configkit.HandlerType]bool
+	EnabledHandlers     map[string]bool
 }
 
 // DispatchBegun indicates that Engine.Dispatch() has been called with a
@@ -50,8 +52,10 @@ type HandlingCompleted struct {
 }
 
 // HandlingSkipped indicates that a message has been not been handled by a
-// specific handler, because handlers of that type are disabled.
+// specific handler, either because all handlers of that type are or the handler
+// itself is disabled.
 type HandlingSkipped struct {
 	Handler  configkit.RichHandler
 	Envelope *envelope.Envelope
+	Explicit bool // true if handler itself was disabled
 }

--- a/engine/fact/dispatch.go
+++ b/engine/fact/dispatch.go
@@ -57,5 +57,5 @@ type HandlingCompleted struct {
 type HandlingSkipped struct {
 	Handler  configkit.RichHandler
 	Envelope *envelope.Envelope
-	Explicit bool // true if handler itself was disabled
+	Reason   HandlerSkipReason
 }

--- a/engine/fact/dispatch.go
+++ b/engine/fact/dispatch.go
@@ -10,16 +10,16 @@ import (
 // DispatchCycleBegun indicates that Engine.Dispatch() has been called with a
 // message that is able to be routed to at least one handler.
 type DispatchCycleBegun struct {
-	Envelope        *envelope.Envelope
-	EngineTime      time.Time
-	EnabledHandlers map[configkit.HandlerType]bool
+	Envelope            *envelope.Envelope
+	EngineTime          time.Time
+	EnabledHandlerTypes map[configkit.HandlerType]bool
 }
 
 // DispatchCycleCompleted indicates that a call Engine.Dispatch() has completed.
 type DispatchCycleCompleted struct {
-	Envelope        *envelope.Envelope
-	Error           error
-	EnabledHandlers map[configkit.HandlerType]bool
+	Envelope            *envelope.Envelope
+	Error               error
+	EnabledHandlerTypes map[configkit.HandlerType]bool
 }
 
 // DispatchBegun indicates that Engine.Dispatch() has been called with a

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -91,7 +91,7 @@ func (l *Logger) dispatchCycleBegun(f DispatchCycleBegun) {
 		},
 		"dispatching",
 		formatEngineTime(f.EngineTime),
-		formatEnabledHandlers(f.EnabledHandlers),
+		formatEnabledHandlerTypes(f.EnabledHandlerTypes),
 	)
 }
 
@@ -153,7 +153,7 @@ func (l *Logger) tickCycleBegun(f TickCycleBegun) {
 		},
 		"ticking",
 		formatEngineTime(f.EngineTime),
-		formatEnabledHandlers(f.EnabledHandlers),
+		formatEnabledHandlerTypes(f.EnabledHandlerTypes),
 	)
 }
 
@@ -510,7 +510,7 @@ func formatEngineTime(t time.Time) string {
 	return "engine time is " + t.Format(time.RFC3339)
 }
 
-func formatEnabledHandlers(e map[configkit.HandlerType]bool) string {
+func formatEnabledHandlerTypes(e map[configkit.HandlerType]bool) string {
 	s := "enabled: "
 
 	first := true

--- a/engine/fact/logger.go
+++ b/engine/fact/logger.go
@@ -2,6 +2,7 @@ package fact
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/dogmatiq/configkit"
@@ -91,7 +92,7 @@ func (l *Logger) dispatchCycleBegun(f DispatchCycleBegun) {
 		},
 		"dispatching",
 		formatEngineTime(f.EngineTime),
-		formatEnabledHandlerTypes(f.EnabledHandlerTypes),
+		formatEnabledHandlers(f.EnabledHandlerTypes, f.EnabledHandlers),
 	)
 }
 
@@ -153,7 +154,7 @@ func (l *Logger) tickCycleBegun(f TickCycleBegun) {
 		},
 		"ticking",
 		formatEngineTime(f.EngineTime),
-		formatEnabledHandlerTypes(f.EnabledHandlerTypes),
+		formatEnabledHandlers(f.EnabledHandlerTypes, f.EnabledHandlers),
 	)
 }
 
@@ -510,20 +511,39 @@ func formatEngineTime(t time.Time) string {
 	return "engine time is " + t.Format(time.RFC3339)
 }
 
-func formatEnabledHandlerTypes(e map[configkit.HandlerType]bool) string {
-	s := "enabled: "
+var handlerTypePlurals = map[configkit.HandlerType]string{
+	configkit.AggregateHandlerType:   "aggregates",
+	configkit.ProcessHandlerType:     "processes",
+	configkit.IntegrationHandlerType: "integrations",
+	configkit.ProjectionHandlerType:  "projections",
+}
 
-	first := true
+func formatEnabledHandlers(
+	byType map[configkit.HandlerType]bool,
+	byName map[string]bool,
+) string {
+	var s string
+
 	for _, t := range configkit.HandlerTypes {
-		if e[t] {
-			if !first {
-				s += ", "
-			}
-			first = false
-
-			s += t.String()
+		if byType[t] {
+			s += " +" + handlerTypePlurals[t]
 		}
 	}
 
-	return s
+	// sort the handler names to display them deterministically
+	var sorted []string
+	for n := range byName {
+		sorted = append(sorted, n)
+	}
+	sort.Strings(sorted)
+
+	for _, n := range sorted {
+		if byName[n] {
+			s += " +" + n
+		} else {
+			s += " -" + n
+		}
+	}
+
+	return "enabled:" + s
 }

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -98,7 +98,7 @@ var _ = Describe("type Logger", func() {
 				DispatchCycleBegun{
 					Envelope:   command,
 					EngineTime: now,
-					EnabledHandlers: map[configkit.HandlerType]bool{
+					EnabledHandlerTypes: map[configkit.HandlerType]bool{
 						configkit.AggregateHandlerType: true,
 						configkit.ProcessHandlerType:   true,
 					},
@@ -178,7 +178,7 @@ var _ = Describe("type Logger", func() {
 				"= ----  ∵ ----  ⋲ ----    ⚙    ticking ● engine time is 2006-01-02T15:04:05+07:00 ● enabled: aggregate, process",
 				TickCycleBegun{
 					EngineTime: now,
-					EnabledHandlers: map[configkit.HandlerType]bool{
+					EnabledHandlerTypes: map[configkit.HandlerType]bool{
 						configkit.AggregateHandlerType: true,
 						configkit.ProcessHandlerType:   true,
 					},

--- a/engine/fact/logger_test.go
+++ b/engine/fact/logger_test.go
@@ -94,13 +94,17 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"DispatchCycleBegun",
-				"= 0100  ∵ 0100  ⋲ 0100  ▼ ⚙    dispatching ● engine time is 2006-01-02T15:04:05+07:00 ● enabled: aggregate, process",
+				"= 0100  ∵ 0100  ⋲ 0100  ▼ ⚙    dispatching ● engine time is 2006-01-02T15:04:05+07:00 ● enabled: +aggregates +processes -<disabled> +<enabled>",
 				DispatchCycleBegun{
 					Envelope:   command,
 					EngineTime: now,
 					EnabledHandlerTypes: map[configkit.HandlerType]bool{
 						configkit.AggregateHandlerType: true,
 						configkit.ProcessHandlerType:   true,
+					},
+					EnabledHandlers: map[string]bool{
+						"<enabled>":  true,
+						"<disabled>": false,
 					},
 				},
 			),
@@ -175,12 +179,16 @@ var _ = Describe("type Logger", func() {
 
 			Entry(
 				"TickCycleBegun",
-				"= ----  ∵ ----  ⋲ ----    ⚙    ticking ● engine time is 2006-01-02T15:04:05+07:00 ● enabled: aggregate, process",
+				"= ----  ∵ ----  ⋲ ----    ⚙    ticking ● engine time is 2006-01-02T15:04:05+07:00 ● enabled: +aggregates +processes -<disabled> +<enabled>",
 				TickCycleBegun{
 					EngineTime: now,
 					EnabledHandlerTypes: map[configkit.HandlerType]bool{
 						configkit.AggregateHandlerType: true,
 						configkit.ProcessHandlerType:   true,
+					},
+					EnabledHandlers: map[string]bool{
+						"<enabled>":  true,
+						"<disabled>": false,
 					},
 				},
 			),

--- a/engine/fact/skip.go
+++ b/engine/fact/skip.go
@@ -1,0 +1,15 @@
+package fact
+
+// HandlerSkipReason is an enumeration of the reasons a handler can be skipped
+// while dispatching a message or ticking.
+type HandlerSkipReason byte
+
+const (
+	// HandlerTypeDisabled indicates that a handler skipped because all handlers
+	// of that type have been disabled.
+	HandlerTypeDisabled HandlerSkipReason = 'T'
+
+	// IndividualHandlerDisabled indicates that a handler was skipped because
+	// that specific handler was disabled.
+	IndividualHandlerDisabled HandlerSkipReason = 'I'
+)

--- a/engine/fact/tick.go
+++ b/engine/fact/tick.go
@@ -35,6 +35,6 @@ type TickCompleted struct {
 // either because all handlers of that type are or the handler itself is
 // disabled.
 type TickSkipped struct {
-	Handler  configkit.RichHandler
-	Explicit bool // true if handler itself was disabled
+	Handler configkit.RichHandler
+	Reason  HandlerSkipReason
 }

--- a/engine/fact/tick.go
+++ b/engine/fact/tick.go
@@ -8,14 +8,14 @@ import (
 
 // TickCycleBegun indicates that Engine.Tick() has been called.
 type TickCycleBegun struct {
-	EngineTime      time.Time
-	EnabledHandlers map[configkit.HandlerType]bool
+	EngineTime          time.Time
+	EnabledHandlerTypes map[configkit.HandlerType]bool
 }
 
 // TickCycleCompleted indicates that a call Engine.Tick() has completed.
 type TickCycleCompleted struct {
-	Error           error
-	EnabledHandlers map[configkit.HandlerType]bool
+	Error               error
+	EnabledHandlerTypes map[configkit.HandlerType]bool
 }
 
 // TickBegun indicates that a call to Controller.Tick() is being made.

--- a/engine/fact/tick.go
+++ b/engine/fact/tick.go
@@ -10,12 +10,14 @@ import (
 type TickCycleBegun struct {
 	EngineTime          time.Time
 	EnabledHandlerTypes map[configkit.HandlerType]bool
+	EnabledHandlers     map[string]bool
 }
 
 // TickCycleCompleted indicates that a call Engine.Tick() has completed.
 type TickCycleCompleted struct {
 	Error               error
 	EnabledHandlerTypes map[configkit.HandlerType]bool
+	EnabledHandlers     map[string]bool
 }
 
 // TickBegun indicates that a call to Controller.Tick() is being made.
@@ -27,4 +29,12 @@ type TickBegun struct {
 type TickCompleted struct {
 	Handler configkit.RichHandler
 	Error   error
+}
+
+// TickSkipped indicates that a call to Controller.Tick() has been skipped,
+// either because all handlers of that type are or the handler itself is
+// disabled.
+type TickSkipped struct {
+	Handler  configkit.RichHandler
+	Explicit bool // true if handler itself was disabled
 }

--- a/engine/operationoption.go
+++ b/engine/operationoption.go
@@ -67,6 +67,21 @@ func enableHandlerType(t configkit.HandlerType, enabled bool) OperationOption {
 	}
 }
 
+// EnableHandler returns an operation option that enables or disables a specific
+// handler.
+//
+// This option takes precedence over any EnableAggregates(), EnableProcesses(),
+// EnableIntegrations() or EnableProjections() options.
+func EnableHandler(name string, enabled bool) OperationOption {
+	if err := configkit.ValidateIdentityName(name); err != nil {
+		panic(err)
+	}
+
+	return func(oo *operationOptions) {
+		oo.enabledHandlers[name] = enabled
+	}
+}
+
 // WithCurrentTime returns an operation option that sets the engine's current
 // time.
 func WithCurrentTime(t time.Time) OperationOption {
@@ -81,6 +96,7 @@ type operationOptions struct {
 	now                 time.Time
 	observers           fact.ObserverGroup
 	enabledHandlerTypes map[configkit.HandlerType]bool
+	enabledHandlers     map[string]bool
 }
 
 // newOperationOptions returns a new operationOptions with the given options.
@@ -93,6 +109,7 @@ func newOperationOptions(options []OperationOption) *operationOptions {
 			configkit.IntegrationHandlerType: true,
 			configkit.ProjectionHandlerType:  true,
 		},
+		enabledHandlers: map[string]bool{},
 	}
 
 	for _, opt := range options {

--- a/engine/operationoption.go
+++ b/engine/operationoption.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
-
 	"github.com/dogmatiq/testkit/engine/fact"
 )
 
@@ -64,7 +63,7 @@ func enableHandlerType(t configkit.HandlerType, enabled bool) OperationOption {
 	t.MustValidate()
 
 	return func(oo *operationOptions) {
-		oo.enabledHandlers[t] = enabled
+		oo.enabledHandlerTypes[t] = enabled
 	}
 }
 
@@ -79,16 +78,16 @@ func WithCurrentTime(t time.Time) OperationOption {
 // operationOptions is a container for the options set via OperationOption
 // values.
 type operationOptions struct {
-	now             time.Time
-	observers       fact.ObserverGroup
-	enabledHandlers map[configkit.HandlerType]bool
+	now                 time.Time
+	observers           fact.ObserverGroup
+	enabledHandlerTypes map[configkit.HandlerType]bool
 }
 
 // newOperationOptions returns a new operationOptions with the given options.
 func newOperationOptions(options []OperationOption) *operationOptions {
 	oo := &operationOptions{
 		now: time.Now(),
-		enabledHandlers: map[configkit.HandlerType]bool{
+		enabledHandlerTypes: map[configkit.HandlerType]bool{
 			configkit.AggregateHandlerType:   true,
 			configkit.ProcessHandlerType:     true,
 			configkit.IntegrationHandlerType: true,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dogmatiq/testkit
 go 1.15
 
 require (
-	github.com/dogmatiq/configkit v0.9.0
+	github.com/dogmatiq/configkit v0.9.1
 	github.com/dogmatiq/cosyne v0.1.0
 	github.com/dogmatiq/dapper v0.4.0
 	github.com/dogmatiq/dogma v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -7,14 +7,12 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dogmatiq/configkit v0.9.0 h1:irS6Kb6tRzHtGmEKqNegK9bEatMNeZF64iN1Z46trAc=
-github.com/dogmatiq/configkit v0.9.0/go.mod h1:qukQmrrJT/XhZu1/n+2HQ58zzt2FG0ywIFA394JG+g0=
+github.com/dogmatiq/configkit v0.9.1 h1:gx2egDrmeiel1m8/RwAOk3ZFlvZa1mmElPz9v1K0AzY=
+github.com/dogmatiq/configkit v0.9.1/go.mod h1:lchVdCxCweenWrmm9WlgRH9X7Ppb340CvilcoVdTE8c=
 github.com/dogmatiq/cosyne v0.1.0 h1:j7b5WEZz7d+jfTP3JRgKpCWTsfaf4E1Z0s65A6yW9ic=
 github.com/dogmatiq/cosyne v0.1.0/go.mod h1:/OyJ0EHpWAZFt8/793nFrn6JIr7WSG4Zf+jlowBnCtw=
 github.com/dogmatiq/dapper v0.4.0 h1:WshL6xcW56jxkh1XE/x7sXyzxOvjBFjMcxz1jdjwn60=
 github.com/dogmatiq/dapper v0.4.0/go.mod h1:U32cRxzGYI5owhc/hMKjYLgBTVCdW/s3MdFJHwfDrLQ=
-github.com/dogmatiq/dogma v0.9.0 h1:PGRUqBPVI76HhkxulEEvzxe+693pq9cfQxJWBCpV730=
-github.com/dogmatiq/dogma v0.9.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
 github.com/dogmatiq/dogma v0.10.0 h1:2kLivwq72nr6yF3/jpIA5U57IOmPRxeO+I9lE06IebE=
 github.com/dogmatiq/dogma v0.10.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
@@ -35,7 +33,6 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -156,7 +153,7 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/test.go
+++ b/test.go
@@ -157,38 +157,6 @@ func (t *Test) EventRecorder() dogma.EventRecorder {
 	return &t.recorder
 }
 
-// // EnableAggregates returns an operation option that enables or disables
-// // aggregate message handlers.
-// //
-// // All handler types are enabled by default.
-// func EnableAggregates() OperationOption {
-// 	return enableHandlerType(configkit.AggregateHandlerType, enabled)
-// }
-
-// // EnableProcesses returns an operation option that enables or disables process
-// // message handlers.
-// //
-// // All handler types are enabled by default.
-// func EnableProcesses(enabled bool) OperationOption {
-// 	return enableHandlerType(configkit.ProcessHandlerType, enabled)
-// }
-
-// // EnableIntegrations returns an operation option that enables or disables
-// // integration message handlers.
-// //
-// // All handler types are enabled by default.
-// func EnableIntegrations(enabled bool) OperationOption {
-// 	return enableHandlerType(configkit.IntegrationHandlerType, enabled)
-// }
-
-// // EnableProjections returns an operation option that enables or disables
-// // projection message handlers.
-// //
-// // All handler types are enabled by default.
-// func EnableProjections(enabled bool) OperationOption {
-// 	return enableHandlerType(configkit.ProjectionHandlerType, enabled)
-// }
-
 func (t *Test) buildReport(e Expectation) {
 	t.t.Helper()
 

--- a/test.go
+++ b/test.go
@@ -24,9 +24,10 @@ type Test struct {
 	executor         engine.CommandExecutor
 	recorder         engine.EventRecorder
 	now              time.Time
-	operationOptions []engine.OperationOption
 	comparator       compare.Comparator
 	renderer         render.Renderer
+	enabledHandlers  map[configkit.HandlerType]bool
+	operationOptions []engine.OperationOption
 }
 
 // Begin starts a new test.
@@ -56,11 +57,12 @@ func BeginContext(
 	e := engine.MustNew(cfg, to.engineOptions...)
 
 	return &Test{
-		ctx:    ctx,
-		t:      t,
-		app:    cfg,
-		engine: e,
-		now:    to.time,
+		ctx:             ctx,
+		t:               t,
+		app:             cfg,
+		engine:          e,
+		now:             to.time,
+		enabledHandlers: map[configkit.HandlerType]bool{},
 		operationOptions: append(
 			to.operationOptions,
 			engine.WithObserver(
@@ -155,6 +157,38 @@ func (t *Test) EventRecorder() dogma.EventRecorder {
 	return &t.recorder
 }
 
+// // EnableAggregates returns an operation option that enables or disables
+// // aggregate message handlers.
+// //
+// // All handler types are enabled by default.
+// func EnableAggregates() OperationOption {
+// 	return enableHandlerType(configkit.AggregateHandlerType, enabled)
+// }
+
+// // EnableProcesses returns an operation option that enables or disables process
+// // message handlers.
+// //
+// // All handler types are enabled by default.
+// func EnableProcesses(enabled bool) OperationOption {
+// 	return enableHandlerType(configkit.ProcessHandlerType, enabled)
+// }
+
+// // EnableIntegrations returns an operation option that enables or disables
+// // integration message handlers.
+// //
+// // All handler types are enabled by default.
+// func EnableIntegrations(enabled bool) OperationOption {
+// 	return enableHandlerType(configkit.IntegrationHandlerType, enabled)
+// }
+
+// // EnableProjections returns an operation option that enables or disables
+// // projection message handlers.
+// //
+// // All handler types are enabled by default.
+// func EnableProjections(enabled bool) OperationOption {
+// 	return enableHandlerType(configkit.ProjectionHandlerType, enabled)
+// }
+
 func (t *Test) buildReport(e Expectation) {
 	t.t.Helper()
 
@@ -180,7 +214,12 @@ func (t *Test) buildReport(e Expectation) {
 }
 
 // buildOperationOptions builds the operation options to provide to each action.
-func (t *Test) buildOperationOptions() (options []engine.OperationOption) {
+func (t *Test) buildOperationOptions() []engine.OperationOption {
+	options := []engine.OperationOption{
+		engine.EnableProjections(false),
+		engine.EnableIntegrations(false),
+	}
+
 	options = append(options, t.operationOptions...)
 	options = append(options, engine.WithCurrentTime(t.now))
 	return options


### PR DESCRIPTION
#### What change does this introduce?

This PR adds the `engine.EnableHandler()` option which allows enabling/disabling individual handlers while dispatching a message or ticking the engine.

#### What issues does this relate to?

- Partially addresses #56
- Fixes #108

#### Why make this change?

In complex applications it will be necessary to enable/disable individual handlers in order to isolate tests to specific parts of the application. I suspect most likely this will occur when testing integrations and projections.

#### Is there anything you are unsure about?

This option takes precedence over the existing `Enable[Aggregates|Projections|Processes|Integrations]()` options. I'm not sure if `Enable` is quite the right word given that passing a value of `false` is a very explicit *disable*.

For example ...

```go
myEngine.Tick(
    ctx,
   engine.EnableHandler("some-aggregate", false),
   engine.EnableAggregates("foo", true),
)
```

The result of this is that all aggregates *except* `some-aggregate` are enabled; but I wonder if that is obvious given the order of the options.

I think the naming of the maps used to indicate which types/handlers are enabled/disabled inside the `fact` package could likely be improved too. I'm referring to fields like `fact.DispatchCycleBegun.EnabledHandlerTypes` and `EnabledHandlers`. 

In the case of `EnabledHandlerTypes` the map contains an entry for every handler type. Whereas `EnabledHandlers` only contains an entry for those handlers that were explicitly enabled or disabled.