### PR TITLE
Use more consistency terminology surrounding the "virtual clock".

### DIFF
--- a/action.go
+++ b/action.go
@@ -25,9 +25,9 @@ type Action interface {
 type ActionScope struct {
 	App              configkit.RichApplication
 	TestingT         TestingT
-	VirtualClock     *time.Time
+	Engine           *engine.Engine
 	Executor         *engine.CommandExecutor
 	Recorder         *engine.EventRecorder
-	Engine           *engine.Engine
+	VirtualClock     *time.Time
 	OperationOptions []engine.OperationOption
 }

--- a/advancetime_test.go
+++ b/advancetime_test.go
@@ -38,7 +38,7 @@ var _ = Describe("func AdvanceTime()", func() {
 		test = Begin(
 			t,
 			app,
-			WithStartTime(startTime),
+			StartVirtualClockAt(startTime),
 			WithOperationOptions(
 				engine.WithObserver(buf),
 			),

--- a/call_test.go
+++ b/call_test.go
@@ -67,7 +67,7 @@ var _ = Describe("func Call()", func() {
 		test = Begin(
 			t,
 			app,
-			WithStartTime(startTime),
+			StartVirtualClockAt(startTime),
 			WithOperationOptions(
 				engine.WithObserver(buf),
 			),

--- a/dispatchcommand_test.go
+++ b/dispatchcommand_test.go
@@ -53,7 +53,7 @@ var _ = Describe("func ExecuteCommand()", func() {
 		test = Begin(
 			t,
 			app,
-			WithStartTime(startTime),
+			StartVirtualClockAt(startTime),
 			WithOperationOptions(
 				engine.WithObserver(buf),
 			),

--- a/dispatchevent_test.go
+++ b/dispatchevent_test.go
@@ -55,7 +55,7 @@ var _ = Describe("func RecordEvent()", func() {
 		test = Begin(
 			t,
 			app,
-			WithStartTime(startTime),
+			StartVirtualClockAt(startTime),
 			WithOperationOptions(
 				engine.WithObserver(buf),
 			),

--- a/testoption.go
+++ b/testoption.go
@@ -9,11 +9,11 @@ import (
 // TestOption applies optional settings to a test.
 type TestOption func(*testOptions)
 
-// WithStartTime returns a test option that sets the time of the test runner's
-// clock at the start of the test.
+// StartVirtualClockAt returns a test option that sets initial the time of the
+// test's virtual clock.
 //
 // By default, the current system time is used.
-func WithStartTime(t time.Time) TestOption {
+func StartVirtualClockAt(t time.Time) TestOption {
 	return func(to *testOptions) {
 		to.time = t
 	}

--- a/testoption_test.go
+++ b/testoption_test.go
@@ -45,7 +45,7 @@ var _ = Describe("func WithStartTime()", func() {
 		Begin(
 			&testingmock.T{},
 			app,
-			WithStartTime(now),
+			StartVirtualClockAt(now),
 			WithOperationOptions(
 				engine.EnableProjections(true),
 			),


### PR DESCRIPTION
#### What change does this introduce?

This PR updates some internal terminology to refer to the test time as the "virtual clock" more consistently.

#### What issues does this relate to?

None

#### Why make this change?

Internal naming consistency.

#### Is there anything you are unsure about?

No