### PR TITLE
Rename `WithOperationOptions()` to `WithUnsafeOperationOptions()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ migrate tests from prior versions.
 - **[BC]** The function passed to `Call()` no longer returns an `error`
 - **[BC]** `engine.New()` and `MustNew()` now accept `configkit.RichApplication` (previously `dogma.Application`)
 - **[BC]** Rename `WithStartTime()` to `StartVirtualClockAt()`
+- **[BC]** Rename `WithOperationOptions()` to `WithUnsafeOperationOptions()`
 
 ### Removed
 

--- a/advancetime_test.go
+++ b/advancetime_test.go
@@ -39,7 +39,7 @@ var _ = Describe("func AdvanceTime()", func() {
 			t,
 			app,
 			StartVirtualClockAt(startTime),
-			WithOperationOptions(
+			WithUnsafeOperationOptions(
 				engine.WithObserver(buf),
 			),
 		)

--- a/assert/common_test.go
+++ b/assert/common_test.go
@@ -116,7 +116,7 @@ func runTest(
 	test := testkit.Begin(
 		t,
 		app,
-		testkit.WithOperationOptions(opts...),
+		testkit.WithUnsafeOperationOptions(opts...),
 	)
 
 	op(test)

--- a/call_test.go
+++ b/call_test.go
@@ -68,7 +68,7 @@ var _ = Describe("func Call()", func() {
 			t,
 			app,
 			StartVirtualClockAt(startTime),
-			WithOperationOptions(
+			WithUnsafeOperationOptions(
 				engine.WithObserver(buf),
 			),
 		)

--- a/dispatchcommand_test.go
+++ b/dispatchcommand_test.go
@@ -54,7 +54,7 @@ var _ = Describe("func ExecuteCommand()", func() {
 			t,
 			app,
 			StartVirtualClockAt(startTime),
-			WithOperationOptions(
+			WithUnsafeOperationOptions(
 				engine.WithObserver(buf),
 			),
 		)

--- a/dispatchevent_test.go
+++ b/dispatchevent_test.go
@@ -56,7 +56,7 @@ var _ = Describe("func RecordEvent()", func() {
 			t,
 			app,
 			StartVirtualClockAt(startTime),
-			WithOperationOptions(
+			WithUnsafeOperationOptions(
 				engine.WithObserver(buf),
 			),
 		)

--- a/test.go
+++ b/test.go
@@ -188,8 +188,8 @@ func (t *Test) buildReport(e Expectation) {
 
 // buildOperationOptions builds the operation options to provide to each action.
 func (t *Test) buildOperationOptions() []engine.OperationOption {
-	var options []engine.OperationOption
-	options = append(options, t.operationOptions...)
-	options = append(options, engine.WithCurrentTime(t.virtualClock))
-	return options
+	options := []engine.OperationOption{
+		engine.WithCurrentTime(t.virtualClock),
+	}
+	return append(options, t.operationOptions...)
 }

--- a/testoption.go
+++ b/testoption.go
@@ -19,9 +19,15 @@ func StartVirtualClockAt(st time.Time) TestOption {
 	}
 }
 
-// WithOperationOptions returns a TestOption that applies optional per-operation
-// settings when performing assertions.
-func WithOperationOptions(options ...engine.OperationOption) TestOption {
+// WithUnsafeOperationOptions returns a TestOption that applies a set of engine
+// operation options when performing any action.
+//
+// This function is provided for forward-compatibility with engine operations
+// and for low level control of the engine's behavior.
+//
+// The provided options may override options that the Test sets during its
+// normal operation and should be used with caution.
+func WithUnsafeOperationOptions(options ...engine.OperationOption) TestOption {
 	return func(t *Test) {
 		t.operationOptions = append(t.operationOptions, options...)
 	}

--- a/testoption_test.go
+++ b/testoption_test.go
@@ -46,7 +46,7 @@ var _ = Describe("func StartVirtualClockAt()", func() {
 			&testingmock.T{},
 			app,
 			StartVirtualClockAt(now),
-			WithOperationOptions(
+			WithUnsafeOperationOptions(
 				engine.EnableProjections(true),
 			),
 		).Prepare(


### PR DESCRIPTION
#### What change does this introduce?

This PR renames `WithOperationOptions()` to `WithUnsafeOperationOptions()`.
This is a `TestOption` that allows low level control of the engine used within the `Test`.'

#### What issues does this relate to?

Prepares for #156 

#### Why make this change?

We want to discourage the use of this function so that we can hide the internals of the engine behind the `Test` facade.

#### Is there anything you are unsure about?

No