### PR TITLE
`Test.EnableHandlers()` and `DisableHandlers()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ migrate tests from prior versions.
 - Add `testkit.ExecuteCommand()`, `RecordEvent()`, `AdvanceTime()` and `Call()`
 - Add `TimeAdjuster` interface, for use with `AdvanceTime()`
 - Add `engine.EnableHandler()`
+- Add `Test.EnableHandlers()` and `DisableHandlers()`
 - **[BC]** Add `TestingT.Failed()`, `Fatal()` and `Helper()` methods
 
 ### Changed

--- a/test.go
+++ b/test.go
@@ -162,6 +162,34 @@ func (t *Test) EventRecorder() dogma.EventRecorder {
 	return &t.recorder
 }
 
+// EnableHandlers enables a set of handlers by name.
+//
+// By default all integration and projection handlers are disabled.
+func (t *Test) EnableHandlers(names ...string) *Test {
+	for _, n := range names {
+		t.operationOptions = append(
+			t.operationOptions,
+			engine.EnableHandler(n, true),
+		)
+	}
+
+	return t
+}
+
+// DisableHandlers disables a set of handlers by name.
+//
+// By default all integration and projection handlers are disabled.
+func (t *Test) DisableHandlers(names ...string) *Test {
+	for _, n := range names {
+		t.operationOptions = append(
+			t.operationOptions,
+			engine.EnableHandler(n, false),
+		)
+	}
+
+	return t
+}
+
 func (t *Test) buildReport(e Expectation) {
 	t.t.Helper()
 

--- a/test_test.go
+++ b/test_test.go
@@ -1,0 +1,77 @@
+package testkit_test
+
+import (
+	"context"
+
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/testkit"
+	"github.com/dogmatiq/testkit/internal/testingmock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Test", func() {
+	Describe("func EnableHandlers()", func() {
+		It("enables the handler", func() {
+			called := false
+			app := &Application{
+				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+					c.Identity("<app>", "<app-key>")
+					c.RegisterProjection(&ProjectionMessageHandler{
+						ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+							c.Identity("<projection>", "<projection-key>")
+							c.ConsumesEventType(MessageE{})
+						},
+						HandleEventFunc: func(
+							_ context.Context,
+							_, _, _ []byte,
+							_ dogma.ProjectionEventScope,
+							_ dogma.Message,
+						) (bool, error) {
+							called = true
+							return true, nil
+						},
+					})
+				},
+			}
+
+			Begin(&testingmock.T{}, app).
+				EnableHandlers("<projection>").
+				Prepare(RecordEvent(MessageE1))
+
+			Expect(called).To(BeTrue())
+		})
+	})
+
+	Describe("func DisableHandlers()", func() {
+		It("disables the handler", func() {
+			app := &Application{
+				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+					c.Identity("<app>", "<app-key>")
+					c.RegisterAggregate(&AggregateMessageHandler{
+						ConfigureFunc: func(c dogma.AggregateConfigurer) {
+							c.Identity("<aggregate>", "<aggregate-key>")
+							c.ConsumesCommandType(MessageC{})
+							c.ProducesEventType(MessageE{})
+						},
+						RouteCommandToInstanceFunc: func(dogma.Message) string {
+							return "<instance>"
+						},
+						HandleCommandFunc: func(
+							dogma.AggregateRoot,
+							dogma.AggregateCommandScope,
+							dogma.Message,
+						) {
+							Fail("unexpected call")
+						},
+					})
+				},
+			}
+
+			Begin(&testingmock.T{}, app).
+				DisableHandlers("<aggregate>").
+				Prepare(ExecuteCommand(MessageC1))
+		})
+	})
+})

--- a/testoption_test.go
+++ b/testoption_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit"
-	"github.com/dogmatiq/testkit/engine"
 	"github.com/dogmatiq/testkit/internal/testingmock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,12 +45,9 @@ var _ = Describe("func StartVirtualClockAt()", func() {
 			&testingmock.T{},
 			app,
 			StartVirtualClockAt(now),
-			WithUnsafeOperationOptions(
-				engine.EnableProjections(true),
-			),
-		).Prepare(
-			RecordEvent(MessageA1),
-		)
+		).
+			EnableHandlers("<handler-name>").
+			Prepare(RecordEvent(MessageA1))
 
 		Expect(called).To(BeTrue())
 	})


### PR DESCRIPTION
#### What change does this introduce?

This PR adds the `Test.EnableHandlers()` and `DisableHandlers()` methods which can be used to enable/disable specific handlers by name for the duration of a test.

#### What issues does this relate to?

Fixes #156 

#### Why make this change?

Projections and integration handlers often have many dependencies. They are disabled by default when testing to allow tests that focus on business logic to avoid initialization of these dependencies. 

This change gives a mechanism to enable specific projections/integrations that need to be engaged during the test. 

After this change a user should no longer need to use the `engine` package when testing.

#### Is there anything you are unsure about?

No