### PR TITLE
Improve logging "banners".

### DIFF
--- a/action.go
+++ b/action.go
@@ -13,6 +13,13 @@ import (
 // Actions always attempt to cause some state change within the engine or
 // application.
 type Action interface {
+	// Banner returns a human-readable banner to display in the logs when this
+	// action is applied.
+	//
+	// The banner text should be in uppercase, and worded in the present tense,
+	// for example "DOING ACTION".
+	Banner() string
+
 	// ExpectOptions returns the options to use by default when this action is
 	// used with Test.Expect().
 	ExpectOptions() []ExpectOption

--- a/action_test.go
+++ b/action_test.go
@@ -13,5 +13,6 @@ var noop noopAction
 // testing the test system itself.
 type noopAction struct{}
 
+func (noopAction) Banner() string                                 { return "NO-OP" }
 func (noopAction) ExpectOptions() []ExpectOption                  { return nil }
 func (noopAction) Apply(ctx context.Context, s ActionScope) error { return nil }

--- a/action_test.go
+++ b/action_test.go
@@ -13,6 +13,6 @@ var noop noopAction
 // testing the test system itself.
 type noopAction struct{}
 
-func (noopAction) Banner() string                                 { return "NO-OP" }
+func (noopAction) Banner() string                                 { return "[NO-OP]" }
 func (noopAction) ExpectOptions() []ExpectOption                  { return nil }
 func (noopAction) Apply(ctx context.Context, s ActionScope) error { return nil }

--- a/advancetime.go
+++ b/advancetime.go
@@ -66,6 +66,18 @@ type advanceTime struct {
 	adj TimeAdjustment
 }
 
+// Banner returns a human-readable banner to display in the logs when this
+// action is applied.
+//
+// The banner text should be in uppercase, and worded in the present tense,
+// for example "DOING ACTION".
+func (a advanceTime) Banner() string {
+	return fmt.Sprintf(
+		"ADVANCING TIME (%s)",
+		a.adj.Description(),
+	)
+}
+
 // ExpectOptions returns the options to use by default when this action is
 // used with Test.Expect().
 func (a advanceTime) ExpectOptions() []ExpectOption {
@@ -91,12 +103,6 @@ func (a advanceTime) Apply(ctx context.Context, s ActionScope) error {
 	s.OperationOptions = append(
 		s.OperationOptions,
 		engine.WithCurrentTime(now),
-	)
-
-	logf(
-		s.TestingT,
-		"--- ADVANCING TIME (%s) ---",
-		a.adj.Description(),
 	)
 
 	return s.Engine.Tick(ctx, s.OperationOptions...)

--- a/advancetime_test.go
+++ b/advancetime_test.go
@@ -113,7 +113,7 @@ var _ = Describe("func AdvanceTime()", func() {
 			))
 		})
 
-		It("logs a suitable heading", func() {
+		It("produces the expected banner", func() {
 			test.Prepare(
 				AdvanceTime(ToTime(targetTime)),
 			)
@@ -144,7 +144,7 @@ var _ = Describe("func AdvanceTime()", func() {
 			))
 		})
 
-		It("logs a suitable heading", func() {
+		It("produces the expected banner", func() {
 			test.Prepare(
 				AdvanceTime(ByDuration(3 * time.Second)),
 			)

--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -25,6 +25,13 @@ type ExpectOptionSet struct {
 type Assertion interface {
 	fact.Observer
 
+	// Banner returns a human-readable banner to display in the logs when this
+	// expectation is used.
+	//
+	// The banner text should be in uppercase, and complete the sentence "The
+	// application is expected ...". For example, "TO DO A THING".
+	Banner() string
+
 	// Begin is called to prepare the assertion for a new test.
 	Begin(o ExpectOptionSet)
 

--- a/assert/message.go
+++ b/assert/message.go
@@ -79,6 +79,19 @@ type messageAssertion struct {
 	tracker tracker
 }
 
+// Banner returns a human-readable banner to display in the logs when this
+// expectation is used.
+//
+// The banner text should be in uppercase, and complete the sentence "The
+// application is expected ...". For example, "TO DO A THING".
+func (a *messageAssertion) Banner() string {
+	return inflect.Sprintf(
+		a.role,
+		"TO <PRODUCE> A SPECIFIC '%s' <MESSAGE>",
+		message.TypeOf(a.expected),
+	)
+}
+
 // Begin is called to prepare the assertion for a new test.
 func (a *messageAssertion) Begin(o ExpectOptionSet) {
 	// reset everything

--- a/assert/messagetype.go
+++ b/assert/messagetype.go
@@ -55,6 +55,19 @@ type messageTypeAssertion struct {
 	tracker tracker
 }
 
+// Banner returns a human-readable banner to display in the logs when this
+// expectation is used.
+//
+// The banner text should be in uppercase, and complete the sentence "The
+// application is expected ...". For example, "TO DO A THING".
+func (a *messageTypeAssertion) Banner() string {
+	return inflect.Sprintf(
+		a.role,
+		"TO <PRODUCE> ANY '%s' <MESSAGE>",
+		a.expected,
+	)
+}
+
 // Begin is called to prepare the assertion for a new test.
 func (a *messageTypeAssertion) Begin(o ExpectOptionSet) {
 	// reset everything

--- a/call.go
+++ b/call.go
@@ -28,6 +28,15 @@ type call struct {
 	fn func()
 }
 
+// Banner returns a human-readable banner to display in the logs when this
+// action is applied.
+//
+// The banner text should be in uppercase, and worded in the present tense,
+// for example "DOING ACTION".
+func (a call) Banner() string {
+	return "CALLING USER-DEFINED FUNCTION"
+}
+
 // ExpectOptions returns the options to use by default when this action is
 // used with Test.Expect().
 func (a call) ExpectOptions() []ExpectOption {

--- a/call_test.go
+++ b/call_test.go
@@ -172,7 +172,7 @@ var _ = Describe("func Call()", func() {
 		)
 	})
 
-	It("logs a suitable heading", func() {
+	It("produces the expected banner", func() {
 		test.Prepare(
 			Call(func() {}),
 		)

--- a/composite.go
+++ b/composite.go
@@ -21,8 +21,9 @@ func AllOf(children ...Expectation) Expectation {
 	}
 
 	return &compositeExpectation{
-		Criteria: "all of",
-		Children: children,
+		BannerText: fmt.Sprintf("TO MEET %d EXPECTATIONS", n),
+		Criteria:   "all of",
+		Children:   children,
 		Predicate: func(passed int) (string, bool) {
 			if passed == n {
 				return "", true
@@ -49,8 +50,9 @@ func AnyOf(children ...Expectation) Expectation {
 	}
 
 	return &compositeExpectation{
-		Criteria: "any of",
-		Children: children,
+		BannerText: fmt.Sprintf("TO MEET AT LEAST ONE OF %d EXPECTATIONS", n),
+		Criteria:   "any of",
+		Children:   children,
 		Predicate: func(passed int) (string, bool) {
 			if passed > 0 {
 				return "", true
@@ -72,9 +74,15 @@ func NoneOf(children ...Expectation) Expectation {
 		panic("NoneOf(): at least one child expectation must be provided")
 	}
 
+	banner := fmt.Sprintf("NOT TO MEET ANY OF %d EXPECTATIONS", n)
+	if n == 1 {
+		banner = fmt.Sprintf("NOT %s", children[0].Banner())
+	}
+
 	return &compositeExpectation{
-		Criteria: "none of",
-		Children: children,
+		BannerText: banner,
+		Criteria:   "none of",
+		Children:   children,
 		Predicate: func(passed int) (string, bool) {
 			if passed == 0 {
 				return "", true
@@ -95,6 +103,10 @@ func NoneOf(children ...Expectation) Expectation {
 // compositeExpectation is an expectation that runs several child expectations.
 // Its final result is determined by a predicate function.
 type compositeExpectation struct {
+	// BannerText is a human-readable banner to display in the logs when this
+	// expectation is used.
+	BannerText string
+
 	// Criteria is a brief description of the expectation that must be met.
 	Criteria string
 
@@ -117,6 +129,15 @@ type compositeExpectation struct {
 	//
 	// It is populated the first time Ok() is called.
 	outcome string
+}
+
+// Banner returns a human-readable banner to display in the logs when this
+// expectation is used.
+//
+// The banner text should be in uppercase, and complete the sentence "The
+// application is expected ...". For example, "TO DO A THING".
+func (e *compositeExpectation) Banner() string {
+	return e.BannerText
 }
 
 // Notify notifies the expectation of the occurrence of a fact.

--- a/composite_test.go
+++ b/composite_test.go
@@ -86,6 +86,17 @@ var _ = Context("composite expectations", func() {
 			),
 		)
 
+		It("produces the expected banner", func() {
+			test.Expect(
+				noop,
+				AllOf(pass, fail),
+			)
+
+			Expect(testingT.Logs).To(ContainElement(
+				"--- EXPECT [NO-OP] TO MEET 2 EXPECTATIONS ---",
+			))
+		})
+
 		It("panics if no children are provided", func() {
 			Expect(func() {
 				AllOf()
@@ -136,6 +147,17 @@ var _ = Context("composite expectations", func() {
 				),
 			),
 		)
+
+		It("produces the expected banner", func() {
+			test.Expect(
+				noop,
+				AnyOf(pass, fail),
+			)
+
+			Expect(testingT.Logs).To(ContainElement(
+				"--- EXPECT [NO-OP] TO MEET AT LEAST ONE OF 2 EXPECTATIONS ---",
+			))
+		})
 
 		It("panics if no children are provided", func() {
 			Expect(func() {
@@ -188,6 +210,28 @@ var _ = Context("composite expectations", func() {
 				),
 			),
 		)
+
+		It("produces the expected banner", func() {
+			test.Expect(
+				noop,
+				NoneOf(pass, fail),
+			)
+
+			Expect(testingT.Logs).To(ContainElement(
+				"--- EXPECT [NO-OP] NOT TO MEET ANY OF 2 EXPECTATIONS ---",
+			))
+		})
+
+		It("produces the expected banner when there is only one child", func() {
+			test.Expect(
+				noop,
+				NoneOf(pass),
+			)
+
+			Expect(testingT.Logs).To(ContainElement(
+				"--- EXPECT [NO-OP] NOT TO [ALWAYS PASS] ---",
+			))
+		})
 
 		It("panics if no children are provided", func() {
 			Expect(func() {

--- a/dispatch.go
+++ b/dispatch.go
@@ -41,7 +41,7 @@ type dispatch struct {
 func (a dispatch) Banner() string {
 	return inflect.Sprintf(
 		a.r,
-		"<PRODUCING> TEST <MESSAGE> (%T)",
+		"<PRODUCING> %T <MESSAGE>",
 		a.m,
 	)
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -33,12 +33,12 @@ type dispatch struct {
 	m dogma.Message
 }
 
-// Heading returns a human-readable description of the action, used as a
-// heading within the test report.
+// Banner returns a human-readable banner to display in the logs when this
+// action is applied.
 //
-// Any engine activity as a result of this action is logged beneath this
-// heading.
-func (a dispatch) Heading() string {
+// The banner text should be in uppercase, and worded in the present tense,
+// for example "DOING ACTION".
+func (a dispatch) Banner() string {
 	return inflect.Sprintf(
 		a.r,
 		"<PRODUCING> TEST <MESSAGE> (%T)",
@@ -74,15 +74,6 @@ func (a dispatch) Apply(ctx context.Context, s ActionScope) error {
 			),
 		)
 	}
-
-	log(
-		s.TestingT,
-		inflect.Sprintf(
-			a.r,
-			"--- <PRODUCING> TEST <MESSAGE> (%T) ---",
-			a.m,
-		),
-	)
 
 	return s.Engine.Dispatch(ctx, a.m, s.OperationOptions...)
 }

--- a/dispatchcommand_test.go
+++ b/dispatchcommand_test.go
@@ -125,13 +125,13 @@ var _ = Describe("func ExecuteCommand()", func() {
 		Expect(t.Failed()).To(BeTrue())
 	})
 
-	It("logs a suitable heading", func() {
+	It("produces the expected banner", func() {
 		test.Prepare(
 			ExecuteCommand(MessageC1),
 		)
 
 		Expect(t.Logs).To(ContainElement(
-			"--- EXECUTING TEST COMMAND (fixtures.MessageC) ---",
+			"--- EXECUTING fixtures.MessageC COMMAND ---",
 		))
 	})
 

--- a/dispatchevent_test.go
+++ b/dispatchevent_test.go
@@ -127,13 +127,13 @@ var _ = Describe("func RecordEvent()", func() {
 		Expect(t.Failed()).To(BeTrue())
 	})
 
-	It("logs a suitable heading", func() {
+	It("produces the expected banner", func() {
 		test.Prepare(
 			RecordEvent(MessageE1),
 		)
 
 		Expect(t.Logs).To(ContainElement(
-			"--- RECORDING TEST EVENT (fixtures.MessageE) ---",
+			"--- RECORDING fixtures.MessageE EVENT ---",
 		))
 	})
 

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -19,6 +19,14 @@ const (
 // It is intended to be used for testing the test system itself.
 type staticExpectation bool
 
+func (a staticExpectation) Banner() string {
+	if a {
+		return "TO [ALWAYS PASS]"
+	}
+
+	return "TO [ALWAYS FAIL]"
+}
+
 func (a staticExpectation) Begin(ExpectOptionSet) {}
 func (a staticExpectation) End()                  {}
 func (a staticExpectation) Ok() bool              { return bool(a) }

--- a/satisfy.go
+++ b/satisfy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/dogmatiq/testkit/assert"
@@ -25,6 +26,7 @@ func ToSatisfy(
 	x func(*SatisfyT),
 ) Expectation {
 	return &toSatisfy{
+		c: d,
 		t: SatisfyT{name: d},
 		x: x,
 	}
@@ -33,8 +35,18 @@ func ToSatisfy(
 // toSatisfy is an expectation that calls a function to check for specific
 // criteria.
 type toSatisfy struct {
+	c string
 	t SatisfyT
 	x func(*SatisfyT)
+}
+
+// Banner returns a human-readable banner to display in the logs when this
+// expectation is used.
+//
+// The banner text should be in uppercase, and complete the sentence "The
+// application is expected ...". For example, "TO DO A THING".
+func (e *toSatisfy) Banner() string {
+	return "TO " + strings.ToUpper(e.c)
 }
 
 // Notify the observer of a fact.
@@ -82,7 +94,7 @@ func (e *toSatisfy) BuildReport(ok bool, r render.Renderer) *assert.Report {
 	rep := &assert.Report{
 		TreeOk:   ok,
 		Ok:       e.Ok(),
-		Criteria: e.t.name,
+		Criteria: e.c,
 	}
 
 	if e.t.skipped {

--- a/satisfy_test.go
+++ b/satisfy_test.go
@@ -227,6 +227,20 @@ var _ = Describe("func ToSatisfy()", func() {
 		),
 	)
 
+	It("produces the expected banner", func() {
+		test.Expect(
+			noop,
+			ToSatisfy(
+				"<criteria>",
+				func(*SatisfyT) {},
+			),
+		)
+
+		Expect(testingT.Logs).To(ContainElement(
+			"--- EXPECT [NO-OP] TO <CRITERIA> ---",
+		))
+	})
+
 	Describe("type SatisfyT", func() {
 		run := func(x func(*SatisfyT)) {
 			test.Expect(

--- a/test.go
+++ b/test.go
@@ -138,7 +138,7 @@ func (t *Test) Expect(act Action, e Expectation, options ...ExpectOption) {
 	func() {
 		defer e.End()
 
-		logf(t.t, "--- %s ---", act.Banner())
+		logf(t.t, "--- EXPECT %s %s ---", act.Banner(), e.Banner())
 		if err := act.Apply(t.ctx, s); err != nil {
 			t.t.Fatal(err)
 		}

--- a/test.go
+++ b/test.go
@@ -95,10 +95,8 @@ func (t *Test) Prepare(actions ...Action) *Test {
 			OperationOptions: t.buildOperationOptions(),
 		}
 
-		if err := act.Apply(
-			t.ctx,
-			s,
-		); err != nil {
+		logf(t.t, "--- %s ---", act.Banner())
+		if err := act.Apply(t.ctx, s); err != nil {
 			t.t.Fatal(err)
 		}
 	}
@@ -140,6 +138,7 @@ func (t *Test) Expect(act Action, e Expectation, options ...ExpectOption) {
 	func() {
 		defer e.End()
 
+		logf(t.t, "--- %s ---", act.Banner())
 		if err := act.Apply(t.ctx, s); err != nil {
 			t.t.Fatal(err)
 		}


### PR DESCRIPTION
#### What change does this introduce?

This PR formalizes the concept of the "banners" that are rendered in the test logs when an action is performed.

#### What issues does this relate to?

In preparation for #162 

#### Why make this change?

Actions are expected to render a banner before they produce any other log output. By adding the `Action.Banner()` method and performing the logging in `Test` we make `Action` implementors aware of this requirement.

By adding `Expectation.Banner()` we can improve the banners logged via `Expect()` to include information about the expectation as well.

For example, if you run the following test:

```go
test.Expect(
    ExecuteCommand(ChangeEmailAddress{}),
    assert.EventRecorded(EmailAddressChanged{}),
)
```

The banner shown in the logs will be:

```
--- EXPECT EXECUTING ChangeEmailAddress COMMAND TO RECORD A SPECIFIC EmailAddressChanged EVENT ---
```

#### Is there anything you are unsure about?

No