### PR TITLE
Add functions for getting the location of functions and calls.

### DIFF
--- a/engine/panicx/linenumber_test.go
+++ b/engine/panicx/linenumber_test.go
@@ -1,0 +1,53 @@
+package panicx_test
+
+// This file contains definitions used within tests that check for specific line
+// numbers. To minimize test disruption edit this file as infrequently as
+// possible.
+//
+// New additions should always be made at the end so that the line numbers of
+// existing definitions do not change. The padding below can be removed as
+// imports statements added.
+
+import (
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/testkit/engine/panicx"
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+	// import padding
+)
+
+func doNothing()                     {}
+func panicWithUnexpectedMessage()    { panic(dogma.UnexpectedMessage) }
+func locationOfCallLayer1() Location { return LocationOfCall() }
+func locationOfCallLayer2() Location { return locationOfCallLayer1() }

--- a/engine/panicx/linenumber_test.go
+++ b/engine/panicx/linenumber_test.go
@@ -51,3 +51,7 @@ func doNothing()                     {}
 func panicWithUnexpectedMessage()    { panic(dogma.UnexpectedMessage) }
 func locationOfCallLayer1() Location { return LocationOfCall() }
 func locationOfCallLayer2() Location { return locationOfCallLayer1() }
+
+type locationOfMethodT struct{}
+
+func (locationOfMethodT) Method() {}

--- a/engine/panicx/location.go
+++ b/engine/panicx/location.go
@@ -42,7 +42,10 @@ func (l Location) String() string {
 
 // LocationOfFunc returns the location of the definition of fn.
 func LocationOfFunc(fn interface{}) Location {
-	rv := reflect.ValueOf(fn)
+	return locationOfFunc(reflect.ValueOf(fn))
+}
+
+func locationOfFunc(rv reflect.Value) Location {
 	if rv.Kind() != reflect.Func {
 		panic("fn must be a function")
 	}
@@ -58,6 +61,18 @@ func LocationOfFunc(fn interface{}) Location {
 	}
 
 	return loc
+}
+
+// LocationOfMethod returns the location of the definition of fn.
+func LocationOfMethod(recv interface{}, m string) Location {
+	rt := reflect.TypeOf(recv)
+
+	rm, ok := rt.MethodByName(m)
+	if !ok {
+		panic("method does not exist")
+	}
+
+	return locationOfFunc(rm.Func)
 }
 
 // LocationOfCall returns the location where its caller was called itself.

--- a/engine/panicx/location_test.go
+++ b/engine/panicx/location_test.go
@@ -22,7 +22,7 @@ var _ = Describe("type Location", func() {
 			))
 		})
 
-		It("returns an empty location if the value is not a function", func() {
+		It("panics value is not a function", func() {
 			Expect(func() {
 				LocationOfFunc("<not a function>")
 			}).To(PanicWith("fn must be a function"))
@@ -40,6 +40,12 @@ var _ = Describe("type Location", func() {
 					"Line": Equal(57),
 				},
 			))
+		})
+
+		It("panics if the methods does not exist", func() {
+			Expect(func() {
+				LocationOfMethod(locationOfMethodT{}, "DoesNotExist")
+			}).To(PanicWith("method does not exist"))
 		})
 	})
 

--- a/engine/panicx/location_test.go
+++ b/engine/panicx/location_test.go
@@ -5,9 +5,44 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("type Location", func() {
+	Describe("func LocationOfFunc()", func() {
+		It("returns the expected location", func() {
+			loc := LocationOfFunc(doNothing)
+
+			Expect(loc).To(MatchAllFields(
+				Fields{
+					"Func": Equal("github.com/dogmatiq/testkit/engine/panicx_test.doNothing"),
+					"File": HaveSuffix("/engine/panicx/linenumber_test.go"),
+					"Line": Equal(50),
+				},
+			))
+		})
+
+		It("returns an empty location if the value is not a function", func() {
+			Expect(func() {
+				LocationOfFunc("<not a function>")
+			}).To(PanicWith("fn must be a function"))
+		})
+	})
+
+	Describe("func LocationOfCall()", func() {
+		It("returns the expected location", func() {
+			loc := locationOfCallLayer2()
+
+			Expect(loc).To(MatchAllFields(
+				Fields{
+					"Func": Equal("github.com/dogmatiq/testkit/engine/panicx_test.locationOfCallLayer2"),
+					"File": HaveSuffix("/engine/panicx/linenumber_test.go"),
+					"Line": Equal(53),
+				},
+			))
+		})
+	})
+
 	Describe("func String()", func() {
 		DescribeTable(
 			"it returns the expectation string",

--- a/engine/panicx/location_test.go
+++ b/engine/panicx/location_test.go
@@ -29,6 +29,20 @@ var _ = Describe("type Location", func() {
 		})
 	})
 
+	Describe("func LocationOfMethod()", func() {
+		It("returns the expected location", func() {
+			loc := LocationOfMethod(locationOfMethodT{}, "Method")
+
+			Expect(loc).To(MatchAllFields(
+				Fields{
+					"Func": Equal("github.com/dogmatiq/testkit/engine/panicx_test.locationOfMethodT.Method"),
+					"File": HaveSuffix("/engine/panicx/linenumber_test.go"),
+					"Line": Equal(57),
+				},
+			))
+		})
+	})
+
 	Describe("func LocationOfCall()", func() {
 		It("returns the expected location", func() {
 			loc := locationOfCallLayer2()

--- a/engine/panicx/unexpectedmessage_test.go
+++ b/engine/panicx/unexpectedmessage_test.go
@@ -109,8 +109,8 @@ var _ = Describe("func EnrichUnexpectedMessage()", func() {
 					"PanicLocation": MatchAllFields(
 						Fields{
 							"Func": Equal("github.com/dogmatiq/testkit/engine/panicx_test.panicWithUnexpectedMessage"),
-							"File": HaveSuffix("/engine/panicx/unexpectedmessage_test.go"),
-							"Line": Equal(123),
+							"File": HaveSuffix("/engine/panicx/linenumber_test.go"),
+							"Line": Equal(51),
 						},
 					),
 				},
@@ -118,7 +118,3 @@ var _ = Describe("func EnrichUnexpectedMessage()", func() {
 		))
 	})
 })
-
-func panicWithUnexpectedMessage() {
-	panic(dogma.UnexpectedMessage)
-}


### PR DESCRIPTION
#### What change does this introduce?

This PR adds `panicx.LocationOfFunc()`, `LocationOfMethod()` and `LocationOfCall()`.

#### What issues does this relate to?

Prepares for #162 

#### Why make this change?

We need to find the location of various handler method implementations in order to make good suggestions in test reports.

#### Is there anything you are unsure about?

No