### PR TITLE
Add `panicx.UnexpectedBehavior`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ migrate tests from prior versions.
 - Add `TimeAdjuster` interface, for use with `AdvanceTime()`
 - Add `engine.EnableHandler()`
 - Add `Test.EnableHandlers()` and `DisableHandlers()`
-- Add `panicx.Location`
+- Add `engine/panicx` package
 - **[BC]** Add `TestingT.Failed()`, `Fatal()` and `Helper()` methods
 
 ### Changed

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -58,20 +58,29 @@ func (c *Controller) Handle(
 	)
 
 	if id == "" {
-		panic(fmt.Sprintf(
-			"the '%s' aggregate message handler attempted to route a %s command to an empty instance ID",
-			c.Config.Identity().Name,
-			message.TypeOf(env.Message),
-		))
+		panic(panicx.UnexpectedBehavior{
+			Handler:        c.Config,
+			Interface:      "AggregateMessageHandler",
+			Method:         "RouteCommandToInstance",
+			Implementation: c.Config.Handler(),
+			Message:        env.Message,
+			Description:    fmt.Sprintf("routed command of type %T to an empty instance ID", env.Message),
+			Location:       panicx.LocationOfMethod(c.Config.Handler(), "RouteCommandToInstance"),
+		})
 	}
 
 	history, exists := c.history[id]
 	r := c.Config.Handler().New()
 	if r == nil {
-		panic(fmt.Sprintf(
-			"the '%s' aggregate message handler returned a nil root from New()",
-			c.Config.Identity().Name,
-		))
+		panic(panicx.UnexpectedBehavior{
+			Handler:        c.Config,
+			Interface:      "AggregateMessageHandler",
+			Method:         "New",
+			Implementation: c.Config.Handler(),
+			Message:        env.Message,
+			Description:    "returned a nil AggregateRoot",
+			Location:       panicx.LocationOfMethod(c.Config.Handler(), "New"),
+		})
 	}
 
 	if exists {

--- a/engine/controller/aggregate/controller.go
+++ b/engine/controller/aggregate/controller.go
@@ -64,7 +64,7 @@ func (c *Controller) Handle(
 			Method:         "RouteCommandToInstance",
 			Implementation: c.Config.Handler(),
 			Message:        env.Message,
-			Description:    fmt.Sprintf("routed command of type %T to an empty instance ID", env.Message),
+			Description:    fmt.Sprintf("routed a command of type %T to an empty instance ID", env.Message),
 			Location:       panicx.LocationOfMethod(c.Config.Handler(), "RouteCommandToInstance"),
 		})
 	}

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -173,7 +173,25 @@ var _ = Describe("type Controller", func() {
 					time.Now(),
 					command,
 				)
-			}).To(PanicWith("the '<name>' aggregate message handler attempted to route a fixtures.MessageC command to an empty instance ID"))
+			}).To(PanicWith(
+				MatchAllFields(
+					Fields{
+						"Handler":        Equal(config),
+						"Interface":      Equal("AggregateMessageHandler"),
+						"Method":         Equal("RouteCommandToInstance"),
+						"Implementation": Equal(config.Handler()),
+						"Message":        Equal(command.Message),
+						"Description":    Equal("routed command of type fixtures.MessageC to an empty instance ID"),
+						"Location": MatchAllFields(
+							Fields{
+								"Func": Not(BeEmpty()),
+								"File": HaveSuffix("/fixtures/aggregate.go"), // from dogmatiq/dogma module
+								"Line": Not(BeZero()),
+							},
+						),
+					},
+				),
+			))
 		})
 
 		When("the instance does not exist", func() {
@@ -227,7 +245,25 @@ var _ = Describe("type Controller", func() {
 						time.Now(),
 						command,
 					)
-				}).To(PanicWith("the '<name>' aggregate message handler returned a nil root from New()"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("AggregateMessageHandler"),
+							"Method":         Equal("New"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(command.Message),
+							"Description":    Equal("returned a nil AggregateRoot"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/fixtures/aggregate.go"), // from dogmatiq/dogma module
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 

--- a/engine/controller/aggregate/controller_test.go
+++ b/engine/controller/aggregate/controller_test.go
@@ -181,7 +181,7 @@ var _ = Describe("type Controller", func() {
 						"Method":         Equal("RouteCommandToInstance"),
 						"Implementation": Equal(config.Handler()),
 						"Message":        Equal(command.Message),
-						"Description":    Equal("routed command of type fixtures.MessageC to an empty instance ID"),
+						"Description":    Equal("routed a command of type fixtures.MessageC to an empty instance ID"),
 						"Location": MatchAllFields(
 							Fields{
 								"Func": Not(BeEmpty()),

--- a/engine/controller/aggregate/scope.go
+++ b/engine/controller/aggregate/scope.go
@@ -46,19 +46,27 @@ func (s *scope) Destroy() {
 
 func (s *scope) RecordEvent(m dogma.Message) {
 	if !s.config.MessageTypes().Produced.HasM(m) {
-		panic(fmt.Sprintf(
-			"the '%s' handler is not configured to record events of type %T",
-			s.config.Identity().Name,
-			m,
-		))
+		panic(panicx.UnexpectedBehavior{
+			Handler:        s.config,
+			Interface:      "AggregateMessageHandler",
+			Method:         "HandleCommand",
+			Implementation: s.config.Handler(),
+			Message:        s.command.Message,
+			Description:    fmt.Sprintf("recorded an event of type %T, which is not produced by this handler", m),
+			Location:       panicx.LocationOfCall(),
+		})
 	}
 
 	if err := dogma.ValidateMessage(m); err != nil {
-		panic(fmt.Sprintf(
-			"can not record event of type %T, it is invalid: %s",
-			m,
-			err,
-		))
+		panic(panicx.UnexpectedBehavior{
+			Handler:        s.config,
+			Interface:      "AggregateMessageHandler",
+			Method:         "HandleCommand",
+			Implementation: s.config.Handler(),
+			Message:        s.command.Message,
+			Description:    fmt.Sprintf("recorded an invalid %T event: %s", m, err),
+			Location:       panicx.LocationOfCall(),
+		})
 	}
 
 	if !s.exists {

--- a/engine/controller/aggregate/scope_test.go
+++ b/engine/controller/aggregate/scope_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dogmatiq/testkit/engine/fact"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("type scope", func() {
@@ -333,7 +334,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						command,
 					)
-				}).To(PanicWith("the '<name>' handler is not configured to record events of type fixtures.MessageX"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("AggregateMessageHandler"),
+							"Method":         Equal("HandleCommand"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(command.Message),
+							"Description":    Equal("recorded an event of type fixtures.MessageX, which is not produced by this handler"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/aggregate/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 
 			It("panics if the event is invalid", func() {
@@ -354,7 +373,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						command,
 					)
-				}).To(PanicWith("can not record event of type fixtures.MessageE, it is invalid: <invalid>"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("AggregateMessageHandler"),
+							"Method":         Equal("HandleCommand"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(command.Message),
+							"Description":    Equal("recorded an invalid fixtures.MessageE event: <invalid>"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/aggregate/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 	})

--- a/engine/controller/integration/scope.go
+++ b/engine/controller/integration/scope.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/envelope"
 	"github.com/dogmatiq/testkit/engine/fact"
+	"github.com/dogmatiq/testkit/engine/panicx"
 )
 
 // scope is an implementation of dogma.IntegrationCommandScope.
@@ -22,19 +23,27 @@ type scope struct {
 
 func (s *scope) RecordEvent(m dogma.Message) {
 	if !s.config.MessageTypes().Produced.HasM(m) {
-		panic(fmt.Sprintf(
-			"the '%s' handler is not configured to record events of type %T",
-			s.config.Identity().Name,
-			m,
-		))
+		panic(panicx.UnexpectedBehavior{
+			Handler:        s.config,
+			Interface:      "IntegrationMessageHandler",
+			Method:         "HandleCommand",
+			Implementation: s.config.Handler(),
+			Message:        s.command.Message,
+			Description:    fmt.Sprintf("recorded an event of type %T, which is not produced by this handler", m),
+			Location:       panicx.LocationOfCall(),
+		})
 	}
 
 	if err := dogma.ValidateMessage(m); err != nil {
-		panic(fmt.Sprintf(
-			"can not record event of type %T, it is invalid: %s",
-			m,
-			err,
-		))
+		panic(panicx.UnexpectedBehavior{
+			Handler:        s.config,
+			Interface:      "IntegrationMessageHandler",
+			Method:         "HandleCommand",
+			Implementation: s.config.Handler(),
+			Message:        s.command.Message,
+			Description:    fmt.Sprintf("recorded an invalid %T event: %s", m, err),
+			Location:       panicx.LocationOfCall(),
+		})
 	}
 
 	env := s.command.NewEvent(

--- a/engine/controller/integration/scope_test.go
+++ b/engine/controller/integration/scope_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dogmatiq/testkit/engine/fact"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("type scope", func() {
@@ -106,7 +107,25 @@ var _ = Describe("type scope", func() {
 					time.Now(),
 					command,
 				)
-			}).To(PanicWith("the '<name>' handler is not configured to record events of type fixtures.MessageX"))
+			}).To(PanicWith(
+				MatchAllFields(
+					Fields{
+						"Handler":        Equal(config),
+						"Interface":      Equal("IntegrationMessageHandler"),
+						"Method":         Equal("HandleCommand"),
+						"Implementation": Equal(config.Handler()),
+						"Message":        Equal(command.Message),
+						"Description":    Equal("recorded an event of type fixtures.MessageX, which is not produced by this handler"),
+						"Location": MatchAllFields(
+							Fields{
+								"Func": Not(BeEmpty()),
+								"File": HaveSuffix("/engine/controller/integration/scope_test.go"),
+								"Line": Not(BeZero()),
+							},
+						),
+					},
+				),
+			))
 		})
 
 		It("panics if the event is invalid", func() {
@@ -128,7 +147,25 @@ var _ = Describe("type scope", func() {
 					time.Now(),
 					command,
 				)
-			}).To(PanicWith("can not record event of type fixtures.MessageE, it is invalid: <invalid>"))
+			}).To(PanicWith(
+				MatchAllFields(
+					Fields{
+						"Handler":        Equal(config),
+						"Interface":      Equal("IntegrationMessageHandler"),
+						"Method":         Equal("HandleCommand"),
+						"Implementation": Equal(config.Handler()),
+						"Message":        Equal(command.Message),
+						"Description":    Equal("recorded an invalid fixtures.MessageE event: <invalid>"),
+						"Location": MatchAllFields(
+							Fields{
+								"Func": Not(BeEmpty()),
+								"File": HaveSuffix("/engine/controller/integration/scope_test.go"),
+								"Line": Not(BeZero()),
+							},
+						),
+					},
+				),
+			))
 		})
 	})
 

--- a/engine/controller/process/controller_test.go
+++ b/engine/controller/process/controller_test.go
@@ -757,7 +757,25 @@ var _ = Describe("type Controller", func() {
 					time.Now(),
 					event,
 				)
-			}).To(PanicWith("the '<name>' process message handler attempted to route a fixtures.MessageE event to an empty instance ID"))
+			}).To(PanicWith(
+				MatchAllFields(
+					Fields{
+						"Handler":        Equal(config),
+						"Interface":      Equal("ProcessMessageHandler"),
+						"Method":         Equal("RouteEventToInstance"),
+						"Implementation": Equal(config.Handler()),
+						"Message":        Equal(event.Message),
+						"Description":    Equal("routed an event of type fixtures.MessageE to an empty instance ID"),
+						"Location": MatchAllFields(
+							Fields{
+								"Func": Not(BeEmpty()),
+								"File": HaveSuffix("/fixtures/process.go"), // from dogmatiq/dogma module
+								"Line": Not(BeZero()),
+							},
+						),
+					},
+				),
+			))
 		})
 
 		When("the instance does not exist", func() {
@@ -792,7 +810,25 @@ var _ = Describe("type Controller", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("the '<name>' process message handler returned a nil root from New()"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("New"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("returned a nil ProcessRoot"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/fixtures/process.go"), // from dogmatiq/dogma module
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 

--- a/engine/controller/process/scope_test.go
+++ b/engine/controller/process/scope_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dogmatiq/testkit/engine/fact"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("type scope", func() {
@@ -102,7 +103,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("can not access process root of non-existent instance"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("accessed the root of a process instance that has not begun"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 
@@ -175,7 +194,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("can not end non-existent instance"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("ended a process instance that has not begun"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 
@@ -197,7 +234,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("can not execute command against non-existent instance"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("executed a command of type fixtures.MessageC on a process instance that has not begun"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 
@@ -219,7 +274,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("can not schedule timeout against non-existent instance"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("scheduled a timeout of type fixtures.MessageT on a process instance that has not begun"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 	})
@@ -437,7 +510,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("the '<name>' handler is not configured to execute commands of type fixtures.MessageX"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("executed a command of type fixtures.MessageX, which is not produced by this handler"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 
 			It("panics if the command is invalid", func() {
@@ -459,7 +550,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("can not execute command of type fixtures.MessageC, it is invalid: <invalid>"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("executed an invalid fixtures.MessageC command: <invalid>"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 
@@ -531,7 +640,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("the '<name>' handler is not configured to schedule timeouts of type fixtures.MessageX"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("scheduled a timeout of type fixtures.MessageX, which is not produced by this handler"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 
 			It("panics if the timeout is invalid", func() {
@@ -556,7 +683,25 @@ var _ = Describe("type scope", func() {
 						time.Now(),
 						event,
 					)
-				}).To(PanicWith("can not schedule timeout of type fixtures.MessageT, it is invalid: <invalid>"))
+				}).To(PanicWith(
+					MatchAllFields(
+						Fields{
+							"Handler":        Equal(config),
+							"Interface":      Equal("ProcessMessageHandler"),
+							"Method":         Equal("HandleEvent"),
+							"Implementation": Equal(config.Handler()),
+							"Message":        Equal(event.Message),
+							"Description":    Equal("scheduled an invalid fixtures.MessageT timeout: <invalid>"),
+							"Location": MatchAllFields(
+								Fields{
+									"Func": Not(BeEmpty()),
+									"File": HaveSuffix("/engine/controller/process/scope_test.go"),
+									"Line": Not(BeZero()),
+								},
+							),
+						},
+					),
+				))
 			})
 		})
 	})

--- a/engine/panicx/location_test.go
+++ b/engine/panicx/location_test.go
@@ -22,7 +22,7 @@ var _ = Describe("type Location", func() {
 			))
 		})
 
-		It("panics value is not a function", func() {
+		It("panics if the value is not a function", func() {
 			Expect(func() {
 				LocationOfFunc("<not a function>")
 			}).To(PanicWith("fn must be a function"))

--- a/engine/panicx/unexpectedbehavior.go
+++ b/engine/panicx/unexpectedbehavior.go
@@ -1,0 +1,48 @@
+package panicx
+
+import (
+	"fmt"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dogma"
+)
+
+// UnexpectedBehavior is a panic value that occurs when a handler exhibits some
+// behavior that the engine did not expect.
+//
+// Often this means it has violated the Dogma specification.
+type UnexpectedBehavior struct {
+	// Handler is the non-compliant handler.
+	Handler configkit.RichHandler
+
+	// Interface is the name of the interface containing the method with the
+	// unexpected behavior.
+	Interface string
+
+	// Method is the name of the method that behaved unexpectedly.
+	Method string
+
+	// Implementation is the value that implements the nominated interface.
+	Implementation interface{}
+
+	// Message is the message that was being handled at the time, if any.
+	Message dogma.Message
+
+	// Description is a human-readable description of the behavior.
+	Description string
+
+	// Location is the engine's best attempt at pinpointing the location of the
+	// unexpected behavior.
+	Location Location
+}
+
+func (x UnexpectedBehavior) String() string {
+	return fmt.Sprintf(
+		"the '%s' %s message handler behaved unexpectedly in %T.%s(): %s",
+		x.Handler.Identity().Name,
+		x.Handler.HandlerType(),
+		x.Implementation,
+		x.Method,
+		x.Description,
+	)
+}

--- a/engine/panicx/unexpectedbehavior_test.go
+++ b/engine/panicx/unexpectedbehavior_test.go
@@ -1,0 +1,37 @@
+package panicx_test
+
+import (
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/testkit/engine/panicx"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type UnexpectedBehavior", func() {
+	config := configkit.FromProjection(
+		&ProjectionMessageHandler{
+			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+				c.Identity("<name>", "<key>")
+				c.ConsumesEventType(MessageE{})
+			},
+		},
+	)
+
+	Describe("func String()", func() {
+		It("returns a description of the panic", func() {
+			x := UnexpectedBehavior{
+				Handler:        config,
+				Interface:      "<interface>",
+				Method:         "<method>",
+				Implementation: config.Handler(),
+				Description:    "<description>",
+			}
+
+			Expect(x.String()).To(Equal(
+				"the '<name>' projection message handler behaved unexpectedly in *fixtures.ProjectionMessageHandler.<method>(): <description>",
+			))
+		})
+	})
+})


### PR DESCRIPTION
#### What change does this introduce?

This PR adds the `panicx.UnexpectedBehavior` type and changes the engine to panic with this value whenever the application behaves in an unexpected way.

#### What issues does this relate to?

Prepares for #162 

#### Why make this change?

These panic values were previously just strings.

We need to allow the in-memory engine to panic when an application misbehaves (such as recording an invalid event) so that the developer can catch these issues. However, when using the engine within a test we want to add information about these panic values to a test report rather than just letting them unwind the stack fully.

#### Is there anything you are unsure about?

No