### PR TITLE
Disambiguate engine-level context errors from handler-level errors.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -148,8 +148,19 @@ func (e *Engine) tick(
 		)
 
 		envs, cerr := c.Tick(ctx, oo.observers, oo.now)
-		err = multierr.Append(err, cerr)
 		queue = append(queue, envs...)
+
+		if cerr != nil {
+			err = multierr.Append(
+				err,
+				fmt.Errorf(
+					"%s %s: %w",
+					c.HandlerConfig().Identity().Name,
+					c.HandlerConfig().HandlerType(),
+					cerr,
+				),
+			)
+		}
 
 		oo.observers.Notify(
 			fact.TickCompleted{
@@ -281,7 +292,18 @@ func (e *Engine) dispatch(
 		for _, c := range controllers {
 			envs, cerr := e.handle(ctx, oo, env, c)
 			queue = append(queue, envs...)
-			derr = multierr.Append(derr, cerr)
+
+			if cerr != nil {
+				derr = multierr.Append(
+					derr,
+					fmt.Errorf(
+						"%s %s: %w",
+						c.HandlerConfig().Identity().Name,
+						c.HandlerConfig().HandlerType(),
+						cerr,
+					),
+				)
+			}
 		}
 
 		oo.observers.Notify(

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -113,6 +113,10 @@ func (e *Engine) Tick(
 		},
 	)
 
+	if e := ctx.Err(); e != nil {
+		return e
+	}
+
 	return err
 }
 
@@ -228,6 +232,10 @@ func (e *Engine) Dispatch(
 			EnabledHandlers:     oo.enabledHandlers,
 		},
 	)
+
+	if e := ctx.Err(); e != nil {
+		return e
+	}
 
 	return err
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -195,6 +195,19 @@ var _ = Describe("type Engine", func() {
 			Expect(err).To(Equal(context.Canceled))
 		})
 
+		It("adds handler details to controller errors", func() {
+			integration.HandleCommandFunc = func(
+				context.Context,
+				dogma.IntegrationCommandScope,
+				dogma.Message,
+			) error {
+				return errors.New("<error>")
+			}
+
+			err := engine.Dispatch(context.Background(), MessageC1)
+			Expect(err).To(MatchError("<integration> integration: <error>"))
+		})
+
 		It("panics if the message is invalid", func() {
 			Expect(func() {
 				engine.Dispatch(
@@ -281,6 +294,18 @@ var _ = Describe("type Engine", func() {
 
 			err := engine.Tick(ctx)
 			Expect(err).To(Equal(context.Canceled))
+		})
+
+		It("adds handler details to controller errors", func() {
+			projection.CompactFunc = func(
+				context.Context,
+				dogma.ProjectionCompactScope,
+			) error {
+				return errors.New("<error>")
+			}
+
+			err := engine.Tick(context.Background())
+			Expect(err).To(MatchError("<projection> projection: <error>"))
 		})
 	})
 })

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -179,6 +179,22 @@ var _ = Describe("type Engine", func() {
 			Expect(called).To(BeTrue())
 		})
 
+		It("always returns context errors even if other errors occur", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			integration.HandleCommandFunc = func(
+				context.Context,
+				dogma.IntegrationCommandScope,
+				dogma.Message,
+			) error {
+				cancel()
+				return errors.New("<error>")
+			}
+
+			err := engine.Dispatch(ctx, MessageC1)
+			Expect(err).To(Equal(context.Canceled))
+		})
+
 		It("panics if the message is invalid", func() {
 			Expect(func() {
 				engine.Dispatch(
@@ -250,6 +266,21 @@ var _ = Describe("type Engine", func() {
 					Handler: h,
 				},
 			))
+		})
+
+		It("always returns context errors even if other errors occur", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			projection.CompactFunc = func(
+				context.Context,
+				dogma.ProjectionCompactScope,
+			) error {
+				cancel()
+				return errors.New("<error>")
+			}
+
+			err := engine.Tick(ctx)
+			Expect(err).To(Equal(context.Canceled))
 		})
 	})
 })


### PR DESCRIPTION
#### What change does this introduce?

This PR ensures that the engine always returns a `context.Canceled` or `context.DeadlineExceeded` if the context passed to `Engine.Dispatch()` or `Engine.Tick()` is canceled/times-out, even if the handlers within the engine return an error.

#### What issues does this relate to?

Fixes #180 

#### Why make this change?

These changes let us tell if the engine itself was asked to stop or timed out (usually because a test timed out), vs an individual handler timing out while handling a message, for example.

#### Is there anything you are unsure about?

No