### PR TITLE
Validate messages in actions and expectations.

### DIFF
--- a/action.advancetime.go
+++ b/action.advancetime.go
@@ -23,7 +23,7 @@ import (
 // concepts within the application's business domain.
 func AdvanceTime(adj TimeAdjustment) Action {
 	if adj == nil {
-		panic("AdvanceTime(): adjustment must not be nil")
+		panic("AdvanceTime(<nil>): adjustment must not be nil")
 	}
 
 	return advanceTimeAction{adj}
@@ -55,7 +55,7 @@ func ToTime(t time.Time) TimeAdjustment {
 // fixed duration.
 func ByDuration(d time.Duration) TimeAdjustment {
 	if d < 0 {
-		panic("ByDuration(): duration must not be negative")
+		panic(fmt.Sprintf("ByDuration(%s): duration must not be negative", d))
 	}
 
 	return byDuration(d)

--- a/action.advancetime_test.go
+++ b/action.advancetime_test.go
@@ -88,7 +88,7 @@ var _ = Describe("func AdvanceTime()", func() {
 	It("panics if the adjustment is nil", func() {
 		Expect(func() {
 			AdvanceTime(nil)
-		}).To(PanicWith("AdvanceTime(): adjustment must not be nil"))
+		}).To(PanicWith("AdvanceTime(<nil>): adjustment must not be nil"))
 	})
 
 	When("passed a ToTime() adjustment", func() {
@@ -156,8 +156,8 @@ var _ = Describe("func AdvanceTime()", func() {
 
 		It("panics if the duration is negative", func() {
 			Expect(func() {
-				ByDuration(-1)
-			}).To(PanicWith("ByDuration(): duration must not be negative"))
+				ByDuration(-1 * time.Second)
+			}).To(PanicWith("ByDuration(-1s): duration must not be negative"))
 		})
 	})
 })

--- a/action.call.go
+++ b/action.call.go
@@ -17,7 +17,7 @@ import "context"
 // produced by handlers within the Dogma application.
 func Call(fn func()) Action {
 	if fn == nil {
-		panic("Call(): function must not be nil")
+		panic("Call(<nil>): function must not be nil")
 	}
 
 	return callAction{fn}

--- a/action.call_test.go
+++ b/action.call_test.go
@@ -184,6 +184,6 @@ var _ = Describe("func Call()", func() {
 	It("panics if the function is nil", func() {
 		Expect(func() {
 			Call(nil)
-		}).To(PanicWith("Call(): function must not be nil"))
+		}).To(PanicWith("Call(<nil>): function must not be nil"))
 	})
 })

--- a/action.dispatch.command_test.go
+++ b/action.dispatch.command_test.go
@@ -137,6 +137,6 @@ var _ = Describe("func ExecuteCommand()", func() {
 	It("panics if the message is nil", func() {
 		Expect(func() {
 			ExecuteCommand(nil)
-		}).To(PanicWith("ExecuteCommand(): message must not be nil"))
+		}).To(PanicWith("ExecuteCommand(<nil>): message must not be nil"))
 	})
 })

--- a/action.dispatch.event_test.go
+++ b/action.dispatch.event_test.go
@@ -139,6 +139,6 @@ var _ = Describe("func RecordEvent()", func() {
 	It("panics if the message is nil", func() {
 		Expect(func() {
 			RecordEvent(nil)
-		}).To(PanicWith("RecordEvent(): message must not be nil"))
+		}).To(PanicWith("RecordEvent(<nil>): message must not be nil"))
 	})
 })

--- a/action.dispatch.go
+++ b/action.dispatch.go
@@ -2,6 +2,7 @@ package testkit
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
@@ -10,8 +11,8 @@ import (
 
 // ExecuteCommand returns an Action that executes a command message.
 func ExecuteCommand(m dogma.Message) Action {
-	if m == nil {
-		panic("ExecuteCommand(): message must not be nil")
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf("ExecuteCommand(%T): %s", m, err))
 	}
 
 	return dispatchAction{message.CommandRole, m}
@@ -19,8 +20,8 @@ func ExecuteCommand(m dogma.Message) Action {
 
 // RecordEvent returns an Action that records an event message.
 func RecordEvent(m dogma.Message) Action {
-	if m == nil {
-		panic("RecordEvent(): message must not be nil")
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf("RecordEvent(%T): %s", m, err))
 	}
 
 	return dispatchAction{message.EventRole, m}

--- a/expectation.message.command_test.go
+++ b/expectation.message.command_test.go
@@ -263,9 +263,9 @@ var _ = Describe("func ToExecuteCommand()", func() {
 		),
 	)
 
-	It("panics if the message is nil", func() {
+	It("panics if the message is invalid", func() {
 		Expect(func() {
 			ToExecuteCommand(nil)
-		}).To(PanicWith("ToExecuteCommand(): message must not be nil"))
+		}).To(PanicWith("ToExecuteCommand(<nil>): message must not be nil"))
 	})
 })

--- a/expectation.message.event_test.go
+++ b/expectation.message.event_test.go
@@ -293,6 +293,6 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 	It("panics if the message is nil", func() {
 		Expect(func() {
 			ToRecordEvent(nil)
-		}).To(PanicWith("ToRecordEvent(): message must not be nil"))
+		}).To(PanicWith("ToRecordEvent(<nil>): message must not be nil"))
 	})
 })

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -1,6 +1,7 @@
 package testkit
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/dogmatiq/configkit/message"
@@ -15,8 +16,8 @@ import (
 // ToExecuteCommand returns an expectation that passes if a command is executed
 // that is equal to m.
 func ToExecuteCommand(m dogma.Message) Expectation {
-	if m == nil {
-		panic("ToExecuteCommand(): message must not be nil")
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf("ToExecuteCommand(%T): %s", m, err))
 	}
 
 	return &messageExpectation{
@@ -28,8 +29,8 @@ func ToExecuteCommand(m dogma.Message) Expectation {
 // ToRecordEvent returns an expectation that passes if an event is recorded that
 // is equal to m.
 func ToRecordEvent(m dogma.Message) Expectation {
-	if m == nil {
-		panic("ToRecordEvent(): message must not be nil")
+	if err := dogma.ValidateMessage(m); err != nil {
+		panic(fmt.Sprintf("ToRecordEvent(%T): %s", m, err))
 	}
 
 	return &messageExpectation{

--- a/expectation.messagetype.command_test.go
+++ b/expectation.messagetype.command_test.go
@@ -221,6 +221,6 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 	It("panics if the message is nil", func() {
 		Expect(func() {
 			ToExecuteCommandOfType(nil)
-		}).To(PanicWith("ToExecuteCommandOfType(): message must not be nil"))
+		}).To(PanicWith("ToExecuteCommandOfType(<nil>): message must not be nil"))
 	})
 })

--- a/expectation.messagetype.event_test.go
+++ b/expectation.messagetype.event_test.go
@@ -248,6 +248,6 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 	It("panics if the message is nil", func() {
 		Expect(func() {
 			ToRecordEventOfType(nil)
-		}).To(PanicWith("ToRecordEventOfType(): message must not be nil"))
+		}).To(PanicWith("ToRecordEventOfType(<nil>): message must not be nil"))
 	})
 })

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -14,7 +14,7 @@ import (
 // same type as m is executed.
 func ToExecuteCommandOfType(m dogma.Message) Expectation {
 	if m == nil {
-		panic("ToExecuteCommandOfType(): message must not be nil")
+		panic("ToExecuteCommandOfType(<nil>): message must not be nil")
 	}
 
 	return &messageTypeExpectation{
@@ -27,7 +27,7 @@ func ToExecuteCommandOfType(m dogma.Message) Expectation {
 // same type as m is recorded.
 func ToRecordEventOfType(m dogma.Message) Expectation {
 	if m == nil {
-		panic("ToRecordEventOfType(): message must not be nil")
+		panic("ToRecordEventOfType(<nil>): message must not be nil")
 	}
 
 	return &messageTypeExpectation{

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -23,6 +23,14 @@ func ToSatisfy(
 	d string,
 	x func(*SatisfyT),
 ) Expectation {
+	if x == nil {
+		panic(fmt.Sprintf("ToSatisfy(%#v, <nil>): function must not be nil", d))
+	}
+
+	if d == "" {
+		panic(fmt.Sprintf("ToSatisfy(%#v, <func>): description must not be empty", d))
+	}
+
 	return &satisfyExpectation{
 		c: d,
 		t: SatisfyT{name: d},

--- a/expectation.satisfy_test.go
+++ b/expectation.satisfy_test.go
@@ -239,6 +239,18 @@ var _ = Describe("func ToSatisfy()", func() {
 		))
 	})
 
+	It("panics if the description is empty", func() {
+		Expect(func() {
+			ToSatisfy("", func(*SatisfyT) {})
+		}).To(PanicWith(`ToSatisfy("", <func>): description must not be empty`))
+	})
+
+	It("panics if the function is nil", func() {
+		Expect(func() {
+			ToSatisfy("<criteria>", nil)
+		}).To(PanicWith(`ToSatisfy("<criteria>", <nil>): function must not be nil`))
+	})
+
 	Describe("type SatisfyT", func() {
 		run := func(x func(*SatisfyT)) {
 			test.Expect(


### PR DESCRIPTION
#### What change does this introduce?

This PR changes action/expectation functions that take `dogma.Message` values to validate using `dogma.ValidateMessage()` instead of just checking for `nil`.

I changed the panic message a little to accomodate this information, so I also changed the panic messages for other functions to use a similar format.

#### What issues does this relate to?

#135 (previous PR)

#### Why make this change?

Some of these changes were made previously but they were lost during the #127 refactor.

#### Is there anything you are unsure about?

No