### PR TITLE
Split expectations into two separate interfaces.

### DIFF
--- a/action.advancetime.go
+++ b/action.advancetime.go
@@ -79,10 +79,10 @@ func (a advanceTimeAction) Banner() string {
 	)
 }
 
-// ExpectOptions returns the options to use by default when this action is
-// used with Test.Expect().
-func (a advanceTimeAction) ExpectOptions() []ExpectOption {
-	return nil
+// ConfigurePredicate updates o with any options required by the action.
+//
+// It is called before Apply() when the action is used with Test.Expect().
+func (a advanceTimeAction) ConfigurePredicate(o *PredicateOptions) {
 }
 
 // Apply performs the action within the context of a specific test.

--- a/action.call.go
+++ b/action.call.go
@@ -38,14 +38,11 @@ func (a callAction) Banner() string {
 	return "CALLING USER-DEFINED FUNCTION"
 }
 
-// ExpectOptions returns the options to use by default when this action is
-// used with Test.Expect().
-func (a callAction) ExpectOptions() []ExpectOption {
-	return []ExpectOption{
-		func(o *ExpectOptionSet) {
-			o.MatchMessagesInDispatchCycle = true
-		},
-	}
+// ConfigurePredicate updates o with any options required by the action.
+//
+// It is called before Apply() when the action is used with Test.Expect().
+func (a callAction) ConfigurePredicate(o *PredicateOptions) {
+	o.MatchDispatchCycleStartedFacts = true
 }
 
 // Apply performs the action within the context of a specific test.

--- a/action.dispatch.go
+++ b/action.dispatch.go
@@ -47,10 +47,10 @@ func (a dispatchAction) Banner() string {
 	)
 }
 
-// ExpectOptions returns the options to use by default when this action is
-// used with Test.Expect().
-func (a dispatchAction) ExpectOptions() []ExpectOption {
-	return nil
+// ConfigurePredicate updates o with any options required by the action.
+//
+// It is called before Apply() when the action is used with Test.Expect().
+func (a dispatchAction) ConfigurePredicate(o *PredicateOptions) {
 }
 
 // Apply performs the action within the context of a specific test.

--- a/action.go
+++ b/action.go
@@ -20,9 +20,10 @@ type Action interface {
 	// for example "DOING ACTION".
 	Banner() string
 
-	// ExpectOptions returns the options to use by default when this action is
-	// used with Test.Expect().
-	ExpectOptions() []ExpectOption
+	// ConfigurePredicate updates o with any options required by the action.
+	//
+	// It is called before Apply() when the action is used with Test.Expect().
+	ConfigurePredicate(o *PredicateOptions)
 
 	// Apply performs the action within the context of a specific test.
 	Apply(ctx context.Context, s ActionScope) error

--- a/action_test.go
+++ b/action_test.go
@@ -14,5 +14,5 @@ var noop noopAction
 type noopAction struct{}
 
 func (noopAction) Banner() string                                 { return "[NO-OP]" }
-func (noopAction) ExpectOptions() []ExpectOption                  { return nil }
+func (noopAction) ConfigurePredicate(*PredicateOptions)           {}
 func (noopAction) Apply(ctx context.Context, s ActionScope) error { return nil }

--- a/expectation.composite.go
+++ b/expectation.composite.go
@@ -111,12 +111,6 @@ type compositeExpectation struct {
 	pred     func(passed int) (outcome string, ok bool)
 }
 
-func (e *compositeExpectation) Notify(f fact.Fact)          { panic("TODO: remove") }
-func (e *compositeExpectation) Begin(o ExpectOptionSet)     { panic("TODO: remove") }
-func (e *compositeExpectation) End()                        { panic("TODO: remove") }
-func (e *compositeExpectation) Ok() bool                    { panic("TODO: remove") }
-func (e *compositeExpectation) BuildReport(ok bool) *Report { panic("TODO: remove") }
-
 func (e *compositeExpectation) Banner() string {
 	return e.banner
 }
@@ -125,9 +119,7 @@ func (e *compositeExpectation) Predicate(o PredicateOptions) Predicate {
 	var children []Predicate
 
 	for _, c := range e.children {
-		if pe, ok := c.(predicateBasedExpectation); ok {
-			children = append(children, pe.Predicate(o))
-		}
+		children = append(children, c.Predicate(o))
 	}
 
 	return &compositePredicate{

--- a/expectation.composite.go
+++ b/expectation.composite.go
@@ -100,6 +100,8 @@ func NoneOf(children ...Expectation) Expectation {
 
 // compositeExpectation is an Expectation that contains other expectations.
 //
+// It is the implementation used by AllOf(), AnyOf() and NoneOf().
+//
 // It uses a predicate function to determine whether the composite expectation
 // is met based on how many of the "child" expectations are met.
 type compositeExpectation struct {

--- a/expectation.go
+++ b/expectation.go
@@ -4,37 +4,14 @@ import (
 	"github.com/dogmatiq/testkit/fact"
 )
 
-// An Expectation is a predicate for determining whether some specific criteria
-// was met while performing an action.
+// An Expectation describes some criteria that may be met by an action.
 type Expectation interface {
-	fact.Observer
-
 	// Banner returns a human-readable banner to display in the logs when this
 	// expectation is used.
 	//
 	// The banner text should be in uppercase, and complete the sentence "The
 	// application is expected ...". For example, "TO DO A THING".
 	Banner() string
-
-	// Begin is called to prepare the expectation for a new test.
-	Begin(o ExpectOptionSet)
-
-	// End is called once the test is complete.
-	End()
-
-	// Ok returns true if the expectation passed.
-	Ok() bool
-
-	// BuildReport generates a report about the expectation.
-	//
-	// ok is true if the expectation is considered to have passed. This may not be
-	// the same value as returned from Ok() when this expectation is used as a child
-	// of a composite expectation.
-	BuildReport(ok bool) *Report
-}
-
-type predicateBasedExpectation interface {
-	Expectation
 
 	// Predicate returns a new predicate that checks that this expectation is
 	// satisfied.
@@ -71,9 +48,6 @@ type Predicate interface {
 	// The behavior of Report() is undefined if Done() has not been called.
 	Report(treeOk bool) *Report
 }
-
-// ExpectOptionSet TODO REMOVE
-type ExpectOptionSet = PredicateOptions
 
 // PredicateOptions contains values that dictate how a predicate should behave.
 type PredicateOptions struct {

--- a/expectation.go
+++ b/expectation.go
@@ -33,6 +33,33 @@ type Expectation interface {
 	BuildReport(ok bool) *Report
 }
 
+type predicateBasedExpectation interface {
+	Expectation
+
+	// Predicate returns a new predicate that checks that this expectation is
+	// satisfied.
+	Predicate(o PredicateOptions) Predicate
+}
+
+// Predicate tests whether a specific Action satisfies an Expectation.
+type Predicate interface {
+	fact.Observer
+
+	// Ok returns true if the expectation is currently met.
+	//
+	// This may change as the predicate is notified of additional facts.
+	Ok() bool
+
+	// Done indicates that the predicate will not be notified of any more facts.
+	//
+	// It returns a report describing whether or not the expectation was met.
+	//
+	// treeOk is true if the entire "tree" of expectations is considered to have
+	// passed. This may not be the same value as returned from Ok() when this
+	// expectation is used as a child of a composite expectation.
+	Done(treeOk bool) *Report
+}
+
 type ExpectOptionSet = PredicateOptions
 
 // PredicateOptions contains values that dictate how a predicate should behave.

--- a/expectation.go
+++ b/expectation.go
@@ -33,16 +33,15 @@ type Expectation interface {
 	BuildReport(ok bool) *Report
 }
 
-// ExpectOption is an option that changes the behavior the Test.Expect() method.
-type ExpectOption func(*ExpectOptionSet)
+type ExpectOptionSet = PredicateOptions
 
-// ExpectOptionSet is a set of options that dictate the behavior of the
-// Test.Expect() method.
-type ExpectOptionSet struct {
-	// MatchMessagesInDispatchCycle controls whether expectations should match
-	// messages from the start of a dispatch cycle.
+// PredicateOptions contains values that dictate how a predicate should behave.
+type PredicateOptions struct {
+	// MatchDispatchCycleStartedFacts controls whether predicates that look for
+	// specific messages should consider messages from DispatchCycleStarted
+	// facts.
 	//
-	// If it is false, only messages produced by handlers within the application
-	// are matched.
-	MatchMessagesInDispatchCycle bool
+	// If it is false, the predicate must only match against messages produced
+	// by handlers.
+	MatchDispatchCycleStartedFacts bool
 }

--- a/expectation.go
+++ b/expectation.go
@@ -38,6 +38,9 @@ type predicateBasedExpectation interface {
 
 	// Predicate returns a new predicate that checks that this expectation is
 	// satisfied.
+	//
+	// The predicate must be closed by calling Done() once the action it tests
+	// is completed.
 	Predicate(o PredicateOptions) Predicate
 }
 
@@ -45,18 +48,28 @@ type predicateBasedExpectation interface {
 type Predicate interface {
 	fact.Observer
 
-	// Ok returns true if the expectation tested by this predicate has been
-	// met. The return value may change as the predicate is notified of
-	// additional facts.
+	// Ok returns true if the expectation tested by this predicate has been met.
+	//
+	// The return value may change as the predicate is notified of additional
+	// facts. It must return a consistent value once Done() has been called.
 	Ok() bool
 
-	// Done finalizes the predicate and returns a report describing whether or
-	// not the expectation was met.
+	// Done finalizes the predicate.
+	//
+	// The behavior of the predicate is undefined if it is notified of any
+	// additional facts after Done() has been called, or if Done() is called
+	// more than once.
+	Done()
+
+	// Report returns a report describing whether or not the expectation
+	// was met.
 	//
 	// treeOk is true if the entire "tree" of expectations is considered to have
 	// passed. This may not be the same value as returned from Ok() when this
 	// expectation is used as a child of a composite expectation.
-	Done(treeOk bool) *Report
+	//
+	// The behavior of Report() is undefined if Done() has not been called.
+	Report(treeOk bool) *Report
 }
 
 // ExpectOptionSet TODO REMOVE

--- a/expectation.go
+++ b/expectation.go
@@ -45,14 +45,13 @@ type predicateBasedExpectation interface {
 type Predicate interface {
 	fact.Observer
 
-	// Ok returns true if the expectation is currently met.
-	//
-	// This may change as the predicate is notified of additional facts.
+	// Ok returns true if the expectation tested by this predicate has been
+	// met. The return value may change as the predicate is notified of
+	// additional facts.
 	Ok() bool
 
-	// Done indicates that the predicate will not be notified of any more facts.
-	//
-	// It returns a report describing whether or not the expectation was met.
+	// Done finalizes the predicate and returns a report describing whether or
+	// not the expectation was met.
 	//
 	// treeOk is true if the entire "tree" of expectations is considered to have
 	// passed. This may not be the same value as returned from Ok() when this
@@ -60,6 +59,7 @@ type Predicate interface {
 	Done(treeOk bool) *Report
 }
 
+// ExpectOptionSet TODO REMOVE
 type ExpectOptionSet = PredicateOptions
 
 // PredicateOptions contains values that dictate how a predicate should behave.

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -92,7 +92,7 @@ func (e *messageExpectation) Begin(o ExpectOptionSet) {
 		dist:     typecmp.Unrelated,
 		tracker: tracker{
 			role:               e.role,
-			matchDispatchCycle: o.MatchMessagesInDispatchCycle,
+			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
 		},
 	}
 }

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -21,8 +21,8 @@ func ToExecuteCommand(m dogma.Message) Expectation {
 	}
 
 	return &messageExpectation{
-		expected: m,
-		role:     message.CommandRole,
+		expectedMessage: m,
+		expectedRole:    message.CommandRole,
 	}
 }
 
@@ -34,194 +34,175 @@ func ToRecordEvent(m dogma.Message) Expectation {
 	}
 
 	return &messageExpectation{
-		expected: m,
-		role:     message.EventRole,
+		expectedMessage: m,
+		expectedRole:    message.EventRole,
 	}
 }
 
-// messageExpectation verifies that a specific message is produced.
+// messageTypeExpectation is an Expectation that checks that specific message is
+// produced.
+//
+// It is the implementation used by ToExecuteCommand() and ToRecordEvent().
 type messageExpectation struct {
-	// Expected is the message that is expected to be produced.
-	expected dogma.Message
-
-	// Role is the expected role of the expected message.
-	// It must be either CommandRole or EventRole.
-	role message.Role
-
-	// ok is true once the expectation is deemed to have passed, after which no
-	// further updates are performed.
-	ok bool
-
-	// best is an envelope containing the "best-match" message for an
-	// expectation that has not yet passed. Note that this message may not have
-	// the expected role.
-	best *envelope.Envelope
-
-	// dist is a distance between the type of the expected message, and the
-	// current best-match.
-	dist typecmp.Distance
-
-	// equal is true if the best-match message compared as equal to the expected
-	// message. This can occur, and the expectation still fail, if the
-	// best-match message has an unexpected role.
-	equal bool
-
-	// tracker observers the handlers and messages that are involved in the
-	// test.
-	tracker tracker
+	expectedMessage dogma.Message
+	expectedRole    message.Role
 }
 
-// Banner returns a human-readable banner to display in the logs when this
-// expectation is used.
-//
-// The banner text should be in uppercase, and complete the sentence "The
-// application is expected ...". For example, "TO DO A THING".
+func (e *messageExpectation) Notify(f fact.Fact)          { panic("TODO: remove") }
+func (e *messageExpectation) Begin(o ExpectOptionSet)     { panic("TODO: remove") }
+func (e *messageExpectation) End()                        { panic("TODO: remove") }
+func (e *messageExpectation) Ok() bool                    { panic("TODO: remove") }
+func (e *messageExpectation) BuildReport(ok bool) *Report { panic("TODO: remove") }
+
 func (e *messageExpectation) Banner() string {
 	return inflect.Sprintf(
-		e.role,
+		e.expectedRole,
 		"TO <PRODUCE> A SPECIFIC '%s' <MESSAGE>",
-		message.TypeOf(e.expected),
+		message.TypeOf(e.expectedMessage),
 	)
 }
 
-// Begin is called to prepare the expectation for a new test.
-func (e *messageExpectation) Begin(o ExpectOptionSet) {
-	*e = messageExpectation{
-		expected: e.expected,
-		role:     e.role,
-		dist:     typecmp.Unrelated,
+func (e *messageExpectation) Predicate(o PredicateOptions) Predicate {
+	return &messagePredicate{
+		expectedMessage:   e.expectedMessage,
+		expectedRole:      e.expectedRole,
+		bestMatchDistance: typecmp.Unrelated,
 		tracker: tracker{
-			role:               e.role,
+			role:               e.expectedRole,
 			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
 		},
 	}
 }
 
-// End is called once the test is complete.
-func (e *messageExpectation) End() {
+// messagePredicate is the Predicate implementation for messageExpectation.
+type messagePredicate struct {
+	expectedMessage   dogma.Message
+	expectedRole      message.Role
+	ok                bool
+	bestMatch         *envelope.Envelope
+	bestMatchDistance typecmp.Distance
+	bestMatchIsEqual  bool
+	tracker           tracker
 }
 
-// Ok returns true if the expectation passed.
-func (e *messageExpectation) Ok() bool {
-	return e.ok
+// Notify updates the expectation's state in response to a new fact.
+func (p *messagePredicate) Notify(f fact.Fact) {
+	if p.ok {
+		return
+	}
+
+	p.tracker.Notify(f)
+
+	switch x := f.(type) {
+	case fact.DispatchCycleBegun:
+		if p.tracker.matchDispatchCycle {
+			p.messageProduced(x.Envelope)
+		}
+	case fact.EventRecordedByAggregate:
+		p.messageProduced(x.EventEnvelope)
+	case fact.EventRecordedByIntegration:
+		p.messageProduced(x.EventEnvelope)
+	case fact.CommandExecutedByProcess:
+		p.messageProduced(x.CommandEnvelope)
+	}
 }
 
-// BuildReport generates a report about the expectation.
-//
-// ok is true if the expectation is considered to have passed. This may not be
-// the same value as returned from Ok() when this expectation is used as a child
-// of a composite expectation.
-func (e *messageExpectation) BuildReport(ok bool) *Report {
+// messageProduced updates the predicate's state to reflect the fact that a
+// message has been produced.
+func (p *messagePredicate) messageProduced(env *envelope.Envelope) {
+	if !reflect.DeepEqual(env.Message, p.expectedMessage) {
+		p.updateBestMatch(env)
+		return
+	}
+
+	p.bestMatch = env
+	p.bestMatchDistance = typecmp.Identical
+	p.bestMatchIsEqual = true
+
+	if env.Role == p.expectedRole {
+		p.ok = true
+	}
+}
+
+// updateBestMatch replaces p.bestMatch with env if it is a better match.
+func (p *messagePredicate) updateBestMatch(env *envelope.Envelope) {
+	dist := typecmp.MeasureDistance(
+		reflect.TypeOf(p.expectedMessage),
+		reflect.TypeOf(env.Message),
+	)
+
+	if dist < p.bestMatchDistance {
+		p.bestMatch = env
+		p.bestMatchDistance = dist
+	}
+}
+
+func (p *messagePredicate) Ok() bool {
+	return p.ok
+}
+
+func (p *messagePredicate) Done() {
+}
+
+func (p *messagePredicate) Report(treeOk bool) *Report {
 	rep := &Report{
-		TreeOk: ok,
-		Ok:     e.ok,
+		TreeOk: treeOk,
+		Ok:     p.ok,
 		Criteria: inflect.Sprintf(
-			e.role,
+			p.expectedRole,
 			"<produce> a specific '%s' <message>",
-			message.TypeOf(e.expected),
+			message.TypeOf(p.expectedMessage),
 		),
 	}
 
-	if ok || e.ok {
+	if treeOk || p.ok {
 		return rep
 	}
 
-	if e.best == nil {
-		buildReportNoMatch(rep, &e.tracker)
-	} else if e.best.Role == e.role {
-		e.buildReportExpectedRole(rep)
+	if p.bestMatch == nil {
+		reportNoMatch(rep, &p.tracker)
+	} else if p.bestMatch.Role == p.expectedRole {
+		p.reportExpectedRole(rep)
 	} else {
-		e.buildReportUnexpectedRole(rep)
+		p.reportUnexpectedRole(rep)
 	}
 
 	return rep
 }
 
-// Notify updates the expectation's state in response to a new fact.
-func (e *messageExpectation) Notify(f fact.Fact) {
-	if e.ok {
-		return
-	}
-
-	e.tracker.Notify(f)
-
-	switch x := f.(type) {
-	case fact.DispatchCycleBegun:
-		if e.tracker.matchDispatchCycle {
-			e.messageProduced(x.Envelope)
-		}
-	case fact.EventRecordedByAggregate:
-		e.messageProduced(x.EventEnvelope)
-	case fact.EventRecordedByIntegration:
-		e.messageProduced(x.EventEnvelope)
-	case fact.CommandExecutedByProcess:
-		e.messageProduced(x.CommandEnvelope)
-	}
-}
-
-// messageProduced updates the expectation's state to reflect the fact that a
-// message has been produced.
-func (e *messageExpectation) messageProduced(env *envelope.Envelope) {
-	if !reflect.DeepEqual(env.Message, e.expected) {
-		e.updateBestMatch(env)
-		return
-	}
-
-	e.best = env
-	e.dist = typecmp.Identical
-	e.equal = true
-
-	if e.role == env.Role {
-		e.ok = true
-	}
-}
-
-// updateBestMatch replaces e.best with env if it is a better match.
-func (e *messageExpectation) updateBestMatch(env *envelope.Envelope) {
-	dist := typecmp.MeasureDistance(
-		reflect.TypeOf(e.expected),
-		reflect.TypeOf(env.Message),
-	)
-
-	if dist < e.dist {
-		e.best = env
-		e.dist = dist
-	}
-}
-
-// buildReportExpectedRole builds a test report when there is a "best-match"
+// reportExpectedRole builds a test report when there is a "best-match"
 // message available and it is of the expected role.
-func (e *messageExpectation) buildReportExpectedRole(rep *Report) {
+func (p *messagePredicate) reportExpectedRole(rep *Report) {
 	s := rep.Section(suggestionsSection)
 
-	if e.dist == typecmp.Identical {
-		if e.best.Origin == nil {
+	if p.bestMatchDistance == typecmp.Identical {
+		if p.bestMatch.Origin == nil {
 			rep.Explanation = inflect.Sprint(
-				e.role,
+				p.expectedRole,
 				"a similar <message> was <produced> via a <dispatcher>",
 			)
 		} else {
 			rep.Explanation = inflect.Sprintf(
-				e.role,
+				p.expectedRole,
 				"a similar <message> was <produced> by the '%s' %s message handler",
-				e.best.Origin.Handler.Identity().Name,
-				e.best.Origin.HandlerType,
+				p.bestMatch.Origin.Handler.Identity().Name,
+				p.bestMatch.Origin.HandlerType,
 			)
 		}
 
 		s.AppendListItem("check the content of the message")
 	} else {
-		if e.best.Origin == nil {
+		if p.bestMatch.Origin == nil {
 			rep.Explanation = inflect.Sprint(
-				e.role,
+				p.expectedRole,
 				"a <message> of a similar type was <produced> via a <dispatcher>",
 			)
 		} else {
 			rep.Explanation = inflect.Sprintf(
-				e.role,
+				p.expectedRole,
 				"a <message> of a similar type was <produced> by the '%s' %s message handler",
-				e.best.Origin.Handler.Identity().Name,
-				e.best.Origin.HandlerType,
+				p.bestMatch.Origin.Handler.Identity().Name,
+				p.bestMatch.Origin.HandlerType,
 			)
 		}
 
@@ -231,38 +212,29 @@ func (e *messageExpectation) buildReportExpectedRole(rep *Report) {
 		s.AppendListItem("check the message type, should it be a pointer?")
 	}
 
-	e.buildDiff(rep)
+	p.buildDiff(rep)
 }
 
-// buildDiff adds a "message diff" section to the result.
-func (e *messageExpectation) buildDiff(rep *Report) {
-	report.WriteDiff(
-		&rep.Section("Message Diff").Content,
-		report.RenderMessage(e.expected),
-		report.RenderMessage(e.best.Message),
-	)
-}
-
-// buildReportExpectedRole builds a test report when there is a "best-match"
+// reportExpectedRole builds a test report when there is a "best-match"
 // message available but it is of an unexpected role.
-func (e *messageExpectation) buildReportUnexpectedRole(rep *Report) {
+func (p *messagePredicate) reportUnexpectedRole(rep *Report) {
 	s := rep.Section(suggestionsSection)
 
-	if e.best.Origin == nil {
+	if p.bestMatch.Origin == nil {
 		s.AppendListItem(inflect.Sprint(
-			e.best.Role,
+			p.bestMatch.Role,
 			"verify that a <message> of this type was intended to be <produced> via a <dispatcher>",
 		))
 	} else {
 		s.AppendListItem(inflect.Sprintf(
-			e.best.Role,
+			p.bestMatch.Role,
 			"verify that the '%s' %s message handler intended to <produce> a <message> of this type",
-			e.best.Origin.Handler.Identity().Name,
-			e.best.Origin.HandlerType,
+			p.bestMatch.Origin.Handler.Identity().Name,
+			p.bestMatch.Origin.HandlerType,
 		))
 	}
 
-	if e.role == message.CommandRole {
+	if p.expectedRole == message.CommandRole {
 		s.AppendListItem("verify that ToExecuteCommand() is the correct expectation, did you mean ToRecordEvent()?")
 	} else {
 		s.AppendListItem("verify that ToRecordEvent() is the correct expectation, did you mean ToExecuteCommand()?")
@@ -270,50 +242,50 @@ func (e *messageExpectation) buildReportUnexpectedRole(rep *Report) {
 
 	// the "best-match" is equal to the expected message. this means that only
 	// the roles were mismatched.
-	if e.equal {
-		if e.best.Origin == nil {
+	if p.bestMatchIsEqual {
+		if p.bestMatch.Origin == nil {
 			rep.Explanation = inflect.Sprint(
-				e.best.Role,
+				p.bestMatch.Role,
 				"the expected message was <produced> as a <message> via a <dispatcher>",
 			)
 		} else {
 			rep.Explanation = inflect.Sprintf(
-				e.best.Role,
+				p.bestMatch.Role,
 				"the expected message was <produced> as a <message> by the '%s' %s message handler",
-				e.best.Origin.Handler.Identity().Name,
-				e.best.Origin.HandlerType,
+				p.bestMatch.Origin.Handler.Identity().Name,
+				p.bestMatch.Origin.HandlerType,
 			)
 		}
 
 		return // skip diff rendering
 	}
 
-	if e.dist == typecmp.Identical {
-		if e.best.Origin == nil {
+	if p.bestMatchDistance == typecmp.Identical {
+		if p.bestMatch.Origin == nil {
 			rep.Explanation = inflect.Sprint(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a similar message was <produced> as a <message> via a <dispatcher>",
 			)
 		} else {
 			rep.Explanation = inflect.Sprintf(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a similar message was <produced> as a <message> by the '%s' %s message handler",
-				e.best.Origin.Handler.Identity().Name,
-				e.best.Origin.HandlerType,
+				p.bestMatch.Origin.Handler.Identity().Name,
+				p.bestMatch.Origin.HandlerType,
 			)
 		}
 	} else {
-		if e.best.Origin == nil {
+		if p.bestMatch.Origin == nil {
 			rep.Explanation = inflect.Sprint(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a message of a similar type was <produced> as a <message> via a <dispatcher>",
 			)
 		} else {
 			rep.Explanation = inflect.Sprintf(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a message of a similar type was <produced> as a <message> by the '%s' %s message handler",
-				e.best.Origin.Handler.Identity().Name,
-				e.best.Origin.HandlerType,
+				p.bestMatch.Origin.Handler.Identity().Name,
+				p.bestMatch.Origin.HandlerType,
 			)
 		}
 
@@ -323,5 +295,14 @@ func (e *messageExpectation) buildReportUnexpectedRole(rep *Report) {
 		s.AppendListItem("check the message type, should it be a pointer?")
 	}
 
-	e.buildDiff(rep)
+	p.buildDiff(rep)
+}
+
+// buildDiff adds a "message diff" section to the result.
+func (p *messagePredicate) buildDiff(rep *Report) {
+	report.WriteDiff(
+		&rep.Section("Message Diff").Content,
+		report.RenderMessage(p.expectedMessage),
+		report.RenderMessage(p.bestMatch.Message),
+	)
 }

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -48,12 +48,6 @@ type messageExpectation struct {
 	expectedRole    message.Role
 }
 
-func (e *messageExpectation) Notify(f fact.Fact)          { panic("TODO: remove") }
-func (e *messageExpectation) Begin(o ExpectOptionSet)     { panic("TODO: remove") }
-func (e *messageExpectation) End()                        { panic("TODO: remove") }
-func (e *messageExpectation) Ok() bool                    { panic("TODO: remove") }
-func (e *messageExpectation) BuildReport(ok bool) *Report { panic("TODO: remove") }
-
 func (e *messageExpectation) Banner() string {
 	return inflect.Sprintf(
 		e.expectedRole,

--- a/expectation.messagecommon.go
+++ b/expectation.messagecommon.go
@@ -10,9 +10,9 @@ import (
 	"github.com/dogmatiq/testkit/internal/inflect"
 )
 
-// buildReportNoMatch is used by message-related expectations to build a test
-// report when no "best-match" message is found.
-func buildReportNoMatch(rep *Report, t *tracker) {
+// reportNoMatch is used by message-related predicates to build a test report
+// when no "best-match" message is found.
+func reportNoMatch(rep *Report, t *tracker) {
 	s := rep.Section(suggestionsSection)
 
 	allDisabled := true

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -83,7 +83,7 @@ func (e *messageTypeExpectation) Begin(o ExpectOptionSet) {
 		dist:     typecmp.Unrelated,
 		tracker: tracker{
 			role:               e.role,
-			matchDispatchCycle: o.MatchMessagesInDispatchCycle,
+			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
 		},
 	}
 }

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -46,12 +46,6 @@ type messageTypeExpectation struct {
 	expectedRole message.Role
 }
 
-func (e *messageTypeExpectation) Notify(f fact.Fact)          { panic("TODO: remove") }
-func (e *messageTypeExpectation) Begin(o ExpectOptionSet)     { panic("TODO: remove") }
-func (e *messageTypeExpectation) End()                        { panic("TODO: remove") }
-func (e *messageTypeExpectation) Ok() bool                    { panic("TODO: remove") }
-func (e *messageTypeExpectation) BuildReport(ok bool) *Report { panic("TODO: remove") }
-
 func (e *messageTypeExpectation) Banner() string {
 	return inflect.Sprintf(
 		e.expectedRole,

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -18,8 +18,8 @@ func ToExecuteCommandOfType(m dogma.Message) Expectation {
 	}
 
 	return &messageTypeExpectation{
-		expected: message.TypeOf(m),
-		role:     message.CommandRole,
+		expectedType: message.TypeOf(m),
+		expectedRole: message.CommandRole,
 	}
 }
 
@@ -31,168 +31,127 @@ func ToRecordEventOfType(m dogma.Message) Expectation {
 	}
 
 	return &messageTypeExpectation{
-		expected: message.TypeOf(m),
-		role:     message.EventRole,
+		expectedType: message.TypeOf(m),
+		expectedRole: message.EventRole,
 	}
 }
 
-// messageTypeExpectation verifies that a message of a specific type is
-// produced, either as a command or an event.
+// messageTypeExpectation is an Expectation that checks that a message of a
+// specific type is produced.
+//
+// It is the implementation used by ToExecuteCommand() and ToRecordEvent().
 type messageTypeExpectation struct {
-	// Expected is the type of the message that is expected to be produced.
-	expected message.Type
-
-	// Role is the expected role that the message must have.
-	// It must be either CommandRole or EventRole.
-	role message.Role
-
-	// ok is true once the expectation has passed, after which no further
-	// updates are performed.
-	ok bool
-
-	// best is an envelope containing the "best-match" message found so far.
-	// Note that this message may not have the expected role.
-	best *envelope.Envelope
-
-	// dist is a distance between the expected message type, and the current
-	// best-match.
-	dist typecmp.Distance
-
-	// tracker observes the handlers and messages that are involved in the test.
-	tracker tracker
+	expectedType message.Type
+	expectedRole message.Role
 }
 
-// Banner returns a human-readable banner to display in the logs when this
-// expectation is used.
-//
-// The banner text should be in uppercase, and complete the sentence "The
-// application is expected ...". For example, "TO DO A THING".
+func (e *messageTypeExpectation) Notify(f fact.Fact)          { panic("TODO: remove") }
+func (e *messageTypeExpectation) Begin(o ExpectOptionSet)     { panic("TODO: remove") }
+func (e *messageTypeExpectation) End()                        { panic("TODO: remove") }
+func (e *messageTypeExpectation) Ok() bool                    { panic("TODO: remove") }
+func (e *messageTypeExpectation) BuildReport(ok bool) *Report { panic("TODO: remove") }
+
 func (e *messageTypeExpectation) Banner() string {
 	return inflect.Sprintf(
-		e.role,
+		e.expectedRole,
 		"TO <PRODUCE> A <MESSAGE> OF TYPE %s",
-		e.expected,
+		e.expectedType,
 	)
 }
 
-// Begin is called to prepare the expectation for a new test.
-func (e *messageTypeExpectation) Begin(o ExpectOptionSet) {
-	*e = messageTypeExpectation{
-		expected: e.expected,
-		role:     e.role,
-		dist:     typecmp.Unrelated,
+func (e *messageTypeExpectation) Predicate(o PredicateOptions) Predicate {
+	return &messageTypePredicate{
+		expectedType:      e.expectedType,
+		expectedRole:      e.expectedRole,
+		bestMatchDistance: typecmp.Unrelated,
 		tracker: tracker{
-			role:               e.role,
+			role:               e.expectedRole,
 			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
 		},
 	}
 }
 
-// End is called once the test is complete.
-func (e *messageTypeExpectation) End() {
+// messageTypePredicate is the Predicate implementation for
+// messageTypeExpectation.
+type messageTypePredicate struct {
+	expectedType      message.Type
+	expectedRole      message.Role
+	ok                bool
+	bestMatch         *envelope.Envelope
+	bestMatchDistance typecmp.Distance
+	tracker           tracker
 }
 
-// Ok returns true if the expectation passed.
-func (e *messageTypeExpectation) Ok() bool {
-	return e.ok
+func (p *messageTypePredicate) Notify(f fact.Fact) {
+	if p.ok {
+		return
+	}
+
+	p.tracker.Notify(f)
+
+	switch x := f.(type) {
+	case fact.DispatchCycleBegun:
+		if p.tracker.matchDispatchCycle {
+			p.messageProduced(x.Envelope)
+		}
+	case fact.EventRecordedByAggregate:
+		p.messageProduced(x.EventEnvelope)
+	case fact.EventRecordedByIntegration:
+		p.messageProduced(x.EventEnvelope)
+	case fact.CommandExecutedByProcess:
+		p.messageProduced(x.CommandEnvelope)
+	}
 }
 
-// BuildReport generates a report about the expectation.
-//
-// ok is true if the expectation is considered to have passed. This may not be
-// the same value as returned from Ok() when this expectation is used as a child
-// of a composite expectation.
-func (e *messageTypeExpectation) BuildReport(ok bool) *Report {
+func (p *messageTypePredicate) Ok() bool {
+	return p.ok
+}
+
+func (p *messageTypePredicate) Done() {
+}
+
+func (p *messageTypePredicate) Report(treeOk bool) *Report {
 	rep := &Report{
-		TreeOk: ok,
-		Ok:     e.ok,
+		TreeOk: treeOk,
+		Ok:     p.ok,
 		Criteria: inflect.Sprintf(
-			e.role,
+			p.expectedRole,
 			"<produce> any '%s' <message>",
-			e.expected,
+			p.expectedType,
 		),
 	}
 
-	if ok || e.ok {
+	if treeOk || p.ok {
 		return rep
 	}
 
-	if e.best == nil {
-		buildReportNoMatch(rep, &e.tracker)
-	} else if e.best.Role == e.role {
-		e.buildReportExpectedRole(rep)
+	if p.bestMatch == nil {
+		buildReportNoMatch(rep, &p.tracker)
+	} else if p.bestMatch.Role == p.expectedRole {
+		p.reportExpectedRole(rep)
 	} else {
-		e.buildReportUnexpectedRole(rep)
+		p.reportUnexpectedRole(rep)
 	}
 
 	return rep
 }
 
-// Notify updates the expectation's state in response to a new fact.
-func (e *messageTypeExpectation) Notify(f fact.Fact) {
-	if e.ok {
-		return
-	}
-
-	e.tracker.Notify(f)
-
-	switch x := f.(type) {
-	case fact.DispatchCycleBegun:
-		if e.tracker.matchDispatchCycle {
-			e.messageProduced(x.Envelope)
-		}
-	case fact.EventRecordedByAggregate:
-		e.messageProduced(x.EventEnvelope)
-	case fact.EventRecordedByIntegration:
-		e.messageProduced(x.EventEnvelope)
-	case fact.CommandExecutedByProcess:
-		e.messageProduced(x.CommandEnvelope)
-	}
-}
-
-// messageProduced updates the expectation's state to reflect the fact that a
-// message has been produced.
-func (e *messageTypeExpectation) messageProduced(env *envelope.Envelope) {
-	dist := typecmp.MeasureDistance(
-		e.expected.ReflectType(),
-		env.Type.ReflectType(),
-	)
-
-	if dist < e.dist {
-		e.best = env
-		e.dist = dist
-	}
-
-	if dist == typecmp.Identical && e.role == env.Role {
-		e.ok = true
-	}
-}
-
-// buildDiff adds a "message type diff" section to the result.
-func (e *messageTypeExpectation) buildDiff(rep *Report) {
-	report.WriteDiff(
-		&rep.Section("Message Type Diff").Content,
-		e.expected.String(),
-		e.best.Type.ReflectType().String(),
-	)
-}
-
-// buildReportExpectedRole builds a test report when there is a "best-match"
-// message available and it is of the expected role.
-func (e *messageTypeExpectation) buildReportExpectedRole(rep *Report) {
+// reportExpectedRole builds a test report when a "best-match" message was found
+// and it has the expected role.
+func (p *messageTypePredicate) reportExpectedRole(rep *Report) {
 	s := rep.Section(suggestionsSection)
 
-	if e.best.Origin == nil {
+	if p.bestMatch.Origin == nil {
 		rep.Explanation = inflect.Sprint(
-			e.role,
+			p.expectedRole,
 			"a <message> of a similar type was <produced> via a <dispatcher>",
 		)
 	} else {
 		rep.Explanation = inflect.Sprintf(
-			e.role,
+			p.expectedRole,
 			"a <message> of a similar type was <produced> by the '%s' %s message handler",
-			e.best.Origin.Handler.Identity().Name,
-			e.best.Origin.Handler.HandlerType(),
+			p.bestMatch.Origin.Handler.Identity().Name,
+			p.bestMatch.Origin.Handler.HandlerType(),
 		)
 	}
 
@@ -200,60 +159,60 @@ func (e *messageTypeExpectation) buildReportExpectedRole(rep *Report) {
 	// it currently is or isn't a pointer, just questions if it should be.
 	s.AppendListItem("check the message type, should it be a pointer?")
 
-	e.buildDiff(rep)
+	p.buildDiff(rep)
 }
 
-// buildReportUnexpectedRole builds a test report when there is a "best-match"
-// message available but it does not have the expected role.
-func (e *messageTypeExpectation) buildReportUnexpectedRole(rep *Report) {
+// reportUnexpectedRole builds a test report when a "best-match" message was
+// found but it does not have the expected role.
+func (p *messageTypePredicate) reportUnexpectedRole(rep *Report) {
 	s := rep.Section(suggestionsSection)
 
-	if e.best.Origin == nil {
+	if p.bestMatch.Origin == nil {
 		s.AppendListItem(inflect.Sprint(
-			e.best.Role,
+			p.bestMatch.Role,
 			"verify that a <message> of this type was intended to be <produced> via a <dispatcher>",
 		))
 	} else {
 		s.AppendListItem(inflect.Sprintf(
-			e.best.Role,
+			p.bestMatch.Role,
 			"verify that the '%s' %s message handler intended to <produce> a <message> of this type",
-			e.best.Origin.Handler.Identity().Name,
-			e.best.Origin.Handler.HandlerType(),
+			p.bestMatch.Origin.Handler.Identity().Name,
+			p.bestMatch.Origin.Handler.HandlerType(),
 		))
 	}
 
-	if e.role == message.CommandRole {
+	if p.expectedRole == message.CommandRole {
 		s.AppendListItem("verify that ToExecuteCommandOfType() is the correct expectation, did you mean ToRecordEventOfType()?")
 	} else {
 		s.AppendListItem("verify that ToRecordEventOfType() is the correct expectation, did you mean ToExecuteCommandOfType()?")
 	}
 
-	if e.dist == typecmp.Identical {
-		if e.best.Origin == nil {
+	if p.bestMatchDistance == typecmp.Identical {
+		if p.bestMatch.Origin == nil {
 			rep.Explanation = inflect.Sprint(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a message of this type was <produced> as a <message> via a <dispatcher>",
 			)
 		} else {
 			rep.Explanation = inflect.Sprintf(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a message of this type was <produced> as a <message> by the '%s' %s message handler",
-				e.best.Origin.Handler.Identity().Name,
-				e.best.Origin.Handler.HandlerType(),
+				p.bestMatch.Origin.Handler.Identity().Name,
+				p.bestMatch.Origin.Handler.HandlerType(),
 			)
 		}
 	} else {
-		if e.best.Origin == nil {
+		if p.bestMatch.Origin == nil {
 			rep.Explanation = inflect.Sprint(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a message of a similar type was <produced> as a <message> via a <dispatcher>",
 			)
 		} else {
 			rep.Explanation = inflect.Sprintf(
-				e.best.Role,
+				p.bestMatch.Role,
 				"a message of a similar type was <produced> as a <message> by the '%s' %s message handler",
-				e.best.Origin.Handler.Identity().Name,
-				e.best.Origin.Handler.HandlerType(),
+				p.bestMatch.Origin.Handler.Identity().Name,
+				p.bestMatch.Origin.Handler.HandlerType(),
 			)
 		}
 
@@ -262,6 +221,33 @@ func (e *messageTypeExpectation) buildReportUnexpectedRole(rep *Report) {
 		// should be.
 		s.AppendListItem("check the message type, should it be a pointer?")
 
-		e.buildDiff(rep)
+		p.buildDiff(rep)
+	}
+}
+
+// buildDiff adds a "message type diff" section to the result.
+func (p *messageTypePredicate) buildDiff(rep *Report) {
+	report.WriteDiff(
+		&rep.Section("Message Type Diff").Content,
+		p.expectedType.String(),
+		p.bestMatch.Type.String(),
+	)
+}
+
+// messageProduced updates the predicates's state to reflect the fact that a
+// message has been produced.
+func (p *messageTypePredicate) messageProduced(env *envelope.Envelope) {
+	dist := typecmp.MeasureDistance(
+		p.expectedType.ReflectType(),
+		env.Type.ReflectType(),
+	)
+
+	if dist < p.bestMatchDistance {
+		p.bestMatch = env
+		p.bestMatchDistance = dist
+	}
+
+	if dist == typecmp.Identical && p.expectedRole == env.Role {
+		p.ok = true
 	}
 }

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -46,12 +46,6 @@ type satisfyExpectation struct {
 	pred     func(*SatisfyT)
 }
 
-func (e *satisfyExpectation) Notify(f fact.Fact)          { panic("TODO: remove") }
-func (e *satisfyExpectation) Begin(o ExpectOptionSet)     { panic("TODO: remove") }
-func (e *satisfyExpectation) End()                        { panic("TODO: remove") }
-func (e *satisfyExpectation) Ok() bool                    { panic("TODO: remove") }
-func (e *satisfyExpectation) BuildReport(ok bool) *Report { panic("TODO: remove") }
-
 func (e *satisfyExpectation) Banner() string {
 	return "TO " + strings.ToUpper(e.criteria)
 }
@@ -130,12 +124,14 @@ func (p *satisfyPredicate) Report(treeOk bool) *Report {
 // SatisfyT is used within expectations made via ToSatisfy() to enforce the
 // expectation.
 //
-// It is analogous to the *testing.T type that is passed to tests in the native Go
-// test runner.
+// It is analogous to the *testing.T type that is passed to tests in the native
+// Go test runner.
 type SatisfyT struct {
-	// Options contains the set of options that dictate the behavior of the
-	// expectation.
-	Options ExpectOptionSet
+	// Options contains the set of options that change the behavior of the
+	// predicate function.
+	//
+	// They are not necessarily applicable to every predicate.
+	Options PredicateOptions
 
 	// Facts is an ordered slice of the facts that occurred.
 	Facts []fact.Fact

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -39,6 +39,8 @@ func ToSatisfy(
 
 // satisfyExpectation is an Expectation that calls a user-supplied function to
 // check for arbitrary criteria.
+//
+// It is the implementation used by ToSatisfy().
 type satisfyExpectation struct {
 	criteria string
 	pred     func(*SatisfyT)

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -15,6 +15,8 @@ const (
 
 // staticExpectation is is an Expectation that always produces the same result.
 // It is intended to be used for testing the test system itself.
+//
+// It implements both the Expectation and Predicate interfaces.
 type staticExpectation bool
 
 func (a staticExpectation) Banner() string {
@@ -26,12 +28,9 @@ func (a staticExpectation) Banner() string {
 }
 
 func (a staticExpectation) Predicate(PredicateOptions) Predicate { return a }
-func (a staticExpectation) Begin(ExpectOptionSet)                { panic("TODO: remove") }
-func (a staticExpectation) End()                                 { panic("TODO: remove") }
+func (a staticExpectation) Notify(fact.Fact)                     {}
 func (a staticExpectation) Ok() bool                             { return bool(a) }
 func (a staticExpectation) Done()                                {}
-func (a staticExpectation) Notify(fact.Fact)                     {}
-func (a staticExpectation) BuildReport(treeOk bool) *Report      { panic("TODO: remove") }
 func (a staticExpectation) Report(treeOk bool) *Report {
 	c := "<always fail>"
 	if a {

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -25,18 +25,20 @@ func (a staticExpectation) Banner() string {
 	return "TO [ALWAYS FAIL]"
 }
 
-func (a staticExpectation) Begin(ExpectOptionSet) {}
-func (a staticExpectation) End()                  {}
-func (a staticExpectation) Ok() bool              { return bool(a) }
-func (a staticExpectation) Notify(fact.Fact)      {}
-func (a staticExpectation) BuildReport(ok bool) *Report {
+func (a staticExpectation) Predicate(PredicateOptions) Predicate { return a }
+func (a staticExpectation) Begin(ExpectOptionSet)                {}
+func (a staticExpectation) End()                                 {}
+func (a staticExpectation) Ok() bool                             { return bool(a) }
+func (a staticExpectation) Notify(fact.Fact)                     {}
+func (a staticExpectation) BuildReport(treeOk bool) *Report      { return a.Done(treeOk) }
+func (a staticExpectation) Done(treeOk bool) *Report {
 	c := "<always fail>"
 	if a {
 		c = "<always pass>"
 	}
 
 	return &Report{
-		TreeOk:   ok,
+		TreeOk:   treeOk,
 		Ok:       bool(a),
 		Criteria: c,
 	}

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -26,12 +26,13 @@ func (a staticExpectation) Banner() string {
 }
 
 func (a staticExpectation) Predicate(PredicateOptions) Predicate { return a }
-func (a staticExpectation) Begin(ExpectOptionSet)                {}
-func (a staticExpectation) End()                                 {}
+func (a staticExpectation) Begin(ExpectOptionSet)                { panic("TODO: remove") }
+func (a staticExpectation) End()                                 { panic("TODO: remove") }
 func (a staticExpectation) Ok() bool                             { return bool(a) }
+func (a staticExpectation) Done()                                {}
 func (a staticExpectation) Notify(fact.Fact)                     {}
-func (a staticExpectation) BuildReport(treeOk bool) *Report      { return a.Done(treeOk) }
-func (a staticExpectation) Done(treeOk bool) *Report {
+func (a staticExpectation) BuildReport(treeOk bool) *Report      { panic("TODO: remove") }
+func (a staticExpectation) Report(treeOk bool) *Report {
 	c := "<always fail>"
 	if a {
 		c = "<always pass>"

--- a/test.go
+++ b/test.go
@@ -96,6 +96,7 @@ func (t *Test) Expect(act Action, e Expectation) {
 
 	if pe, ok := e.(predicateBasedExpectation); ok {
 		t.expectPred(act, pe)
+		return
 	}
 
 	o := PredicateOptions{}
@@ -132,13 +133,6 @@ func (t *Test) expectPred(act Action, e predicateBasedExpectation) {
 	if err := t.applyAction(act, engine.WithObserver(p)); err != nil {
 		t.testingT.Fatal(err)
 	}
-
-	func() {
-		// Wrapping this defer in the closure guarantees not only that it is
-		// always called, but that it is called before t.buildReport().
-		defer e.End()
-
-	}()
 
 	rep := p.Done(p.Ok())
 

--- a/test.go
+++ b/test.go
@@ -91,18 +91,11 @@ func (t *Test) Prepare(actions ...Action) *Test {
 }
 
 // Expect ensures that a single action results in some expected behavior.
-func (t *Test) Expect(act Action, e Expectation, options ...ExpectOption) {
+func (t *Test) Expect(act Action, e Expectation) {
 	t.testingT.Helper()
 
-	o := ExpectOptionSet{}
-
-	for _, opt := range act.ExpectOptions() {
-		opt(&o)
-	}
-
-	for _, opt := range options {
-		opt(&o)
-	}
+	o := PredicateOptions{}
+	act.ConfigurePredicate(&o)
 
 	e.Begin(o)
 


### PR DESCRIPTION
#### What change does this introduce?

This PR splits the `Expectation` interface into two separate interfaces. The existing `Expectation` interface represents the expectation, such as "record a specific <foo> event". The new `Predicate` interface is the object that actually tests that a given set of facts satisfy that expectation.

#### What issues does this relate to?

Fixes #199 

#### Why make this change?

- It makes `Expectations` stateless
- It prevents misuse of the `Expectation` interface, because you can no longer call things out of order

#### Is there anything you are unsure about?

No