### PR TITLE
Check roles of messages used in expectations.

### DIFF
--- a/action.dispatch.go
+++ b/action.dispatch.go
@@ -58,6 +58,10 @@ func (a dispatchAction) Apply(ctx context.Context, s ActionScope) error {
 	mt := message.TypeOf(a.m)
 	r, ok := s.App.MessageTypes().RoleOf(mt)
 
+	// TODO: These checks should result in information being added to the
+	// report, not just returning an error.
+	//
+	// See https://github.com/dogmatiq/testkit/issues/162
 	if !ok {
 		return inflect.Errorf(
 			a.r,

--- a/expectation.composite.go
+++ b/expectation.composite.go
@@ -115,11 +115,14 @@ func (e *compositeExpectation) Banner() string {
 	return e.banner
 }
 
-func (e *compositeExpectation) Predicate(o PredicateOptions) (Predicate, error) {
+func (e *compositeExpectation) Predicate(
+	s PredicateScope,
+	o PredicateOptions,
+) (Predicate, error) {
 	var children []Predicate
 
 	for _, c := range e.children {
-		p, err := c.Predicate(o)
+		p, err := c.Predicate(s, o)
 		if err != nil {
 			return nil, err
 		}

--- a/expectation.go
+++ b/expectation.go
@@ -1,6 +1,7 @@
 package testkit
 
 import (
+	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/testkit/fact"
 )
 
@@ -18,7 +19,7 @@ type Expectation interface {
 	//
 	// The predicate must be closed by calling Done() once the action it tests
 	// is completed.
-	Predicate(o PredicateOptions) (Predicate, error)
+	Predicate(s PredicateScope, o PredicateOptions) (Predicate, error)
 }
 
 // Predicate tests whether a specific Action satisfies an Expectation.
@@ -47,6 +48,13 @@ type Predicate interface {
 	//
 	// The behavior of Report() is undefined if Done() has not been called.
 	Report(treeOk bool) *Report
+}
+
+// PredicateScope encapsulates the element's of a Test's state that may be
+// inspected by Predicate implementations.
+type PredicateScope struct {
+	// App is the application being tested.
+	App configkit.RichApplication
 }
 
 // PredicateOptions contains values that dictate how a predicate should behave.

--- a/expectation.message.commandcall_test.go
+++ b/expectation.message.commandcall_test.go
@@ -32,7 +32,9 @@ var _ = Describe("func ToExecuteCommand() (when used with the Call() action)", f
 				c.RegisterAggregate(&AggregateMessageHandler{
 					ConfigureFunc: func(c dogma.AggregateConfigurer) {
 						c.Identity("<aggregate>", "<aggregate-key>")
-						c.ConsumesCommandType(MessageR{}) // R = record an event
+						c.ConsumesCommandType(MessageR{})  // R = record an event
+						c.ConsumesCommandType(&MessageR{}) // pointer, used to test type similarity
+						c.ConsumesCommandType(MessageX{})
 						c.ProducesEventType(MessageN{})
 					},
 					RouteCommandToInstanceFunc: func(dogma.Message) string {
@@ -216,65 +218,6 @@ var _ = Describe("func ToExecuteCommand() (when used with the Call() action)", f
 				`  | MESSAGE DIFF`,
 				`  |     fixtures.MessageR{`,
 				`  |         Value: "R[-2-]{+1+}"`,
-				`  |     }`,
-			),
-		),
-		Entry(
-			"expected message recorded as an event rather than executed as a command",
-			recordEventViaRecorder(MessageN1),
-			ToExecuteCommand(MessageN1),
-			expectFail,
-			expectReport(
-				`✗ execute a specific 'fixtures.MessageN' command`,
-				``,
-				`  | EXPLANATION`,
-				`  |     the expected message was recorded as an event via a dogma.EventRecorder`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that an event of this type was intended to be recorded via a dogma.EventRecorder`,
-				`  |     • verify that ToExecuteCommand() is the correct expectation, did you mean ToRecordEvent()?`,
-			),
-		),
-		Entry(
-			"similar message with a different value recorded as an event rather than executed as a command",
-			recordEventViaRecorder(MessageN1),
-			ToExecuteCommand(MessageN2),
-			expectFail,
-			expectReport(
-				`✗ execute a specific 'fixtures.MessageN' command`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a similar message was recorded as an event via a dogma.EventRecorder`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that an event of this type was intended to be recorded via a dogma.EventRecorder`,
-				`  |     • verify that ToExecuteCommand() is the correct expectation, did you mean ToRecordEvent()?`,
-				`  | `,
-				`  | MESSAGE DIFF`,
-				`  |     fixtures.MessageN{`,
-				`  |         Value: "N[-2-]{+1+}"`,
-				`  |     }`,
-			),
-		),
-		Entry(
-			"similar message with a different type recorded as an event rather than executed as a command",
-			recordEventViaRecorder(MessageN1),
-			ToExecuteCommand(&MessageN1), // note: message type is pointer
-			expectFail,
-			expectReport(
-				`✗ execute a specific '*fixtures.MessageN' command`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a message of a similar type was recorded as an event via a dogma.EventRecorder`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that an event of this type was intended to be recorded via a dogma.EventRecorder`,
-				`  |     • verify that ToExecuteCommand() is the correct expectation, did you mean ToRecordEvent()?`,
-				`  |     • check the message type, should it be a pointer?`,
-				`  | `,
-				`  | MESSAGE DIFF`,
-				`  |     [-*-]fixtures.MessageN{`,
-				`  |         Value: "N1"`,
 				`  |     }`,
 			),
 		),

--- a/expectation.message.event_test.go
+++ b/expectation.message.event_test.go
@@ -17,7 +17,6 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 	var (
 		testingT *testingmock.T
 		app      dogma.Application
-		test     *Test
 	)
 
 	BeforeEach(func() {
@@ -35,6 +34,8 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 						c.ConsumesCommandType(MessageR{}) // R = record an event
 						c.ConsumesCommandType(MessageN{}) // N = do nothing
 						c.ProducesEventType(MessageE{})
+						c.ProducesEventType(&MessageE{}) // pointer, used to test type similarity
+						c.ProducesEventType(MessageX{})
 					},
 					RouteCommandToInstanceFunc: func(dogma.Message) string {
 						return "<instance>"
@@ -54,6 +55,7 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 					ConfigureFunc: func(c dogma.ProcessConfigurer) {
 						c.Identity("<process>", "<process-key>")
 						c.ConsumesEventType(MessageE{}) // E = execute a command
+						c.ConsumesEventType(MessageO{}) // O = only consumed, never produced
 						c.ProducesCommandType(MessageN{})
 					},
 					RouteEventToInstanceFunc: func(
@@ -87,7 +89,7 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 			rm reportMatcher,
 			options ...TestOption,
 		) {
-			test = Begin(testingT, app, options...)
+			test := Begin(testingT, app, options...)
 			test.Expect(a, e)
 			rm(testingT)
 			Expect(testingT.Failed()).To(Equal(!ok))
@@ -229,66 +231,46 @@ var _ = Describe("func ToExecuteCommandOfType()", func() {
 				`  |     }`,
 			),
 		),
-		Entry(
-			"expected message executed as a command rather than recorded as an event",
-			RecordEvent(MessageE1),
-			ToRecordEvent(MessageN1),
-			expectFail,
-			expectReport(
-				`✗ record a specific 'fixtures.MessageN' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     the expected message was executed as a command by the '<process>' process message handler`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that the '<process>' process message handler intended to execute a command of this type`,
-				`  |     • verify that ToRecordEvent() is the correct expectation, did you mean ToExecuteCommand()?`,
-			),
-		),
-		Entry(
-			"similar message with a different value executed as a command rather than recorded as an event",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(MessageN2),
-			expectFail,
-			expectReport(
-				`✗ record a specific 'fixtures.MessageN' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a similar message was executed as a command by the '<process>' process message handler`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that the '<process>' process message handler intended to execute a command of this type`,
-				`  |     • verify that ToRecordEvent() is the correct expectation, did you mean ToExecuteCommand()?`,
-				`  | `,
-				`  | MESSAGE DIFF`,
-				`  |     fixtures.MessageN{`,
-				`  |         Value: "N[-2-]{+1+}"`,
-				`  |     }`,
-			),
-		),
-		Entry(
-			"similar message with a different type executed as a command rather than recorded as an event",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(&MessageN1), // note: message type is pointer
-			expectFail,
-			expectReport(
-				`✗ record a specific '*fixtures.MessageN' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a message of a similar type was executed as a command by the '<process>' process message handler`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that the '<process>' process message handler intended to execute a command of this type`,
-				`  |     • verify that ToRecordEvent() is the correct expectation, did you mean ToExecuteCommand()?`,
-				`  |     • check the message type, should it be a pointer?`,
-				`  | `,
-				`  | MESSAGE DIFF`,
-				`  |     [-*-]fixtures.MessageN{`,
-				`  |         Value: "N1"`,
-				`  |     }`,
-			),
-		),
 	)
+
+	It("fails the test if the message type is unrecognized", func() {
+		test := Begin(testingT, app)
+		test.Expect(
+			noop,
+			ToRecordEvent(MessageU1),
+		)
+
+		Expect(testingT.Failed()).To(BeTrue())
+		Expect(testingT.Logs).To(ContainElement(
+			"an event of type fixtures.MessageU can never be recorded, the application does not use this message type",
+		))
+	})
+
+	It("fails the test if the message type is not an event", func() {
+		test := Begin(testingT, app)
+		test.Expect(
+			noop,
+			ToRecordEvent(MessageR1),
+		)
+
+		Expect(testingT.Failed()).To(BeTrue())
+		Expect(testingT.Logs).To(ContainElement(
+			"fixtures.MessageR is a command, it can never be recorded as an event",
+		))
+	})
+
+	It("fails the test if the message type is not produced by any handlers", func() {
+		test := Begin(testingT, app)
+		test.Expect(
+			noop,
+			ToRecordEvent(MessageO1),
+		)
+
+		Expect(testingT.Failed()).To(BeTrue())
+		Expect(testingT.Logs).To(ContainElement(
+			"no handlers record events of type fixtures.MessageO, it is only ever consumed",
+		))
+	})
 
 	It("panics if the message is nil", func() {
 		Expect(func() {

--- a/expectation.message.eventcall_test.go
+++ b/expectation.message.eventcall_test.go
@@ -35,6 +35,8 @@ var _ = Describe("func ToRecordEvent() (when used with the Call() action)", func
 						c.ConsumesCommandType(MessageR{}) // R = record an event
 						c.ConsumesCommandType(MessageN{}) // N = do nothing
 						c.ProducesEventType(MessageE{})
+						c.ProducesEventType(&MessageE{}) // pointer, used to test type similarity
+						c.ProducesEventType(MessageX{})
 					},
 					RouteCommandToInstanceFunc: func(dogma.Message) string {
 						return "<instance>"
@@ -222,65 +224,6 @@ var _ = Describe("func ToRecordEvent() (when used with the Call() action)", func
 				`  | MESSAGE DIFF`,
 				`  |     fixtures.MessageE{`,
 				`  |         Value: "E[-2-]{+1+}"`,
-				`  |     }`,
-			),
-		),
-		Entry(
-			"expected message executed as a command rather than recorded as an event",
-			executeCommandViaExecutor(MessageR1),
-			ToRecordEvent(MessageR1),
-			expectFail,
-			expectReport(
-				`✗ record a specific 'fixtures.MessageR' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     the expected message was executed as a command via a dogma.CommandExecutor`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that a command of this type was intended to be executed via a dogma.CommandExecutor`,
-				`  |     • verify that ToRecordEvent() is the correct expectation, did you mean ToExecuteCommand()?`,
-			),
-		),
-		Entry(
-			"similar message with a different value executed as a command rather than recorded as an event",
-			executeCommandViaExecutor(MessageR1),
-			ToRecordEvent(MessageR2),
-			expectFail,
-			expectReport(
-				`✗ record a specific 'fixtures.MessageR' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a similar message was executed as a command via a dogma.CommandExecutor`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that a command of this type was intended to be executed via a dogma.CommandExecutor`,
-				`  |     • verify that ToRecordEvent() is the correct expectation, did you mean ToExecuteCommand()?`,
-				`  | `,
-				`  | MESSAGE DIFF`,
-				`  |     fixtures.MessageR{`,
-				`  |         Value: "R[-2-]{+1+}"`,
-				`  |     }`,
-			),
-		),
-		Entry(
-			"similar message with a different type executed as a command rather than recorded as an event",
-			executeCommandViaExecutor(MessageR1),
-			ToRecordEvent(&MessageR1), // note: message type is pointer
-			expectFail,
-			expectReport(
-				`✗ record a specific '*fixtures.MessageR' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a message of a similar type was executed as a command via a dogma.CommandExecutor`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that a command of this type was intended to be executed via a dogma.CommandExecutor`,
-				`  |     • verify that ToRecordEvent() is the correct expectation, did you mean ToExecuteCommand()?`,
-				`  |     • check the message type, should it be a pointer?`,
-				`  | `,
-				`  | MESSAGE DIFF`,
-				`  |     [-*-]fixtures.MessageR{`,
-				`  |         Value: "R1"`,
 				`  |     }`,
 			),
 		),

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -56,7 +56,10 @@ func (e *messageExpectation) Banner() string {
 	)
 }
 
-func (e *messageExpectation) Predicate(o PredicateOptions) (Predicate, error) {
+func (e *messageExpectation) Predicate(
+	s PredicateScope,
+	o PredicateOptions,
+) (Predicate, error) {
 	return &messagePredicate{
 		expectedMessage:   e.expectedMessage,
 		expectedRole:      e.expectedRole,

--- a/expectation.messagetype.commandcall_test.go
+++ b/expectation.messagetype.commandcall_test.go
@@ -32,7 +32,9 @@ var _ = Describe("func ToExecuteCommandOfType() (when used with the Call() actio
 				c.RegisterAggregate(&AggregateMessageHandler{
 					ConfigureFunc: func(c dogma.AggregateConfigurer) {
 						c.Identity("<aggregate>", "<aggregate-key>")
-						c.ConsumesCommandType(MessageR{}) // R = record an event
+						c.ConsumesCommandType(MessageR{})  // R = record an event
+						c.ConsumesCommandType(&MessageR{}) // pointer, used to test type similarity
+						c.ConsumesCommandType(MessageX{})
 						c.ProducesEventType(MessageN{})
 					},
 					RouteCommandToInstanceFunc: func(dogma.Message) string {
@@ -195,42 +197,6 @@ var _ = Describe("func ToExecuteCommandOfType() (when used with the Call() actio
 				`  | `,
 				`  | MESSAGE TYPE DIFF`,
 				`  |     [-*-]fixtures.MessageR`,
-			),
-		),
-		Entry(
-			"expected message type recorded as an event rather than executed as a command",
-			recordEventViaRecorder(MessageN1),
-			ToExecuteCommandOfType(MessageN{}),
-			expectFail,
-			expectReport(
-				`✗ execute any 'fixtures.MessageN' command`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a message of this type was recorded as an event via a dogma.EventRecorder`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that an event of this type was intended to be recorded via a dogma.EventRecorder`,
-				`  |     • verify that ToExecuteCommandOfType() is the correct expectation, did you mean ToRecordEventOfType()?`,
-			),
-		),
-		Entry(
-			"a message with a similar type recorded as an event rather than executed as a command",
-			recordEventViaRecorder(MessageN1),
-			ToExecuteCommandOfType(&MessageN{}), // note: message type is pointer
-			expectFail,
-			expectReport(
-				`✗ execute any '*fixtures.MessageN' command`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a message of a similar type was recorded as an event via a dogma.EventRecorder`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that an event of this type was intended to be recorded via a dogma.EventRecorder`,
-				`  |     • verify that ToExecuteCommandOfType() is the correct expectation, did you mean ToRecordEventOfType()?`,
-				`  |     • check the message type, should it be a pointer?`,
-				`  | `,
-				`  | MESSAGE TYPE DIFF`,
-				`  |     [-*-]fixtures.MessageN`,
 			),
 		),
 	)

--- a/expectation.messagetype.eventcall_test.go
+++ b/expectation.messagetype.eventcall_test.go
@@ -35,6 +35,8 @@ var _ = Describe("func ToRecordEventOfType() (when used with the Call() action)"
 						c.ConsumesCommandType(MessageR{}) // R = record an event
 						c.ConsumesCommandType(MessageN{}) // N = do nothing
 						c.ProducesEventType(MessageE{})
+						c.ProducesEventType(&MessageE{}) // pointer, used to test type similarity
+						c.ProducesEventType(MessageX{})
 					},
 					RouteCommandToInstanceFunc: func(dogma.Message) string {
 						return "<instance>"
@@ -201,42 +203,6 @@ var _ = Describe("func ToRecordEventOfType() (when used with the Call() action)"
 				`  | `,
 				`  | MESSAGE TYPE DIFF`,
 				`  |     [-*-]fixtures.MessageE`,
-			),
-		),
-		Entry(
-			"expected message type executed as a command rather than recorded as an event",
-			executeCommandViaExecutor(MessageR1),
-			ToRecordEventOfType(MessageR{}),
-			expectFail,
-			expectReport(
-				`✗ record any 'fixtures.MessageR' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a message of this type was executed as a command via a dogma.CommandExecutor`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that a command of this type was intended to be executed via a dogma.CommandExecutor`,
-				`  |     • verify that ToRecordEventOfType() is the correct expectation, did you mean ToExecuteCommandOfType()?`,
-			),
-		),
-		Entry(
-			"a message with a similar type executed as a command rather than recorded as an event",
-			executeCommandViaExecutor(MessageR1),
-			ToRecordEventOfType(&MessageR{}), // note: message type is pointer
-			expectFail,
-			expectReport(
-				`✗ record any '*fixtures.MessageR' event`,
-				``,
-				`  | EXPLANATION`,
-				`  |     a message of a similar type was executed as a command via a dogma.CommandExecutor`,
-				`  | `,
-				`  | SUGGESTIONS`,
-				`  |     • verify that a command of this type was intended to be executed via a dogma.CommandExecutor`,
-				`  |     • verify that ToRecordEventOfType() is the correct expectation, did you mean ToExecuteCommandOfType()?`,
-				`  |     • check the message type, should it be a pointer?`,
-				`  | `,
-				`  | MESSAGE TYPE DIFF`,
-				`  |     [-*-]fixtures.MessageR`,
 			),
 		),
 	)

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -58,38 +58,6 @@ func (e *messageTypeExpectation) Predicate(
 	s PredicateScope,
 	o PredicateOptions,
 ) (Predicate, error) {
-	r, ok := s.App.MessageTypes().RoleOf(e.expectedType)
-
-	// TODO: These checks should result in information being added to the
-	// report, not just returning an error.
-	//
-	// See https://github.com/dogmatiq/testkit/issues/162
-	if !ok {
-		return nil, inflect.Errorf(
-			e.expectedRole,
-			"a <message> of type %s can never be <produced>, the application does not use this message type",
-			e.expectedType,
-		)
-	} else if r != e.expectedRole {
-		return nil, inflect.Errorf(
-			e.expectedRole,
-			"%s is a %s, it can never be <produced> as a <message>",
-			e.expectedType,
-			r,
-		)
-	} else if !o.MatchDispatchCycleStartedFacts {
-		// If we're NOT matching messages from DispatchCycleStarted facts that
-		// means this expectation can only ever pass if the message is produced
-		// by a handler.
-		if _, ok := s.App.MessageTypes().Produced[e.expectedType]; !ok {
-			return nil, inflect.Errorf(
-				e.expectedRole,
-				"no handlers <produce> <messages> of type %s, it is only ever consumed",
-				e.expectedType,
-			)
-		}
-	}
-
 	return &messageTypePredicate{
 		expectedType:      e.expectedType,
 		expectedRole:      e.expectedRole,
@@ -98,7 +66,7 @@ func (e *messageTypeExpectation) Predicate(
 			role:               e.expectedRole,
 			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
 		},
-	}, nil
+	}, validateRole(s, o, e.expectedType, e.expectedRole)
 }
 
 // messageTypePredicate is the Predicate implementation for

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -54,7 +54,10 @@ func (e *messageTypeExpectation) Banner() string {
 	)
 }
 
-func (e *messageTypeExpectation) Predicate(o PredicateOptions) (Predicate, error) {
+func (e *messageTypeExpectation) Predicate(
+	s PredicateScope,
+	o PredicateOptions,
+) (Predicate, error) {
 	return &messageTypePredicate{
 		expectedType:      e.expectedType,
 		expectedRole:      e.expectedRole,

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -50,7 +50,10 @@ func (e *satisfyExpectation) Banner() string {
 	return "TO " + strings.ToUpper(e.criteria)
 }
 
-func (e satisfyExpectation) Predicate(o PredicateOptions) (Predicate, error) {
+func (e satisfyExpectation) Predicate(
+	s PredicateScope,
+	o PredicateOptions,
+) (Predicate, error) {
 	return &satisfyPredicate{
 		criteria: e.criteria,
 		pred:     e.pred,

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -35,7 +35,10 @@ func (e staticExpectation) Banner() string {
 	return "TO [ALWAYS FAIL]"
 }
 
-func (e staticExpectation) Predicate(PredicateOptions) (Predicate, error) {
+func (e staticExpectation) Predicate(
+	PredicateScope,
+	PredicateOptions,
+) (Predicate, error) {
 	return e, e.err
 }
 

--- a/internal/inflect/inflect.go
+++ b/internal/inflect/inflect.go
@@ -57,9 +57,9 @@ func Sprint(r message.Role, s string) string {
 
 // Sprintf formats a string, inflecting words in f match the message role r.
 func Sprintf(r message.Role, f string, v ...interface{}) string {
-	return fmt.Sprintf(
-		Sprint(r, f),
-		v...,
+	return Sprint(
+		r,
+		fmt.Sprintf(f, v...),
 	)
 }
 
@@ -70,8 +70,5 @@ func Error(r message.Role, s string) error {
 
 // Errorf returns a new error, inflecting words in f to match the message role r.
 func Errorf(r message.Role, f string, v ...interface{}) error {
-	return fmt.Errorf(
-		Sprint(r, f),
-		v...,
-	)
+	return errors.New(Sprintf(r, f, v...))
 }

--- a/test.go
+++ b/test.go
@@ -94,12 +94,13 @@ func (t *Test) Prepare(actions ...Action) *Test {
 func (t *Test) Expect(act Action, e Expectation) {
 	t.testingT.Helper()
 
+	s := PredicateScope{App: t.app}
 	o := PredicateOptions{}
 	act.ConfigurePredicate(&o)
 
 	logf(t.testingT, "--- EXPECT %s %s ---", act.Banner(), e.Banner())
 
-	p, err := e.Predicate(o)
+	p, err := e.Predicate(s, o)
 	if err != nil {
 		t.testingT.Fatal(err)
 		return // required when using a mock testingT that does not panic


### PR DESCRIPTION
#### What change does this introduce?

This PR "fails fast" if `ToExecuteCommand[OfType]()` or `ToRecordEvent[OfType]()` are passed a message of the wrong role.

#### What issues does this relate to?

Fixes #196 

#### Why make this change?

We can check this without actually running the engine/application code, which makes the expectation reporting logic simpler.

#### Is there anything you are unsure about?

No