### PR TITLE
Allow `Expectation.Predicate()` to return an error.

### DIFF
--- a/expectation.composite.go
+++ b/expectation.composite.go
@@ -115,18 +115,23 @@ func (e *compositeExpectation) Banner() string {
 	return e.banner
 }
 
-func (e *compositeExpectation) Predicate(o PredicateOptions) Predicate {
+func (e *compositeExpectation) Predicate(o PredicateOptions) (Predicate, error) {
 	var children []Predicate
 
 	for _, c := range e.children {
-		children = append(children, c.Predicate(o))
+		p, err := c.Predicate(o)
+		if err != nil {
+			return nil, err
+		}
+
+		children = append(children, p)
 	}
 
 	return &compositePredicate{
 		criteria: e.criteria,
 		children: children,
 		pred:     e.pred,
-	}
+	}, nil
 }
 
 // compositePredicate is the Predicate implementation for compositeExpectation.

--- a/expectation.composite_test.go
+++ b/expectation.composite_test.go
@@ -97,6 +97,16 @@ var _ = Context("composite expectations", func() {
 			))
 		})
 
+		It("fails the test if one of its children can not construct a predicate", func() {
+			test.Expect(
+				noop,
+				AllOf(pass, failBeforeAction),
+			)
+
+			Expect(testingT.Logs).To(ContainElement("<always fail before action>"))
+			Expect(testingT.Failed()).To(BeTrue())
+		})
+
 		It("panics if no children are provided", func() {
 			Expect(func() {
 				AllOf()
@@ -157,6 +167,16 @@ var _ = Context("composite expectations", func() {
 			Expect(testingT.Logs).To(ContainElement(
 				"--- EXPECT [NO-OP] TO MEET AT LEAST ONE OF 2 EXPECTATIONS ---",
 			))
+		})
+
+		It("fails the test if one of its children can not construct a predicate", func() {
+			test.Expect(
+				noop,
+				AnyOf(pass, failBeforeAction),
+			)
+
+			Expect(testingT.Logs).To(ContainElement("<always fail before action>"))
+			Expect(testingT.Failed()).To(BeTrue())
 		})
 
 		It("panics if no children are provided", func() {
@@ -231,6 +251,16 @@ var _ = Context("composite expectations", func() {
 			Expect(testingT.Logs).To(ContainElement(
 				"--- EXPECT [NO-OP] NOT TO [ALWAYS PASS] ---",
 			))
+		})
+
+		It("fails the test if one of its children can not construct a predicate", func() {
+			test.Expect(
+				noop,
+				NoneOf(pass, failBeforeAction),
+			)
+
+			Expect(testingT.Logs).To(ContainElement("<always fail before action>"))
+			Expect(testingT.Failed()).To(BeTrue())
 		})
 
 		It("panics if no children are provided", func() {

--- a/expectation.go
+++ b/expectation.go
@@ -18,7 +18,7 @@ type Expectation interface {
 	//
 	// The predicate must be closed by calling Done() once the action it tests
 	// is completed.
-	Predicate(o PredicateOptions) Predicate
+	Predicate(o PredicateOptions) (Predicate, error)
 }
 
 // Predicate tests whether a specific Action satisfies an Expectation.

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -56,7 +56,7 @@ func (e *messageExpectation) Banner() string {
 	)
 }
 
-func (e *messageExpectation) Predicate(o PredicateOptions) Predicate {
+func (e *messageExpectation) Predicate(o PredicateOptions) (Predicate, error) {
 	return &messagePredicate{
 		expectedMessage:   e.expectedMessage,
 		expectedRole:      e.expectedRole,
@@ -65,7 +65,7 @@ func (e *messageExpectation) Predicate(o PredicateOptions) Predicate {
 			role:               e.expectedRole,
 			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
 		},
-	}
+	}, nil
 }
 
 // messagePredicate is the Predicate implementation for messageExpectation.

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -54,7 +54,7 @@ func (e *messageTypeExpectation) Banner() string {
 	)
 }
 
-func (e *messageTypeExpectation) Predicate(o PredicateOptions) Predicate {
+func (e *messageTypeExpectation) Predicate(o PredicateOptions) (Predicate, error) {
 	return &messageTypePredicate{
 		expectedType:      e.expectedType,
 		expectedRole:      e.expectedRole,
@@ -63,7 +63,7 @@ func (e *messageTypeExpectation) Predicate(o PredicateOptions) Predicate {
 			role:               e.expectedRole,
 			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
 		},
-	}
+	}, nil
 }
 
 // messageTypePredicate is the Predicate implementation for

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -50,7 +50,7 @@ func (e *satisfyExpectation) Banner() string {
 	return "TO " + strings.ToUpper(e.criteria)
 }
 
-func (e satisfyExpectation) Predicate(o PredicateOptions) Predicate {
+func (e satisfyExpectation) Predicate(o PredicateOptions) (Predicate, error) {
 	return &satisfyPredicate{
 		criteria: e.criteria,
 		pred:     e.pred,
@@ -58,7 +58,7 @@ func (e satisfyExpectation) Predicate(o PredicateOptions) Predicate {
 			Options: o,
 			name:    e.criteria,
 		},
-	}
+	}, nil
 }
 
 // compositePredicate is the Predicate implementation for satisfyExpectation.


### PR DESCRIPTION
#### What change does this introduce?

This PR changes `Expectation.Predicate()` to return an error.

#### What issues does this relate to?

Prepares for #196 

#### Why make this change?

This allows the expectation to indicate a failure before the Dogma application is started.

#### Is there anything you are unsure about?

No