### PR TITLE
Use opaque types for functional options.

### DIFF
--- a/test.go
+++ b/test.go
@@ -69,7 +69,7 @@ func BeginContext(
 	}
 
 	for _, opt := range options {
-		opt(test)
+		opt.applyTestOption(test)
 	}
 
 	return test

--- a/testoption.go
+++ b/testoption.go
@@ -7,16 +7,24 @@ import (
 )
 
 // TestOption applies optional settings to a test.
-type TestOption func(*Test)
+type TestOption interface {
+	applyTestOption(*Test)
+}
+
+type testOptionFunc func(*Test)
+
+func (f testOptionFunc) applyTestOption(t *Test) {
+	f(t)
+}
 
 // StartTimeAt returns a test option that sets the initial time of the test's
 // virtual clock.
 //
 // By default, the current system time is used.
 func StartTimeAt(st time.Time) TestOption {
-	return func(t *Test) {
+	return testOptionFunc(func(t *Test) {
 		t.virtualClock = st
-	}
+	})
 }
 
 // WithUnsafeOperationOptions returns a TestOption that applies a set of engine
@@ -28,7 +36,7 @@ func StartTimeAt(st time.Time) TestOption {
 // The provided options may override options that the Test sets during its
 // normal operation and should be used with caution.
 func WithUnsafeOperationOptions(options ...engine.OperationOption) TestOption {
-	return func(t *Test) {
+	return testOptionFunc(func(t *Test) {
 		t.operationOptions = append(t.operationOptions, options...)
-	}
+	})
 }


### PR DESCRIPTION
#### What change does this introduce?

This PR changes the various "functional option" types to use an interface with unexported methods.

#### What issues does this relate to?

None

#### Why make this change?

To mitigate future BC breaks. This approach entirely hides the implementation details of the options from the user while still allowing references to the option type itself.

#### Is there anything you are unsure about?

No