### PR TITLE
Put `PredicateOptions` inside `PredicateScope`.

### DIFF
--- a/expectation.composite.go
+++ b/expectation.composite.go
@@ -115,14 +115,11 @@ func (e *compositeExpectation) Banner() string {
 	return e.banner
 }
 
-func (e *compositeExpectation) Predicate(
-	s PredicateScope,
-	o PredicateOptions,
-) (Predicate, error) {
+func (e *compositeExpectation) Predicate(s PredicateScope) (Predicate, error) {
 	var children []Predicate
 
 	for _, c := range e.children {
-		p, err := c.Predicate(s, o)
+		p, err := c.Predicate(s)
 		if err != nil {
 			return nil, err
 		}

--- a/expectation.go
+++ b/expectation.go
@@ -19,7 +19,7 @@ type Expectation interface {
 	//
 	// The predicate must be closed by calling Done() once the action it tests
 	// is completed.
-	Predicate(s PredicateScope, o PredicateOptions) (Predicate, error)
+	Predicate(s PredicateScope) (Predicate, error)
 }
 
 // Predicate tests whether a specific Action satisfies an Expectation.
@@ -55,6 +55,10 @@ type Predicate interface {
 type PredicateScope struct {
 	// App is the application being tested.
 	App configkit.RichApplication
+
+	// Options contains values that dictate how the predicate should behave.
+	// The options are provided by the Test and the Action being performed.
+	Options PredicateOptions
 }
 
 // PredicateOptions contains values that dictate how a predicate should behave.

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -59,10 +59,7 @@ func (e *messageExpectation) Banner() string {
 	)
 }
 
-func (e *messageExpectation) Predicate(
-	s PredicateScope,
-	o PredicateOptions,
-) (Predicate, error) {
+func (e *messageExpectation) Predicate(s PredicateScope) (Predicate, error) {
 	return &messagePredicate{
 		expectedMessage:   e.expectedMessage,
 		expectedType:      e.expectedType,
@@ -70,9 +67,9 @@ func (e *messageExpectation) Predicate(
 		bestMatchDistance: typecmp.Unrelated,
 		tracker: tracker{
 			role:               e.expectedRole,
-			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
+			matchDispatchCycle: s.Options.MatchDispatchCycleStartedFacts,
 		},
-	}, validateRole(s, o, e.expectedType, e.expectedRole)
+	}, validateRole(s, e.expectedType, e.expectedRole)
 }
 
 // messagePredicate is the Predicate implementation for messageExpectation.

--- a/expectation.messagecommon.go
+++ b/expectation.messagecommon.go
@@ -75,7 +75,6 @@ func reportNoMatch(rep *Report, t *tracker) {
 // within the application.
 func validateRole(
 	s PredicateScope,
-	o PredicateOptions,
 	t message.Type,
 	r message.Role,
 ) error {
@@ -98,7 +97,7 @@ func validateRole(
 			t,
 			actual,
 		)
-	} else if !o.MatchDispatchCycleStartedFacts {
+	} else if !s.Options.MatchDispatchCycleStartedFacts {
 		// If we're NOT matching messages from DispatchCycleStarted facts that
 		// means this expectation can only ever pass if the message is produced
 		// by a handler.

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -54,19 +54,16 @@ func (e *messageTypeExpectation) Banner() string {
 	)
 }
 
-func (e *messageTypeExpectation) Predicate(
-	s PredicateScope,
-	o PredicateOptions,
-) (Predicate, error) {
+func (e *messageTypeExpectation) Predicate(s PredicateScope) (Predicate, error) {
 	return &messageTypePredicate{
 		expectedType:      e.expectedType,
 		expectedRole:      e.expectedRole,
 		bestMatchDistance: typecmp.Unrelated,
 		tracker: tracker{
 			role:               e.expectedRole,
-			matchDispatchCycle: o.MatchDispatchCycleStartedFacts,
+			matchDispatchCycle: s.Options.MatchDispatchCycleStartedFacts,
 		},
-	}, validateRole(s, o, e.expectedType, e.expectedRole)
+	}, validateRole(s, e.expectedType, e.expectedRole)
 }
 
 // messageTypePredicate is the Predicate implementation for

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -50,15 +50,12 @@ func (e *satisfyExpectation) Banner() string {
 	return "TO " + strings.ToUpper(e.criteria)
 }
 
-func (e satisfyExpectation) Predicate(
-	s PredicateScope,
-	o PredicateOptions,
-) (Predicate, error) {
+func (e satisfyExpectation) Predicate(s PredicateScope) (Predicate, error) {
 	return &satisfyPredicate{
 		criteria: e.criteria,
 		pred:     e.pred,
 		satisfyT: SatisfyT{
-			Options: o,
+			Options: s.Options,
 			name:    e.criteria,
 		},
 	}, nil

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -35,16 +35,10 @@ func (e staticExpectation) Banner() string {
 	return "TO [ALWAYS FAIL]"
 }
 
-func (e staticExpectation) Predicate(
-	PredicateScope,
-	PredicateOptions,
-) (Predicate, error) {
-	return e, e.err
-}
-
-func (e staticExpectation) Notify(fact.Fact) {}
-func (e staticExpectation) Ok() bool         { return e.ok }
-func (e staticExpectation) Done()            {}
+func (e staticExpectation) Predicate(PredicateScope) (Predicate, error) { return e, e.err }
+func (e staticExpectation) Notify(fact.Fact)                            {}
+func (e staticExpectation) Ok() bool                                    { return e.ok }
+func (e staticExpectation) Done()                                       {}
 func (e staticExpectation) Report(treeOk bool) *Report {
 	c := "<always fail>"
 	if e.ok {

--- a/test.go
+++ b/test.go
@@ -95,12 +95,11 @@ func (t *Test) Expect(act Action, e Expectation) {
 	t.testingT.Helper()
 
 	s := PredicateScope{App: t.app}
-	o := PredicateOptions{}
-	act.ConfigurePredicate(&o)
+	act.ConfigurePredicate(&s.Options)
 
 	logf(t.testingT, "--- EXPECT %s %s ---", act.Banner(), e.Banner())
 
-	p, err := e.Predicate(s, o)
+	p, err := e.Predicate(s)
 	if err != nil {
 		t.testingT.Fatal(err)
 		return // required when using a mock testingT that does not panic


### PR DESCRIPTION
#### What change does this introduce?

This PR removes the `PredicateOptions` parameter from the `Expectation.Predicate()` method and instead places it inside the `PredicateScope`.

#### What issues does this relate to?

None

#### Why make this change?

The purpose of the `PredicateScope` type is essentially to emulate key/value parameters to help minimize BC breaks to to the `Predicate` interface. It's counter to this goal to have a separate parameter for this options.

#### Is there anything you are unsure about?

No