### PR TITLE
Return tracked envelope from `tracker.Notify()`.

### DIFF
--- a/expectation.message.go
+++ b/expectation.message.go
@@ -66,8 +66,8 @@ func (e *messageExpectation) Predicate(s PredicateScope) (Predicate, error) {
 		expectedRole:      e.expectedRole,
 		bestMatchDistance: typecmp.Unrelated,
 		tracker: tracker{
-			role:               e.expectedRole,
-			matchDispatchCycle: s.Options.MatchDispatchCycleStartedFacts,
+			role:    e.expectedRole,
+			options: s.Options,
 		},
 	}, validateRole(s, e.expectedType, e.expectedRole)
 }
@@ -90,19 +90,8 @@ func (p *messagePredicate) Notify(f fact.Fact) {
 		return
 	}
 
-	p.tracker.Notify(f)
-
-	switch x := f.(type) {
-	case fact.DispatchCycleBegun:
-		if p.tracker.matchDispatchCycle {
-			p.messageProduced(x.Envelope)
-		}
-	case fact.EventRecordedByAggregate:
-		p.messageProduced(x.EventEnvelope)
-	case fact.EventRecordedByIntegration:
-		p.messageProduced(x.EventEnvelope)
-	case fact.CommandExecutedByProcess:
-		p.messageProduced(x.CommandEnvelope)
+	if env, ok := p.tracker.Notify(f); ok {
+		p.messageProduced(env)
 	}
 }
 

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -60,8 +60,8 @@ func (e *messageTypeExpectation) Predicate(s PredicateScope) (Predicate, error) 
 		expectedRole:      e.expectedRole,
 		bestMatchDistance: typecmp.Unrelated,
 		tracker: tracker{
-			role:               e.expectedRole,
-			matchDispatchCycle: s.Options.MatchDispatchCycleStartedFacts,
+			role:    e.expectedRole,
+			options: s.Options,
 		},
 	}, validateRole(s, e.expectedType, e.expectedRole)
 }
@@ -82,19 +82,8 @@ func (p *messageTypePredicate) Notify(f fact.Fact) {
 		return
 	}
 
-	p.tracker.Notify(f)
-
-	switch x := f.(type) {
-	case fact.DispatchCycleBegun:
-		if p.tracker.matchDispatchCycle {
-			p.messageProduced(x.Envelope)
-		}
-	case fact.EventRecordedByAggregate:
-		p.messageProduced(x.EventEnvelope)
-	case fact.EventRecordedByIntegration:
-		p.messageProduced(x.EventEnvelope)
-	case fact.CommandExecutedByProcess:
-		p.messageProduced(x.CommandEnvelope)
+	if env, ok := p.tracker.Notify(f); ok {
+		p.messageProduced(env)
 	}
 }
 


### PR DESCRIPTION
#### What change does this introduce?

This PR changes the `tracker.Notify()` method to return the envelope of the "tracked" message within the fact.

#### What issues does this relate to?

None

#### Why make this change?

Eliminates a bit of code that is duplicated across `messageExpectation` and `messageTypeExpectation`.

#### Is there anything you are unsure about?

No