### PR TITLE
Replace "banners" with lazily evaluated "captions".

### DIFF
--- a/action.advancetime.go
+++ b/action.advancetime.go
@@ -72,9 +72,9 @@ type advanceTimeAction struct {
 	loc location.Location
 }
 
-func (a advanceTimeAction) Banner() string {
+func (a advanceTimeAction) Caption() string {
 	return fmt.Sprintf(
-		"ADVANCING TIME (%s)",
+		"advancing time %s",
 		a.adj.Description(),
 	)
 }

--- a/action.advancetime_test.go
+++ b/action.advancetime_test.go
@@ -125,13 +125,13 @@ var _ = Describe("func AdvanceTime()", func() {
 			))
 		})
 
-		It("produces the expected banner", func() {
+		It("produces the expected caption", func() {
 			test.Prepare(
 				AdvanceTime(ToTime(targetTime)),
 			)
 
 			Expect(t.Logs).To(ContainElement(
-				"--- ADVANCING TIME (to 2100-01-02T03:04:05Z) ---",
+				"--- advancing time to 2100-01-02T03:04:05Z ---",
 			))
 		})
 	})
@@ -156,13 +156,13 @@ var _ = Describe("func AdvanceTime()", func() {
 			))
 		})
 
-		It("produces the expected banner", func() {
+		It("produces the expected caption", func() {
 			test.Prepare(
 				AdvanceTime(ByDuration(3 * time.Second)),
 			)
 
 			Expect(t.Logs).To(ContainElement(
-				"--- ADVANCING TIME (by 3s) ---",
+				"--- advancing time by 3s ---",
 			))
 		})
 

--- a/action.call.go
+++ b/action.call.go
@@ -37,8 +37,8 @@ type callAction struct {
 	loc location.Location
 }
 
-func (a callAction) Banner() string {
-	return "CALLING USER-DEFINED FUNCTION"
+func (a callAction) Caption() string {
+	return "calling user-defined function"
 }
 
 func (a callAction) Location() location.Location {

--- a/action.call_test.go
+++ b/action.call_test.go
@@ -172,13 +172,13 @@ var _ = Describe("func Call()", func() {
 		)
 	})
 
-	It("produces the expected banner", func() {
+	It("produces the expected caption", func() {
 		test.Prepare(
 			Call(func() {}),
 		)
 
 		Expect(t.Logs).To(ContainElement(
-			"--- CALLING USER-DEFINED FUNCTION ---",
+			"--- calling user-defined function ---",
 		))
 	})
 

--- a/action.dispatch.command_test.go
+++ b/action.dispatch.command_test.go
@@ -125,13 +125,13 @@ var _ = Describe("func ExecuteCommand()", func() {
 		Expect(t.Failed()).To(BeTrue())
 	})
 
-	It("produces the expected banner", func() {
+	It("produces the expected caption", func() {
 		test.Prepare(
 			ExecuteCommand(MessageC1),
 		)
 
 		Expect(t.Logs).To(ContainElement(
-			"--- EXECUTING fixtures.MessageC COMMAND ---",
+			"--- executing fixtures.MessageC command ---",
 		))
 	})
 

--- a/action.dispatch.event_test.go
+++ b/action.dispatch.event_test.go
@@ -127,13 +127,13 @@ var _ = Describe("func RecordEvent()", func() {
 		Expect(t.Failed()).To(BeTrue())
 	})
 
-	It("produces the expected banner", func() {
+	It("produces the expected caption", func() {
 		test.Prepare(
 			RecordEvent(MessageE1),
 		)
 
 		Expect(t.Logs).To(ContainElement(
-			"--- RECORDING fixtures.MessageE EVENT ---",
+			"--- recording fixtures.MessageE event ---",
 		))
 	})
 

--- a/action.dispatch.go
+++ b/action.dispatch.go
@@ -44,10 +44,10 @@ type dispatchAction struct {
 	loc location.Location
 }
 
-func (a dispatchAction) Banner() string {
+func (a dispatchAction) Caption() string {
 	return inflect.Sprintf(
 		a.r,
-		"<PRODUCING> %T <MESSAGE>",
+		"<producing> %T <message>",
 		a.m,
 	)
 }

--- a/action.go
+++ b/action.go
@@ -14,12 +14,9 @@ import (
 // Actions always attempt to cause some state change within the engine or
 // application.
 type Action interface {
-	// Banner returns a human-readable banner to display in the logs when this
-	// action is performed.
-	//
-	// The banner text should be in uppercase, and worded in the present tense,
-	// for example "DOING ACTION".
-	Banner() string
+	// Caption returns the caption that should be used for this action in the
+	// test report.
+	Caption() string
 
 	// Location returns the location within the code that the action was
 	// constructed.

--- a/action_test.go
+++ b/action_test.go
@@ -16,7 +16,7 @@ type noopAction struct {
 	err error
 }
 
-func (a noopAction) Banner() string                              { return "[NO-OP]" }
+func (a noopAction) Caption() string                             { return "[no-op]" }
 func (a noopAction) Location() location.Location                 { return location.Location{Func: "<noop>"} }
 func (a noopAction) ConfigurePredicate(*PredicateOptions)        {}
 func (a noopAction) Do(ctx context.Context, s ActionScope) error { return a.err }

--- a/expectation.composite.go
+++ b/expectation.composite.go
@@ -19,7 +19,7 @@ func AllOf(children ...Expectation) Expectation {
 	}
 
 	return &compositeExpectation{
-		banner:   fmt.Sprintf("TO MEET %d EXPECTATIONS", n),
+		caption:  fmt.Sprintf("to meet %d expectations", n),
 		criteria: "all of",
 		children: children,
 		pred: func(passed int) (string, bool) {
@@ -48,7 +48,7 @@ func AnyOf(children ...Expectation) Expectation {
 	}
 
 	return &compositeExpectation{
-		banner:   fmt.Sprintf("TO MEET AT LEAST ONE OF %d EXPECTATIONS", n),
+		caption:  fmt.Sprintf("to meet at least one of %d expectations", n),
 		criteria: "any of",
 		children: children,
 		pred: func(passed int) (string, bool) {
@@ -72,13 +72,13 @@ func NoneOf(children ...Expectation) Expectation {
 		panic("NoneOf(): at least one child expectation must be provided")
 	}
 
-	banner := fmt.Sprintf("NOT TO MEET ANY OF %d EXPECTATIONS", n)
+	caption := fmt.Sprintf("not to meet any of %d expectations", n)
 	if n == 1 {
-		banner = fmt.Sprintf("NOT %s", children[0].Banner())
+		caption = fmt.Sprintf("not %s", children[0].Caption())
 	}
 
 	return &compositeExpectation{
-		banner:   banner,
+		caption:  caption,
 		criteria: "none of",
 		children: children,
 		pred: func(passed int) (string, bool) {
@@ -105,14 +105,14 @@ func NoneOf(children ...Expectation) Expectation {
 // It uses a predicate function to determine whether the composite expectation
 // is met based on how many of the "child" expectations are met.
 type compositeExpectation struct {
-	banner   string
+	caption  string
 	criteria string
 	children []Expectation
 	pred     func(passed int) (outcome string, ok bool)
 }
 
-func (e *compositeExpectation) Banner() string {
-	return e.banner
+func (e *compositeExpectation) Caption() string {
+	return e.caption
 }
 
 func (e *compositeExpectation) Predicate(s PredicateScope) (Predicate, error) {

--- a/expectation.composite_test.go
+++ b/expectation.composite_test.go
@@ -86,14 +86,14 @@ var _ = Context("composite expectations", func() {
 			),
 		)
 
-		It("produces the expected banner", func() {
+		It("produces the expected caption", func() {
 			test.Expect(
 				noop,
 				AllOf(pass, fail),
 			)
 
 			Expect(testingT.Logs).To(ContainElement(
-				"--- EXPECT [NO-OP] TO MEET 2 EXPECTATIONS ---",
+				"--- expect [no-op] to meet 2 expectations ---",
 			))
 		})
 
@@ -158,14 +158,14 @@ var _ = Context("composite expectations", func() {
 			),
 		)
 
-		It("produces the expected banner", func() {
+		It("produces the expected caption", func() {
 			test.Expect(
 				noop,
 				AnyOf(pass, fail),
 			)
 
 			Expect(testingT.Logs).To(ContainElement(
-				"--- EXPECT [NO-OP] TO MEET AT LEAST ONE OF 2 EXPECTATIONS ---",
+				"--- expect [no-op] to meet at least one of 2 expectations ---",
 			))
 		})
 
@@ -231,25 +231,25 @@ var _ = Context("composite expectations", func() {
 			),
 		)
 
-		It("produces the expected banner", func() {
+		It("produces the expected caption", func() {
 			test.Expect(
 				noop,
 				NoneOf(pass, fail),
 			)
 
 			Expect(testingT.Logs).To(ContainElement(
-				"--- EXPECT [NO-OP] NOT TO MEET ANY OF 2 EXPECTATIONS ---",
+				"--- expect [no-op] not to meet any of 2 expectations ---",
 			))
 		})
 
-		It("produces the expected banner when there is only one child", func() {
+		It("produces the expected caption when there is only one child", func() {
 			test.Expect(
 				noop,
 				NoneOf(pass),
 			)
 
 			Expect(testingT.Logs).To(ContainElement(
-				"--- EXPECT [NO-OP] NOT TO [ALWAYS PASS] ---",
+				"--- expect [no-op] not to [always pass] ---",
 			))
 		})
 

--- a/expectation.go
+++ b/expectation.go
@@ -7,12 +7,9 @@ import (
 
 // An Expectation describes some criteria that may be met by an action.
 type Expectation interface {
-	// Banner returns a human-readable banner to display in the logs when this
-	// expectation is used.
-	//
-	// The banner text should be in uppercase, and complete the sentence "The
-	// application is expected ...". For example, "TO DO A THING".
-	Banner() string
+	// Caption returns the caption that should be used for this action in the
+	// test report.
+	Caption() string
 
 	// Predicate returns a new predicate that checks that this expectation is
 	// satisfied.

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -51,10 +51,10 @@ type messageExpectation struct {
 	expectedRole    message.Role
 }
 
-func (e *messageExpectation) Banner() string {
+func (e *messageExpectation) Caption() string {
 	return inflect.Sprintf(
 		e.expectedRole,
-		"TO <PRODUCE> A SPECIFIC '%s' <MESSAGE>",
+		"to <produce> a specific '%s' <message>",
 		e.expectedType,
 	)
 }

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -46,10 +46,10 @@ type messageTypeExpectation struct {
 	expectedRole message.Role
 }
 
-func (e *messageTypeExpectation) Banner() string {
+func (e *messageTypeExpectation) Caption() string {
 	return inflect.Sprintf(
 		e.expectedRole,
-		"TO <PRODUCE> A <MESSAGE> OF TYPE %s",
+		"to <produce> a <message> of type %s",
 		e.expectedType,
 	)
 }

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/dogmatiq/testkit/fact"
@@ -46,8 +45,8 @@ type satisfyExpectation struct {
 	pred     func(*SatisfyT)
 }
 
-func (e *satisfyExpectation) Banner() string {
-	return "TO " + strings.ToUpper(e.criteria)
+func (e *satisfyExpectation) Caption() string {
+	return fmt.Sprintf("to %s", e.criteria)
 }
 
 func (e satisfyExpectation) Predicate(s PredicateScope) (Predicate, error) {

--- a/expectation.satisfy_test.go
+++ b/expectation.satisfy_test.go
@@ -41,7 +41,7 @@ var _ = Describe("func ToSatisfy()", func() {
 		) {
 			test.Expect(
 				noop,
-				ToSatisfy("<criteria>", x),
+				ToSatisfy("<description>", x),
 			)
 
 			rm(testingT)
@@ -52,7 +52,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			func(*SatisfyT) {},
 			expectPass,
 			expectReport(
-				`✓ <criteria>`,
+				`✓ <description>`,
 			),
 		),
 		Entry(
@@ -62,7 +62,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Fail() called at expectation.satisfy_test.go:61`,
@@ -75,7 +75,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectPass,
 			expectReport(
-				`✓ <criteria> (the expectation was skipped)`,
+				`✓ <description> (the expectation was skipped)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     SkipNow() called at expectation.satisfy_test.go:74`,
@@ -88,7 +88,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectPass,
 			expectReport(
-				`✓ <criteria>`,
+				`✓ <description>`,
 				``,
 				`  | LOG MESSAGES`,
 				`  |     <message>`,
@@ -101,7 +101,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectPass,
 			expectReport(
-				`✓ <criteria>`,
+				`✓ <description>`,
 				``,
 				`  | LOG MESSAGES`,
 				`  |     <format value>`,
@@ -114,7 +114,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Error() called at expectation.satisfy_test.go:113`,
@@ -130,7 +130,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Errorf() called at expectation.satisfy_test.go:129`,
@@ -146,7 +146,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Fatal() called at expectation.satisfy_test.go:145`,
@@ -162,7 +162,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Fatalf() called at expectation.satisfy_test.go:161`,
@@ -183,7 +183,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Fail() called indirectly by call at expectation.satisfy_test.go:182`,
@@ -197,7 +197,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Fail() called at expectation.satisfy_test.go:196`,
@@ -217,7 +217,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			},
 			expectFail,
 			expectReport(
-				`✗ <criteria> (the expectation failed)`,
+				`✗ <description> (the expectation failed)`,
 				``,
 				`  | EXPLANATION`,
 				`  |     Fail() called indirectly by call at expectation.satisfy_test.go:216`,
@@ -225,17 +225,17 @@ var _ = Describe("func ToSatisfy()", func() {
 		),
 	)
 
-	It("produces the expected banner", func() {
+	It("produces the expected caption", func() {
 		test.Expect(
 			noop,
 			ToSatisfy(
-				"<criteria>",
+				"<description>",
 				func(*SatisfyT) {},
 			),
 		)
 
 		Expect(testingT.Logs).To(ContainElement(
-			"--- EXPECT [NO-OP] TO <CRITERIA> ---",
+			"--- expect [no-op] to <description> ---",
 		))
 	})
 
@@ -247,8 +247,8 @@ var _ = Describe("func ToSatisfy()", func() {
 
 	It("panics if the function is nil", func() {
 		Expect(func() {
-			ToSatisfy("<criteria>", nil)
-		}).To(PanicWith(`ToSatisfy("<criteria>", <nil>): function must not be nil`))
+			ToSatisfy("<description>", nil)
+		}).To(PanicWith(`ToSatisfy("<description>", <nil>): function must not be nil`))
 	})
 
 	Describe("type SatisfyT", func() {
@@ -256,7 +256,7 @@ var _ = Describe("func ToSatisfy()", func() {
 			test.Expect(
 				noop,
 				ToSatisfy(
-					"<criteria>",
+					"<description>",
 					x,
 				),
 			)
@@ -407,9 +407,9 @@ var _ = Describe("func ToSatisfy()", func() {
 		})
 
 		Describe("func Name()", func() {
-			It("returns the criteria string", func() {
+			It("returns the description", func() {
 				run(func(t *SatisfyT) {
-					Expect(t.Name()).To(Equal("<criteria>"))
+					Expect(t.Name()).To(Equal("<description>"))
 				})
 			})
 		})

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -27,12 +27,12 @@ type staticExpectation struct {
 	err error
 }
 
-func (e staticExpectation) Banner() string {
+func (e staticExpectation) Caption() string {
 	if e.ok {
-		return "TO [ALWAYS PASS]"
+		return "to [always pass]"
 	}
 
-	return "TO [ALWAYS FAIL]"
+	return "to [always fail]"
 }
 
 func (e staticExpectation) Predicate(PredicateScope) (Predicate, error) { return e, e.err }

--- a/internal/report/message_test.go
+++ b/internal/report/message_test.go
@@ -3,7 +3,7 @@ package report_test
 import (
 	"strings"
 
-	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflicts
+	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/testkit/internal/report"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -12,7 +12,7 @@ import (
 var _ = Describe("func RenderMessage()", func() {
 	It("returns a suitable representation", func() {
 		Expect(
-			RenderMessage(fixtures.MessageA1),
+			RenderMessage(MessageA1),
 		).To(Equal(join(
 			"fixtures.MessageA{",
 			`    Value: "A1"`,

--- a/test.go
+++ b/test.go
@@ -81,7 +81,7 @@ func (t *Test) Prepare(actions ...Action) *Test {
 	t.testingT.Helper()
 
 	for _, act := range actions {
-		logf(t.testingT, "--- %s ---", act.Banner())
+		logf(t.testingT, "--- %s ---", act.Caption())
 		if err := t.doAction(act); err != nil {
 			t.testingT.Fatal(err)
 		}
@@ -97,7 +97,7 @@ func (t *Test) Expect(act Action, e Expectation) {
 	s := PredicateScope{App: t.app}
 	act.ConfigurePredicate(&s.Options)
 
-	logf(t.testingT, "--- EXPECT %s %s ---", act.Banner(), e.Banner())
+	logf(t.testingT, "--- expect %s %s ---", act.Caption(), e.Caption())
 
 	p, err := e.Predicate(s)
 	if err != nil {


### PR DESCRIPTION
#### What change does this introduce?

This PR replaces the `Banner()` method on `Action` and `Expectation` with a `Caption()` method.

#### What issues does this relate to?

Prepares for #162

#### Why make this change?

In preparation for the new reporting system (which will support multiple report renderers) we don't want to be making stylistic choices (such as `Banner()`'s uppercase formatting) within the actions and expectations; this should be the responsibility of the renderer.

~The `report.LazyString` type allow deferring interpolation of format placeholders until the rendering stage. This would allow, for example, substituted parts of strings to be placed in bold in a hypothetical HTML renderer.~

For the time being (that is, before #162 is done) the existing logs show the captions exactly as they are presented (in lower case).

#### Is there anything you are unsure about?

No