### PR TITLE
Produce a separate fact to distingush between reverting aggregate des…

### DIFF
--- a/engine/internal/aggregate/scope_test.go
+++ b/engine/internal/aggregate/scope_test.go
@@ -262,7 +262,7 @@ var _ = Describe("type scope", func() {
 				))
 			})
 
-			It("records facts about instance creation and the event if called after Destroy()", func() {
+			It("records facts about reverting destruction and the event if called after Destroy()", func() {
 				handler.HandleCommandFunc = func(
 					_ dogma.AggregateRoot,
 					s dogma.AggregateCommandScope,
@@ -283,7 +283,7 @@ var _ = Describe("type scope", func() {
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(buf.Facts()).To(ContainElement(
-					fact.AggregateInstanceCreated{
+					fact.AggregateInstanceDestructionReverted{
 						Handler:    config,
 						InstanceID: "<instance>",
 						Root: &AggregateRoot{

--- a/fact/aggregate.go
+++ b/fact/aggregate.go
@@ -41,6 +41,16 @@ type AggregateInstanceDestroyed struct {
 	Envelope   *envelope.Envelope
 }
 
+// AggregateInstanceDestructionReverted indicates that an aggregate message
+// handler "reverted" destruction of an aggregate instance by recording a new
+// event.
+type AggregateInstanceDestructionReverted struct {
+	Handler    configkit.RichAggregate
+	InstanceID string
+	Root       dogma.AggregateRoot
+	Envelope   *envelope.Envelope
+}
+
 // EventRecordedByAggregate indicates that an aggregate recorded an event while
 // handling a command.
 type EventRecordedByAggregate struct {

--- a/fact/logger.go
+++ b/fact/logger.go
@@ -48,6 +48,8 @@ func (l *Logger) Notify(f Fact) {
 		l.aggregateInstanceCreated(x)
 	case AggregateInstanceDestroyed:
 		l.aggregateInstanceDestroyed(x)
+	case AggregateInstanceDestructionReverted:
+		l.aggregateInstanceDestructionReverted(x)
 	case EventRecordedByAggregate:
 		l.eventRecordedByAggregate(x)
 	case MessageLoggedByAggregate:
@@ -227,6 +229,20 @@ func (l *Logger) aggregateInstanceDestroyed(f AggregateInstanceDestroyed) {
 		},
 		f.Handler.Identity().Name+" "+f.InstanceID,
 		"instance destroyed",
+	)
+}
+
+// aggregateInstanceDestructionReverted returns the log message for f.
+func (l *Logger) aggregateInstanceDestructionReverted(f AggregateInstanceDestructionReverted) {
+	l.log(
+		f.Envelope,
+		[]logging.Icon{
+			logging.InboundIcon,
+			logging.AggregateIcon,
+			"",
+		},
+		f.Handler.Identity().Name+" "+f.InstanceID,
+		"destruction of instance reverted",
 	)
 }
 

--- a/fact/logger_test.go
+++ b/fact/logger_test.go
@@ -263,6 +263,15 @@ var _ = Describe("type Logger", func() {
 				},
 			),
 			Entry(
+				"AggregateInstanceDestructionReverted",
+				"= 10  ∵ 10  ⋲ 10  ▼ ∴    <aggregate> <instance> ● destruction of instance reverted",
+				AggregateInstanceDestructionReverted{
+					Handler:    aggregate,
+					InstanceID: "<instance>",
+					Envelope:   command,
+				},
+			),
+			Entry(
 				"EventRecordedByAggregate",
 				"= 20  ∵ 10  ⋲ 10  ▲ ∴    <aggregate> <instance> ● recorded an event ● fixtures.MessageE! ● {E1}",
 				EventRecordedByAggregate{


### PR DESCRIPTION
…truction and construction of a new instance.

<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds a new "fact" that indicates destruction of an aggregate instance was "reverted" by recording a new event within the same scope.

#### Why make this change?

Previously an `AggregateInstanceCreated` fact was produced even if it was just undoing the call to `Destroy()`. This change ensures that the fact, and more importantly the logs shown to the user properly explain what actually happened.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None