### PR TITLE
Add `ToRecordEventMatching()` expectation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- Add `ToExecuteCommandMatching()` expectation
+- Add `ToExecuteCommandMatching()` and `ToRecordEventMatching()` expectations
 - Add `ToRepeatedly()` expectation
 
 ## [0.13.0] - 2021-03-01

--- a/expectation.messagematch.event_test.go
+++ b/expectation.messagematch.event_test.go
@@ -1,0 +1,266 @@
+package testkit_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/testkit"
+	"github.com/dogmatiq/testkit/engine"
+	"github.com/dogmatiq/testkit/internal/testingmock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func ToRecordEventMatching()", func() {
+	var (
+		testingT *testingmock.T
+		app      dogma.Application
+	)
+
+	BeforeEach(func() {
+		testingT = &testingmock.T{
+			FailSilently: true,
+		}
+
+		app = &Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+
+				c.RegisterAggregate(&AggregateMessageHandler{
+					ConfigureFunc: func(c dogma.AggregateConfigurer) {
+						c.Identity("<aggregate>", "<aggregate-key>")
+						c.ConsumesCommandType(MessageR{}) // R = record an event
+						c.ConsumesCommandType(MessageN{}) // N = do nothing
+						c.ProducesEventType(MessageE{})
+						c.ProducesEventType(&MessageE{}) // pointer, used to test type similarity
+						c.ProducesEventType(MessageX{})
+					},
+					RouteCommandToInstanceFunc: func(dogma.Message) string {
+						return "<instance>"
+					},
+					HandleCommandFunc: func(
+						_ dogma.AggregateRoot,
+						s dogma.AggregateCommandScope,
+						m dogma.Message,
+					) {
+						if m, ok := m.(MessageR); ok {
+							s.RecordEvent(MessageE1)
+
+							if m.Value == "<multiple>" {
+								s.RecordEvent(MessageE1)
+							}
+						}
+					},
+				})
+
+				c.RegisterProcess(&ProcessMessageHandler{
+					ConfigureFunc: func(c dogma.ProcessConfigurer) {
+						c.Identity("<process>", "<process-key>")
+						c.ConsumesEventType(MessageE{}) // E = execute a command
+						c.ConsumesEventType(MessageO{}) // O = only consumed, never produced
+						c.ProducesCommandType(MessageN{})
+					},
+					RouteEventToInstanceFunc: func(
+						context.Context,
+						dogma.Message,
+					) (string, bool, error) {
+						return "<instance>", true, nil
+					},
+					HandleEventFunc: func(
+						_ context.Context,
+						_ dogma.ProcessRoot,
+						s dogma.ProcessEventScope,
+						m dogma.Message,
+					) error {
+						if _, ok := m.(MessageE); ok {
+							s.ExecuteCommand(MessageN1)
+						}
+						return nil
+					},
+				})
+			},
+		}
+	})
+
+	DescribeTable(
+		"expectation behavior",
+		func(
+			a Action,
+			e Expectation,
+			ok bool,
+			rm reportMatcher,
+			options ...TestOption,
+		) {
+			test := Begin(testingT, app, options...)
+			test.Expect(a, e)
+			rm(testingT)
+			Expect(testingT.Failed()).To(Equal(!ok))
+		},
+		Entry(
+			"matching event recorded as expected",
+			ExecuteCommand(MessageR1),
+			ToRecordEventMatching(
+				func(m dogma.Message) error {
+					if m == MessageE1 {
+						return nil
+					}
+
+					return errors.New("<error>")
+				},
+			),
+			expectPass,
+			expectReport(
+				`✓ record an event that satisfies a predicate function`,
+			),
+		),
+		Entry(
+			"no matching event recorded",
+			ExecuteCommand(MessageR1),
+			ToRecordEventMatching(
+				func(m dogma.Message) error {
+					if m == MessageX1 {
+						return nil
+					}
+
+					return errors.New("<error>")
+				},
+			),
+			expectFail,
+			expectReport(
+				`✗ record an event that satisfies a predicate function`,
+				``,
+				`  | EXPLANATION`,
+				`  |     none of the engaged handlers recorded a matching event`,
+				`  | `,
+				`  | FAILED MATCHES`,
+				`  |     • fixtures.MessageE: <error>`,
+				`  | `,
+				`  | SUGGESTIONS`,
+				`  |     • verify the logic within the predicate function`,
+				`  |     • enable integration handlers using the EnableHandlerType() option`,
+				`  |     • verify the logic within the '<aggregate>' aggregate message handler`,
+			),
+		),
+		Entry(
+			"no messages produced at all",
+			ExecuteCommand(MessageN1),
+			ToRecordEventMatching(
+				func(m dogma.Message) error {
+					panic("unexpected call")
+				},
+			),
+			expectFail,
+			expectReport(
+				`✗ record an event that satisfies a predicate function`,
+				``,
+				`  | EXPLANATION`,
+				`  |     no messages were produced at all`,
+				`  | `,
+				`  | SUGGESTIONS`,
+				`  |     • enable integration handlers using the EnableHandlerType() option`,
+				`  |     • verify the logic within the '<aggregate>' aggregate message handler`,
+			),
+		),
+		Entry(
+			"no events recorded at all",
+			RecordEvent(MessageE1),
+			ToRecordEventMatching(
+				func(m dogma.Message) error {
+					return IgnoreMessage
+				},
+			),
+			expectFail,
+			expectReport(
+				`✗ record an event that satisfies a predicate function`,
+				``,
+				`  | EXPLANATION`,
+				`  |     no events were recorded at all`,
+				`  | `,
+				`  | SUGGESTIONS`,
+				`  |     • enable integration handlers using the EnableHandlerType() option`,
+				`  |     • verify the logic within the '<aggregate>' aggregate message handler`,
+			),
+		),
+		Entry(
+			"no matching event recorded and all relevant handler types disabled",
+			ExecuteCommand(MessageR1),
+			ToRecordEventMatching(
+				func(m dogma.Message) error {
+					panic("unexpected call")
+				},
+			),
+			expectFail,
+			expectReport(
+				`✗ record an event that satisfies a predicate function`,
+				``,
+				`  | EXPLANATION`,
+				`  |     no relevant handler types were enabled`,
+				`  | `,
+				`  | SUGGESTIONS`,
+				`  |     • enable aggregate handlers using the EnableHandlerType() option`,
+				`  |     • enable integration handlers using the EnableHandlerType() option`,
+			),
+			WithUnsafeOperationOptions(
+				engine.EnableAggregates(false),
+				engine.EnableIntegrations(false),
+			),
+		),
+
+		Entry(
+			"no matching event recorded and events were ignored",
+			ExecuteCommand(MessageR1),
+			ToRecordEventMatching(
+				func(m dogma.Message) error {
+					return IgnoreMessage
+				},
+			),
+			expectFail,
+			expectReport(
+				`✗ record an event that satisfies a predicate function`,
+				``,
+				`  | EXPLANATION`,
+				`  |     none of the engaged handlers recorded a matching event`,
+				`  | `,
+				`  | SUGGESTIONS`,
+				`  |     • verify the logic within the predicate function, it ignored 1 event`,
+				`  |     • enable integration handlers using the EnableHandlerType() option`,
+				`  |     • verify the logic within the '<aggregate>' aggregate message handler`,
+			),
+		),
+		Entry(
+			"no matching event recorded and error messages were repeated",
+			ExecuteCommand(MessageR{
+				Value: "<multiple>", // trigger multiple MessageE events
+			}),
+			ToRecordEventMatching(
+				func(m dogma.Message) error {
+					return errors.New("<error>")
+				},
+			),
+			expectFail,
+			expectReport(
+				`✗ record an event that satisfies a predicate function`,
+				``,
+				`  | EXPLANATION`,
+				`  |     none of the engaged handlers recorded a matching event`,
+				`  | `,
+				`  | FAILED MATCHES`,
+				`  |     • fixtures.MessageE: <error> (repeated 2 times)`,
+				`  | `,
+				`  | SUGGESTIONS`,
+				`  |     • verify the logic within the predicate function`,
+				`  |     • enable integration handlers using the EnableHandlerType() option`,
+				`  |     • verify the logic within the '<aggregate>' aggregate message handler`,
+			),
+		),
+	)
+
+	It("panics if the function is nil", func() {
+		Expect(func() {
+			ToRecordEventMatching(nil)
+		}).To(PanicWith("ToRecordEventMatching(<nil>): function must not be nil"))
+	})
+})

--- a/expectation.messagematch.go
+++ b/expectation.messagematch.go
@@ -34,6 +34,30 @@ func ToExecuteCommandMatching(
 	}
 }
 
+// ToRecordEventMatching returns an expectation that passes if a command is
+// executed that satisfies the given predicate function.
+//
+// Always prefer using ToRecordEvent() instead, if possible, as it provides
+// more meaningful information in the result of a failure.
+//
+// desc is a human-readable description of the expectation. It should be phrased
+// as an imperative statement, such as "debit the customer".
+//
+// pred is the predicate function. It is called for each executed command. It
+// must return nil at least once for the expectation to pass.
+func ToRecordEventMatching(
+	pred func(dogma.Message) error,
+) Expectation {
+	if pred == nil {
+		panic("ToRecordEventMatching(<nil>): function must not be nil")
+	}
+
+	return &messageMatchExpectation{
+		pred:         pred,
+		expectedRole: message.EventRole,
+	}
+}
+
 // IgnoreMessage is an error that can be returned by predicate functions used
 // with ToExecuteCommandMatching() and ToRecordEventMatching() to indicate that
 // the predicate does not care about the message and therefore the predicate's


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds `ToRecordEventMatching()`, the event-specific companion to `ToExecuteCommandMatching()` that was added in #226.

#### Why make this change?

To provide the same flexibility when matching events as is available for commands.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Fixes #126 
