### PR TITLE
Unify language used in expectations and their reports.

### DIFF
--- a/expectation.messagematch.command_test.go
+++ b/expectation.messagematch.command_test.go
@@ -109,7 +109,7 @@ var _ = Describe("func ToExecuteCommandMatching()", func() {
 			),
 			expectPass,
 			expectReport(
-				`✓ execute a command that satisfies a predicate function`,
+				`✓ execute a command that matches the predicate near expectation.messagematch.command_test.go:102`,
 			),
 		),
 		Entry(
@@ -126,7 +126,7 @@ var _ = Describe("func ToExecuteCommandMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ execute a command that satisfies a predicate function`,
+				`✗ execute a command that matches the predicate near expectation.messagematch.command_test.go:119`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers executed a matching command`,
@@ -149,7 +149,7 @@ var _ = Describe("func ToExecuteCommandMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ execute a command that satisfies a predicate function`,
+				`✗ execute a command that matches the predicate near expectation.messagematch.command_test.go:146`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no messages were produced at all`,
@@ -168,7 +168,7 @@ var _ = Describe("func ToExecuteCommandMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ execute a command that satisfies a predicate function`,
+				`✗ execute a command that matches the predicate near expectation.messagematch.command_test.go:166`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no commands were executed at all`,
@@ -191,7 +191,7 @@ var _ = Describe("func ToExecuteCommandMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ execute a command that satisfies a predicate function`,
+				`✗ execute a command that matches the predicate near expectation.messagematch.command_test.go:184`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no relevant handler types were enabled`,
@@ -213,7 +213,7 @@ var _ = Describe("func ToExecuteCommandMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ execute a command that satisfies a predicate function`,
+				`✗ execute a command that matches the predicate near expectation.messagematch.command_test.go:211`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers executed a matching command`,
@@ -235,7 +235,7 @@ var _ = Describe("func ToExecuteCommandMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ execute a command that satisfies a predicate function`,
+				`✗ execute a command that matches the predicate near expectation.messagematch.command_test.go:232`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers executed a matching command`,

--- a/expectation.messagematch.event_test.go
+++ b/expectation.messagematch.event_test.go
@@ -113,7 +113,7 @@ var _ = Describe("func ToRecordEventMatching()", func() {
 			),
 			expectPass,
 			expectReport(
-				`✓ record an event that satisfies a predicate function`,
+				`✓ record an event that matches the predicate near expectation.messagematch.event_test.go:106`,
 			),
 		),
 		Entry(
@@ -130,7 +130,7 @@ var _ = Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that satisfies a predicate function`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:123`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,
@@ -154,7 +154,7 @@ var _ = Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that satisfies a predicate function`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:151`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no messages were produced at all`,
@@ -174,7 +174,7 @@ var _ = Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that satisfies a predicate function`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:172`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no events were recorded at all`,
@@ -194,7 +194,7 @@ var _ = Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that satisfies a predicate function`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:191`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no relevant handler types were enabled`,
@@ -219,7 +219,7 @@ var _ = Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that satisfies a predicate function`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:217`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,
@@ -242,7 +242,7 @@ var _ = Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that satisfies a predicate function`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:239`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,

--- a/expectation.messagematch.go
+++ b/expectation.messagematch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dogmatiq/testkit/envelope"
 	"github.com/dogmatiq/testkit/fact"
 	"github.com/dogmatiq/testkit/internal/inflect"
+	"github.com/dogmatiq/testkit/location"
 )
 
 // ToExecuteCommandMatching returns an expectation that passes if a command is
@@ -71,7 +72,8 @@ type messageMatchExpectation struct {
 func (e *messageMatchExpectation) Caption() string {
 	return inflect.Sprintf(
 		e.expectedRole,
-		"to <produce> a <message> that satisfies a predicate function",
+		"to <produce> a <message> that matches the predicate near %s",
+		location.OfFunc(e.pred),
 	)
 }
 
@@ -158,7 +160,8 @@ func (p *messageMatchPredicate) Report(treeOk bool) *Report {
 		Ok:     p.ok,
 		Criteria: inflect.Sprintf(
 			p.expectedRole,
-			"<produce> a <message> that satisfies a predicate function",
+			"<produce> a <message> that matches the predicate near %s",
+			location.OfFunc(p.pred),
 		),
 	}
 


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

- Use consistent language in the expectation functions names and the error messages when the expectation fails (satisfies vs matches)
- Include the location (file/line) of the predicate function in the error message

#### Why make this change?

Just to avoid confusion that might occur by using different terms. Both of these changes to tie the error message to the specific expectation you are making a little better.
#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
