### PR TITLE
Add `InterceptCommandExecutor()` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `InterceptCommandExecutor()` option
+
 ## [0.13.4] - 2021-04-22
 
 ### Changed

--- a/action.call.go
+++ b/action.call.go
@@ -50,12 +50,16 @@ func (a callAction) ConfigurePredicate(o *PredicateOptions) {
 }
 
 func (a callAction) Do(ctx context.Context, s ActionScope) error {
+	s.Executor.Bind(s.Engine, s.OperationOptions)
+
 	s.Recorder.Engine = s.Engine
 	s.Recorder.Options = s.OperationOptions
 
 	defer func() {
 		// Reset the engine and options to nil so that the executor and recorder
 		// can not be used after this Call() action ends.
+		s.Executor.Unbind()
+
 		s.Recorder.Engine = nil
 		s.Recorder.Options = nil
 	}()

--- a/action.call.go
+++ b/action.call.go
@@ -50,17 +50,13 @@ func (a callAction) ConfigurePredicate(o *PredicateOptions) {
 }
 
 func (a callAction) Do(ctx context.Context, s ActionScope) error {
-	s.Executor.Engine = s.Engine
 	s.Recorder.Engine = s.Engine
-	s.Executor.Options = s.OperationOptions
 	s.Recorder.Options = s.OperationOptions
 
 	defer func() {
 		// Reset the engine and options to nil so that the executor and recorder
 		// can not be used after this Call() action ends.
-		s.Executor.Engine = nil
 		s.Recorder.Engine = nil
-		s.Executor.Options = nil
 		s.Recorder.Options = nil
 	}()
 

--- a/action.go
+++ b/action.go
@@ -44,6 +44,10 @@ type ActionScope struct {
 	// Engine is the engine used to handle messages.
 	Engine *engine.Engine
 
+	// Executor is the command executor returned by the Test's CommandExecutor()
+	// method.
+	Executor *CommandExecutor
+
 	// Recorder is the event recorder returned by the Test's EventRecorder()
 	// method.
 	Recorder *engine.EventRecorder

--- a/action.go
+++ b/action.go
@@ -41,12 +41,8 @@ type ActionScope struct {
 	// NEXT Action.
 	VirtualClock *time.Time
 
-	// Engine is the engine used to handled messages.
+	// Engine is the engine used to handle messages.
 	Engine *engine.Engine
-
-	// Executor is the command executor returned by the Test's CommandExecutor()
-	// method.
-	Executor *engine.CommandExecutor
 
 	// Recorder is the event recorder returned by the Test's EventRecorder()
 	// method.

--- a/executor.go
+++ b/executor.go
@@ -56,7 +56,7 @@ func (c *CommandExecutor) Bind(e *engine.Engine, options []engine.OperationOptio
 
 // Unbind removes the engine and options configured by a prior call to Bind().
 //
-// Calls to ExecuteCommand() on an unbound to executor cause a panic.
+// Calls to ExecuteCommand() on an unbound executor will cause a panic.
 func (c *CommandExecutor) Unbind() {
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/executor.go
+++ b/executor.go
@@ -1,0 +1,53 @@
+package testkit
+
+import (
+	"context"
+	"sync"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/testkit/engine"
+)
+
+// commandExecutor is an implementation of dogma.CommandExecutor that executes
+// commands within the context of a test.
+//
+// An instance can be obtained at any time by calling Test.CommandExecutor().
+type commandExecutor struct {
+	m    sync.RWMutex
+	next engine.CommandExecutor
+}
+
+// ExecuteCommand executes the command message m.
+func (c *commandExecutor) ExecuteCommand(ctx context.Context, m dogma.Message) error {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	if c.next.Engine != nil {
+		return c.next.ExecuteCommand(ctx, m)
+	}
+
+	panic("ExecuteCommand(): can not be called outside of a test action")
+}
+
+// bind sets the engine and options that should be used to execute commands.
+//
+// Binding to an engine allowed the executor to be used. A call to unbind() must
+// be made when the executor should not longer be used.
+func (c *commandExecutor) bind(e *engine.Engine, options []engine.OperationOption) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.next.Engine = e
+	c.next.Options = options
+}
+
+// unbind removes the engine and options configured by the prior call to bind().
+//
+// Calling ExecuteCommand() on an unbound executor causes a panic.
+func (c *commandExecutor) unbind() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.next.Engine = nil
+	c.next.Options = nil
+}

--- a/executor.go
+++ b/executor.go
@@ -13,8 +13,9 @@ import (
 //
 // An instance can be obtained at any time by calling Test.CommandExecutor().
 type commandExecutor struct {
-	m    sync.RWMutex
-	next engine.CommandExecutor
+	m           sync.RWMutex
+	next        engine.CommandExecutor
+	interceptor CommandExecutorInterceptor
 }
 
 // ExecuteCommand executes the command message m.
@@ -22,16 +23,20 @@ func (c *commandExecutor) ExecuteCommand(ctx context.Context, m dogma.Message) e
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	if c.next.Engine != nil {
-		return c.next.ExecuteCommand(ctx, m)
+	if c.next.Engine == nil {
+		panic("ExecuteCommand(): can not be called outside of a test action")
 	}
 
-	panic("ExecuteCommand(): can not be called outside of a test action")
+	if c.interceptor != nil {
+		return c.interceptor(ctx, m, c.next)
+	}
+
+	return c.next.ExecuteCommand(ctx, m)
 }
 
 // bind sets the engine and options that should be used to execute commands.
 //
-// Binding to an engine allowed the executor to be used. A call to unbind() must
+// Binding to an engine allows the executor to be used. A call to unbind() must
 // be made when the executor should not longer be used.
 func (c *commandExecutor) bind(e *engine.Engine, options []engine.OperationOption) {
 	c.m.Lock()
@@ -50,4 +55,46 @@ func (c *commandExecutor) unbind() {
 
 	c.next.Engine = nil
 	c.next.Options = nil
+}
+
+// intercept installs an interceptor function that is invoked whenever
+// ExecuteCommand() is called.
+//
+// If fn is nil the interceptor is removed.
+//
+// It returns the previous interceptor, if any.
+func (c *commandExecutor) intercept(fn CommandExecutorInterceptor) CommandExecutorInterceptor {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	prev := c.interceptor
+	c.interceptor = fn
+
+	return prev
+}
+
+// CommandExecutorInterceptor is used by the InterceptCommandExecutor() option
+// to specify custom behavior for the dogma.CommandExecutor returned by
+// Test.CommandExecutor().
+//
+// m is the command being executed.
+//
+// e can be used to execute the command as it would be executed without this
+// interceptor installed.
+type CommandExecutorInterceptor func(
+	ctx context.Context,
+	m dogma.Message,
+	e dogma.CommandExecutor,
+) error
+
+// InterceptCommandExecutor returns an option that causes fn to be called
+// whenever a command is executed via the dogma.CommandExecutor returned by
+// Test.CommandExecutor().
+//
+// Intercepting calls to the command executor allows the user to simulate
+// failures (or any other behavior) in the command executor.
+func InterceptCommandExecutor(fn CommandExecutorInterceptor) TestOption {
+	return testOptionFunc(func(t *Test) {
+		t.executor.intercept(fn)
+	})
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -1,0 +1,78 @@
+package testkit_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/testkit"
+	"github.com/dogmatiq/testkit/internal/testingmock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func InterceptCommandExecutor()", func() {
+	var app dogma.Application
+
+	BeforeEach(func() {
+		handler := &IntegrationMessageHandler{
+			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+				c.Identity("<handler-name>", "<handler-key>")
+				c.ConsumesCommandType(MessageC{})
+				c.ProducesEventType(MessageE{})
+			},
+			HandleCommandFunc: func(
+				_ context.Context,
+				s dogma.IntegrationCommandScope,
+				_ dogma.Message,
+			) error {
+				s.RecordEvent(MessageE1)
+				return nil
+			},
+		}
+
+		app = &Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+				c.RegisterIntegration(handler)
+			},
+		}
+	})
+
+	When("used as a TestOption", func() {
+		It("intercepts calls to ExecuteCommand()", func() {
+			test := Begin(
+				&testingmock.T{},
+				app,
+				InterceptCommandExecutor(
+					func(
+						ctx context.Context,
+						m dogma.Message,
+						e dogma.CommandExecutor,
+					) error {
+						Expect(m).To(Equal(MessageC1))
+
+						err := e.ExecuteCommand(ctx, m)
+						Expect(err).ShouldNot(HaveOccurred())
+
+						return errors.New("<error>")
+					},
+				),
+			)
+
+			test.
+				EnableHandlers("<handler-name>").
+				Expect(
+					Call(func() {
+						err := test.CommandExecutor().ExecuteCommand(
+							context.Background(),
+							MessageC1,
+						)
+						Expect(err).To(MatchError("<error>"))
+					}),
+					ToRecordEvent(MessageE1),
+				)
+		})
+	})
+})

--- a/test.go
+++ b/test.go
@@ -20,7 +20,7 @@ type Test struct {
 	app              configkit.RichApplication
 	virtualClock     time.Time
 	engine           *engine.Engine
-	executor         commandExecutor
+	executor         CommandExecutor
 	recorder         engine.EventRecorder
 	predicateOptions PredicateOptions
 	operationOptions []engine.OperationOption
@@ -140,8 +140,11 @@ func (t *Test) Expect(act Action, e Expectation) *Test {
 // CommandExecutor returns a dogma.CommandExecutor which can be used to execute
 // commands within the context of this test.
 //
-// The executor can be obtained at any time, but it can only be used within a
-// test action, such as Call().
+// The executor can be obtained at any time, but it can only be used within
+// specific test actions.
+//
+// Call() is the only built-in action that supports the command executor. It may
+// be supported by other user-defined actions.
 func (t *Test) CommandExecutor() dogma.CommandExecutor {
 	return &t.executor
 }
@@ -150,7 +153,10 @@ func (t *Test) CommandExecutor() dogma.CommandExecutor {
 // events within the context of this test.
 //
 // The recorder can be obtained at any time, but it can only be used within a
-// test action, such as Call().
+// specific test actions.
+//
+// Call() is the only built-in action that supports the event recorder. It may
+// be supported by other user-defined actions.
 func (t *Test) EventRecorder() dogma.EventRecorder {
 	return &t.recorder
 }
@@ -191,15 +197,13 @@ func (t *Test) doAction(act Action, options ...engine.OperationOption) error {
 	opts = append(opts, t.operationOptions...)
 	opts = append(opts, options...)
 
-	t.executor.bind(t.engine, opts)
-	defer t.executor.unbind()
-
 	return act.Do(
 		t.ctx,
 		ActionScope{
 			App:              t.app,
 			VirtualClock:     &t.virtualClock,
 			Engine:           t.engine,
+			Executor:         &t.executor,
 			Recorder:         &t.recorder,
 			OperationOptions: opts,
 		},

--- a/test.go
+++ b/test.go
@@ -152,7 +152,7 @@ func (t *Test) CommandExecutor() dogma.CommandExecutor {
 // EventRecorder returns a dogma.EventRecorder which can be used to record
 // events within the context of this test.
 //
-// The recorder can be obtained at any time, but it can only be used within a
+// The recorder can be obtained at any time, but it can only be used within
 // specific test actions.
 //
 // Call() is the only built-in action that supports the event recorder. It may


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `InterceptCommandExecutor()` option which allows the user to install a hook function that is called whenever a command is executed via `Test.CommandExecutor().ExecuteCommand()`.

#### Why make this change?

So that we can simulate errors within a `CommandExecutor` for testing error-handling paths.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Partially addresses https://github.com/dogmatiq/testkit/issues/233

- I am yet to add a similar option for `EventRecorder`
- I also want to add a `CallOption` as mentioned in the issue, and make this option usable there as well
