### PR TITLE
Add `CallOption` function optional to `Call()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add `InterceptCommandExecutor()` option
+- Add functional options to `Call()`, see `CallOption`
 
 ## [0.13.4] - 2021-04-22
 

--- a/testoption.go
+++ b/testoption.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dogmatiq/testkit/engine"
 )
 
-// TestOption applies optional settings to a test.
+// TestOption applies optional settings to a Test.
 type TestOption interface {
 	applyTestOption(*Test)
 }


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds functional options to the `Call()` action.

#### Why make this change?

To allow use of the `InterceptCommandExecutor()` option for both an entire `Test` and an individual `Call()`.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Partially addresses https://github.com/dogmatiq/testkit/issues/233

Note that this is being merged back into the `interceptor` branch.  Once this is done I will basically repeat what I've done for command executors so that we have the same features for event recorders.
