### PR TITLE
Improve panic messaging from `engine.CommandExecutor` and `EventRecorder`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
 <!-- references -->
-[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
-[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html
+
+## [Unreleased]
+
+### Fixed
+
+- Fix malformed panic message in `engine.CommandExecutor` and `EventRecorder` when passed an unrecognized message
 
 ## [0.13.6] - 2021-04-28
 
@@ -273,7 +280,7 @@ simple to migrate existing tests to the new API. Please see the
 
 <!-- references -->
 
-[Unreleased]: https://github.com/dogmatiq/testkit
+[unreleased]: https://github.com/dogmatiq/testkit
 [0.1.0]: https://github.com/dogmatiq/testkit/releases/tag/v0.1.0
 [0.1.1]: https://github.com/dogmatiq/testkit/releases/tag/v0.1.1
 [0.2.0]: https://github.com/dogmatiq/testkit/releases/tag/v0.2.0
@@ -297,7 +304,6 @@ simple to migrate existing tests to the new API. Please see the
 [0.13.4]: https://github.com/dogmatiq/testkit/releases/tag/v0.13.4
 [0.13.5]: https://github.com/dogmatiq/testkit/releases/tag/v0.13.5
 [0.13.6]: https://github.com/dogmatiq/testkit/releases/tag/v0.13.6
-
 [v0.11.0 migration guide]: https://github.com/dogmatiq/testkit/blob/main/docs/MIGRATING-v0.11.0.md
 
 <!-- version template

--- a/engine/executor.go
+++ b/engine/executor.go
@@ -21,8 +21,5 @@ type CommandExecutor struct {
 //
 // It panics if the command is not routed to any handlers.
 func (e CommandExecutor) ExecuteCommand(ctx context.Context, m dogma.Message) error {
-	t := message.TypeOf(m)
-	e.Engine.roles[t].MustBe(message.CommandRole)
-
-	return e.Engine.Dispatch(ctx, m, e.Options...)
+	return e.Engine.mustDispatch(ctx, message.CommandRole, m, e.Options...)
 }

--- a/engine/executor_test.go
+++ b/engine/executor_test.go
@@ -63,5 +63,17 @@ var _ = Describe("type CommandExecutor", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 		})
+
+		It("panics if the message is not a command", func() {
+			Expect(func() {
+				executor.ExecuteCommand(context.Background(), MessageE1)
+			}).To(PanicWith("can not execute command, fixtures.MessageE is configured as an event"))
+		})
+
+		It("panics if the message is unrecognized", func() {
+			Expect(func() {
+				executor.ExecuteCommand(context.Background(), MessageX1)
+			}).To(PanicWith("can not execute command, fixtures.MessageX is a not a recognized message type"))
+		})
 	})
 })

--- a/engine/recorder.go
+++ b/engine/recorder.go
@@ -21,8 +21,5 @@ type EventRecorder struct {
 //
 // It is not an error to record an event that is not routed to any handlers.
 func (r EventRecorder) RecordEvent(ctx context.Context, m dogma.Message) error {
-	t := message.TypeOf(m)
-	r.Engine.roles[t].MustBe(message.EventRole)
-
-	return r.Engine.Dispatch(ctx, m, r.Options...)
+	return r.Engine.mustDispatch(ctx, message.EventRole, m, r.Options...)
 }

--- a/engine/recorder_test.go
+++ b/engine/recorder_test.go
@@ -13,24 +13,25 @@ import (
 
 var _ = Describe("type EventRecorder", func() {
 	var (
-		projection *ProjectionMessageHandler
-		app        *Application
-		engine     *Engine
-		recorder   *EventRecorder
+		process  *ProcessMessageHandler
+		app      *Application
+		engine   *Engine
+		recorder *EventRecorder
 	)
 
 	BeforeEach(func() {
-		projection = &ProjectionMessageHandler{
-			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
-				c.Identity("<projection>", "<projection-key>")
+		process = &ProcessMessageHandler{
+			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+				c.Identity("<process>", "<process-key>")
 				c.ConsumesEventType(MessageE{})
+				c.ProducesCommandType(MessageC{})
 			},
 		}
 
 		app = &Application{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "<app-key>")
-				c.RegisterProjection(projection)
+				c.RegisterProcess(process)
 			},
 		}
 
@@ -46,20 +47,39 @@ var _ = Describe("type EventRecorder", func() {
 	Describe("func RecordEvent()", func() {
 		It("dispatches to the engine", func() {
 			called := false
-			projection.HandleEventFunc = func(
+			process.RouteEventToInstanceFunc = func(
+				context.Context,
+				dogma.Message,
+			) (string, bool, error) {
+				return "<instance>", true, nil
+			}
+
+			process.HandleEventFunc = func(
 				_ context.Context,
-				_, _, _ []byte,
-				_ dogma.ProjectionEventScope,
+				_ dogma.ProcessRoot,
+				_ dogma.ProcessEventScope,
 				m dogma.Message,
-			) (bool, error) {
+			) error {
 				called = true
 				Expect(m).To(Equal(MessageE1))
-				return true, nil
+				return nil
 			}
 
 			err := recorder.RecordEvent(context.Background(), MessageE1)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(called).To(BeTrue())
+		})
+
+		It("panics if the message is not an event", func() {
+			Expect(func() {
+				recorder.RecordEvent(context.Background(), MessageC1)
+			}).To(PanicWith("can not record event, fixtures.MessageC is configured as a command"))
+		})
+
+		It("panics if the message is unrecognized", func() {
+			Expect(func() {
+				recorder.RecordEvent(context.Background(), MessageX1)
+			}).To(PanicWith("can not record event, fixtures.MessageX is a not a recognized message type"))
 		})
 	})
 })


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes `engine.CommandExecutor` and `EventRecorder` to use more meaningful panic messages when the user passes an unrecognised message or a message of the wrong role.

#### Why make this change?

Prior to this change the panic message would indicate the role was wrong, without mentioning the type of the message or what role was expected. Worse, if the message was not known to the engine the expected role itself is invalid so you'd get a panic from the internals of the `configkit/message.Role` type.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Fixes #254
