### PR TITLE
Engine acceptance tests

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine_test
 import (
 	"context"
 	"errors"
+	"testing"
 	"time"
 
 	"github.com/dogmatiq/configkit"
@@ -10,12 +11,35 @@ import (
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/enginekit/enginetest"
+	"github.com/dogmatiq/testkit/engine"
 	. "github.com/dogmatiq/testkit/engine"
 	"github.com/dogmatiq/testkit/envelope"
 	"github.com/dogmatiq/testkit/fact"
 	g "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func TestEngine(t *testing.T) {
+	enginetest.RunTests(
+		t,
+		func(p enginetest.SetupParams) enginetest.SetupResult {
+			e, err := New(configkit.FromApplication(p.App))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			return enginetest.SetupResult{
+				RunEngine: func(ctx context.Context) error {
+					return Run(ctx, e, 0)
+				},
+				Executor: &engine.CommandExecutor{
+					Engine: e,
+				},
+			}
+		},
+	)
+}
 
 var _ = g.Describe("type Engine", func() {
 	var (

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dogmatiq/cosyne v0.2.0
 	github.com/dogmatiq/dapper v0.6.0
 	github.com/dogmatiq/dogma v0.14.1
+	github.com/dogmatiq/enginekit v0.10.3-0.20240817220953-b913b67802b5
 	github.com/dogmatiq/iago v0.4.0
 	github.com/dogmatiq/linger v1.1.0
 	github.com/onsi/ginkgo/v2 v2.20.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/dogmatiq/dapper v0.6.0 h1:hnWUsjnt3nUiC9hmkPvuxrnMd7fYNz1i+/GS3gOx0Xs
 github.com/dogmatiq/dapper v0.6.0/go.mod h1:ubRHWzt73s0MsPpGhWvnfW/Z/1YPnrkCsQv6CUOZVEw=
 github.com/dogmatiq/dogma v0.14.1 h1:uSYkfDR9Wr7zCphDIZBZpKOr1QLD4UpTJy5vD+lDFpg=
 github.com/dogmatiq/dogma v0.14.1/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
+github.com/dogmatiq/enginekit v0.10.3-0.20240817220953-b913b67802b5 h1:lM4lOkBFXBi/rkVXUpLjOi6sNh8fp47jLnljMupdc8g=
+github.com/dogmatiq/enginekit v0.10.3-0.20240817220953-b913b67802b5/go.mod h1:HgFLxfBxx63iT5xaIZRAeiWSK7sNai7fwjoSB9BMeUE=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/dogmatiq/interopspec v0.5.4 h1:klyGPy16zUKJartJIJOBZ4JrQ4LxFiY3wgzFTTiNlDk=
@@ -130,3 +132,5 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds engine acceptence tests as implemented in `dogmatiq/enginekit`.

#### Why make this change?

We are doing this in preparation for implementing the Veracity engine, to ensure that it continues to behaves the same as both `testkit` and `verity`.

