### PR TITLE
Refactor 6157adf to allow expectations to control what's reported when inverted.

### DIFF
--- a/expectation.composite_test.go
+++ b/expectation.composite_test.go
@@ -64,42 +64,6 @@ var _ = g.Context("composite expectations", func() {
 				),
 			),
 			g.Entry(
-				"it passes when the child None Of expectation passes",
-				AllOf(pass, NoneOf(fail, fail)),
-				expectPass,
-				expectReport(
-					`✓ all of`,
-					`    ✓ <always pass>`,
-					`    ✓ none of`,
-					`        ✗ <always fail>`,
-					`        ✗ <always fail>`,
-				),
-			),
-			g.Entry(
-				"it fails when the child None Of expectation fails",
-				AllOf(pass, NoneOf(pass, pass)),
-				expectFail,
-				expectReport(
-					`✗ all of (1 of the expectations failed)`,
-					`    ✓ <always pass>`,
-					`    ✗ none of`,
-					`        ✓ <always pass>`,
-					`        ✓ <always pass>`,
-				),
-			),
-			g.Entry(
-				"it fails when the sibling child of None Of expectation fails",
-				AllOf(fail, NoneOf(fail, fail)),
-				expectFail,
-				expectReport(
-					`✗ all of (1 of the expectations failed)`,
-					`    ✗ <always fail>`,
-					`    ✓ none of`,
-					`        ✗ <always fail>`,
-					`        ✗ <always fail>`,
-				),
-			),
-			g.Entry(
 				"it fails when some of the child expectations fail",
 				AllOf(pass, fail),
 				expectFail,

--- a/expectation.go
+++ b/expectation.go
@@ -39,15 +39,18 @@ type Predicate interface {
 	// more than once.
 	Done()
 
-	// Report returns a report describing whether or not the expectation
-	// was met.
+	// Report returns a report describing whether or not the expectation was
+	// met.
 	//
 	// treeOk is true if the entire "tree" of expectations is considered to have
 	// passed. This may not be the same value as returned from Ok() when this
 	// expectation is used as a child of a composite expectation.
 	//
+	// isInverted is true if the expectation is inverted, i.e. it is expected
+	// not be met.
+	//
 	// The behavior of Report() is undefined if Done() has not been called.
-	Report(treeOk bool) *Report
+	Report(treeOk, isInverted bool) *Report
 }
 
 // PredicateScope encapsulates the element's of a Test's state that may be

--- a/expectation.message.command_test.go
+++ b/expectation.message.command_test.go
@@ -207,6 +207,20 @@ var _ = g.Describe("func ToExecuteCommand()", func() {
 				`  |     }`,
 			),
 		),
+		g.Entry(
+			"does not include an explanation when negated and a sibling expectation passes",
+			RecordEvent(MessageE1),
+			NoneOf(
+				ToExecuteCommand(MessageC1),
+				ToExecuteCommand(MessageC2),
+			),
+			expectFail,
+			expectReport(
+				`✗ none of (1 of the expectations passed unexpectedly)`,
+				`    ✓ execute a specific 'fixtures.MessageC' command`,
+				`    ✗ execute a specific 'fixtures.MessageC' command`,
+			),
+		),
 	)
 
 	g.It("fails the test if the message type is unrecognized", func() {

--- a/expectation.message.event_test.go
+++ b/expectation.message.event_test.go
@@ -234,6 +234,20 @@ var _ = g.Describe("func ToExecuteCommandOfType()", func() {
 				`  |     }`,
 			),
 		),
+		g.Entry(
+			"does not include an explanation when negated and a sibling expectation passes",
+			ExecuteCommand(MessageR1),
+			NoneOf(
+				ToRecordEvent(MessageE1),
+				ToRecordEvent(MessageE2),
+			),
+			expectFail,
+			expectReport(
+				`✗ none of (1 of the expectations passed unexpectedly)`,
+				`    ✓ record a specific 'fixtures.MessageE' event`,
+				`    ✗ record a specific 'fixtures.MessageE' event`,
+			),
+		),
 	)
 
 	g.It("fails the test if the message type is unrecognized", func() {

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -139,7 +139,7 @@ func (p *messagePredicate) Ok() bool {
 func (p *messagePredicate) Done() {
 }
 
-func (p *messagePredicate) Report(treeOk bool) *Report {
+func (p *messagePredicate) Report(treeOk, isInverted bool) *Report {
 	rep := &Report{
 		TreeOk: treeOk,
 		Ok:     p.ok,
@@ -150,7 +150,7 @@ func (p *messagePredicate) Report(treeOk bool) *Report {
 		),
 	}
 
-	if treeOk || p.ok {
+	if treeOk || p.ok || isInverted {
 		return rep
 	}
 

--- a/expectation.messagematch.command_test.go
+++ b/expectation.messagematch.command_test.go
@@ -251,6 +251,36 @@ var _ = g.Describe("func ToExecuteCommandMatching()", func() {
 				`  |     • verify the logic within the '<process>' process message handler`,
 			),
 		),
+		g.Entry(
+			"does not include an explanation when negated and a sibling expectation passes",
+			RecordEvent(MessageE1),
+			NoneOf(
+				ToExecuteCommandMatching(
+					func(m dogma.Message) error {
+						if m == MessageC1 {
+							return nil
+						}
+
+						return errors.New("<error>")
+					},
+				),
+				ToExecuteCommandMatching(
+					func(m dogma.Message) error {
+						if m == MessageX1 {
+							return nil
+						}
+
+						return errors.New("<error>")
+					},
+				),
+			),
+			expectFail,
+			expectReport(
+				`✗ none of (1 of the expectations passed unexpectedly)`,
+				`    ✓ execute a command that matches the predicate near expectation.messagematch.command_test.go:259`,
+				`    ✗ execute a command that matches the predicate near expectation.messagematch.command_test.go:268`,
+			),
+		),
 	)
 
 	g.It("panics if the function is nil", func() {

--- a/expectation.messagematch.event_test.go
+++ b/expectation.messagematch.event_test.go
@@ -259,6 +259,36 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 				`  |     • verify the logic within the '<aggregate>' aggregate message handler`,
 			),
 		),
+		g.Entry(
+			"does not include an explanation when negated and a sibling expectation passes",
+			ExecuteCommand(MessageR1),
+			NoneOf(
+				ToRecordEventMatching(
+					func(m dogma.Message) error {
+						if m == MessageE1 {
+							return nil
+						}
+
+						return errors.New("<error>")
+					},
+				),
+				ToRecordEventMatching(
+					func(m dogma.Message) error {
+						if m == MessageX1 {
+							return nil
+						}
+
+						return errors.New("<error>")
+					},
+				),
+			),
+			expectFail,
+			expectReport(
+				`✗ none of (1 of the expectations passed unexpectedly)`,
+				`    ✓ record an event that matches the predicate near expectation.messagematch.event_test.go:267`,
+				`    ✗ record an event that matches the predicate near expectation.messagematch.event_test.go:276`,
+			),
+		),
 	)
 
 	g.It("panics if the function is nil", func() {

--- a/expectation.messagematch.go
+++ b/expectation.messagematch.go
@@ -234,7 +234,7 @@ func (p *messageMatchPredicate) Done() {
 	}
 }
 
-func (p *messageMatchPredicate) Report(treeOk bool) *Report {
+func (p *messageMatchPredicate) Report(treeOk, isInverted bool) *Report {
 	rep := &Report{
 		TreeOk: treeOk,
 		Ok:     p.ok,
@@ -253,7 +253,7 @@ func (p *messageMatchPredicate) Report(treeOk bool) *Report {
 		)
 	}
 
-	if treeOk || p.ok {
+	if treeOk || p.ok || isInverted {
 		return rep
 	}
 

--- a/expectation.messagetype.command_test.go
+++ b/expectation.messagetype.command_test.go
@@ -184,6 +184,20 @@ var _ = g.Describe("func ToExecuteCommandOfType()", func() {
 				`  |     [-*-]fixtures.MessageC`,
 			),
 		),
+		g.Entry(
+			"does not include an explanation when negated and a sibling expectation passes",
+			RecordEvent(MessageE1),
+			NoneOf(
+				ToExecuteCommandOfType(MessageC{}),
+				ToExecuteCommandOfType(MessageX{}),
+			),
+			expectFail,
+			expectReport(
+				`✗ none of (1 of the expectations passed unexpectedly)`,
+				`    ✓ execute any 'fixtures.MessageC' command`,
+				`    ✗ execute any 'fixtures.MessageX' command`,
+			),
+		),
 	)
 
 	g.It("fails the test if the message type is unrecognized", func() {

--- a/expectation.messagetype.event_test.go
+++ b/expectation.messagetype.event_test.go
@@ -212,6 +212,20 @@ var _ = g.Describe("func ToExecuteCommandOfType()", func() {
 				`  |     [-*-]fixtures.MessageE`,
 			),
 		),
+		g.Entry(
+			"does not include an explanation when negated and a sibling expectation passes",
+			ExecuteCommand(MessageR1),
+			NoneOf(
+				ToRecordEventOfType(MessageE{}),
+				ToRecordEventOfType(MessageX{}),
+			),
+			expectFail,
+			expectReport(
+				`✗ none of (1 of the expectations passed unexpectedly)`,
+				`    ✓ record any 'fixtures.MessageE' event`,
+				`    ✗ record any 'fixtures.MessageX' event`,
+			),
+		),
 	)
 
 	g.It("fails the test if the message type is unrecognized", func() {

--- a/expectation.messagetype.go
+++ b/expectation.messagetype.go
@@ -112,7 +112,7 @@ func (p *messageTypePredicate) Ok() bool {
 func (p *messageTypePredicate) Done() {
 }
 
-func (p *messageTypePredicate) Report(treeOk bool) *Report {
+func (p *messageTypePredicate) Report(treeOk, isInverted bool) *Report {
 	rep := &Report{
 		TreeOk: treeOk,
 		Ok:     p.ok,
@@ -123,7 +123,7 @@ func (p *messageTypePredicate) Report(treeOk bool) *Report {
 		),
 	}
 
-	if treeOk || p.ok {
+	if treeOk || p.ok || isInverted {
 		return rep
 	}
 

--- a/expectation.repeat.go
+++ b/expectation.repeat.go
@@ -101,7 +101,7 @@ func (p *repeatPredicate) Done() {
 	}
 }
 
-func (p *repeatPredicate) Report(treeOk bool) *Report {
+func (p *repeatPredicate) Report(treeOk, isInverted bool) *Report {
 	rep := &Report{
 		TreeOk:   treeOk,
 		Ok:       true,
@@ -128,7 +128,7 @@ func (p *repeatPredicate) Report(treeOk bool) *Report {
 			// potentially thousands of very similar expectations which would
 			// pollute the report and make it harder to find the problem.
 			rep.Append(
-				c.Report(treeOk),
+				c.Report(treeOk, isInverted),
 			)
 
 		}

--- a/expectation.satisfy.go
+++ b/expectation.satisfy.go
@@ -93,7 +93,7 @@ func (p *satisfyPredicate) Done() {
 	p.pred(&p.satisfyT)
 }
 
-func (p *satisfyPredicate) Report(treeOk bool) *Report {
+func (p *satisfyPredicate) Report(treeOk, isInverted bool) *Report {
 	rep := &Report{
 		TreeOk:   treeOk,
 		Ok:       p.Ok(),
@@ -104,6 +104,10 @@ func (p *satisfyPredicate) Report(treeOk bool) *Report {
 		rep.Outcome = "the expectation was skipped"
 	} else if p.satisfyT.failed {
 		rep.Outcome = "the expectation failed"
+	}
+
+	if !rep.Ok && isInverted {
+		return rep
 	}
 
 	rep.Explanation = p.satisfyT.explanation

--- a/expectation.satisfy_test.go
+++ b/expectation.satisfy_test.go
@@ -224,6 +224,25 @@ var _ = g.Describe("func ToSatisfy()", func() {
 		),
 	)
 
+	g.It("does not include an explanation when negated and a sibling expectation passes", func() {
+		test.Expect(
+			noop,
+			NoneOf(
+				ToSatisfy("<always pass>", func(*SatisfyT) {}),
+				ToSatisfy("<always fail>", func(t *SatisfyT) { t.Fail() }),
+			),
+		)
+
+		rm := expectReport(
+			`✗ none of (1 of the expectations passed unexpectedly)`,
+			`    ✓ <always pass>`,
+			`    ✗ <always fail> (the expectation failed)`,
+		)
+
+		rm(testingT)
+		Expect(testingT.Failed()).To(BeTrue())
+	})
+
 	g.It("produces the expected caption", func() {
 		test.Expect(
 			noop,

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -39,7 +39,7 @@ func (e staticExpectation) Predicate(PredicateScope) (Predicate, error) { return
 func (e staticExpectation) Notify(fact.Fact)                            {}
 func (e staticExpectation) Ok() bool                                    { return e.ok }
 func (e staticExpectation) Done()                                       {}
-func (e staticExpectation) Report(treeOk bool) *Report {
+func (e staticExpectation) Report(treeOk, isInverted bool) *Report {
 	c := "<always fail>"
 	if e.ok {
 		c = "<always pass>"

--- a/report.go
+++ b/report.go
@@ -136,36 +136,11 @@ func (r *Report) WriteTo(next io.Writer) (_ int64, err error) {
 	if len(r.SubReports) != 0 {
 		iw := indent.NewIndenter(w, subReportsIndent)
 		for _, sr := range r.SubReports {
-			if (r.Criteria == "any of" || r.Criteria == "all of") && sr.Criteria == "none of" {
-				if sr.Ok {
-					must.WriteString(iw, "✓ ")
-				} else {
-					must.WriteString(iw, "✗ ")
-				}
-				must.WriteString(iw, sr.Criteria)
-				must.WriteByte(iw, '\n')
-
-				for _, ssr := range sr.SubReports {
-					ssr.WriteNoneOfCompositesCriteria(iw)
-				}
-			} else {
-				must.WriteTo(iw, sr)
-			}
+			must.WriteTo(iw, sr)
 		}
 	}
 
 	return int64(w.Count()), nil
-}
-
-func (r *Report) WriteNoneOfCompositesCriteria(w io.Writer) {
-	iw := indent.NewIndenter(w, subReportsIndent)
-	if r.Ok {
-		must.WriteString(iw, "✓ ")
-	} else {
-		must.WriteString(iw, "✗ ")
-	}
-	must.WriteString(iw, r.Criteria)
-	must.WriteByte(iw, '\n')
 }
 
 // ReportSection is a section of a report containing additional information

--- a/test.go
+++ b/test.go
@@ -125,7 +125,7 @@ func (t *Test) Expect(act Action, e Expectation) *Test {
 	}
 
 	treeOk := p.Ok()
-	rep := p.Report(treeOk)
+	rep := p.Report(treeOk, false)
 
 	buf := &strings.Builder{}
 	fmt.Fprint(buf, "--- TEST REPORT ---\n\n")


### PR DESCRIPTION
This PR is a refactoring of #346, and targets its branch, not `main`.