### PR TITLE
Use enginekit fixtures

### DIFF
--- a/action.call_test.go
+++ b/action.call_test.go
@@ -5,10 +5,8 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
-	. "github.com/dogmatiq/configkit/fixtures"
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/engine"
@@ -33,33 +31,12 @@ var _ = g.Describe("func Call()", func() {
 		app = &ApplicationStub{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "b51cde16-aaec-4d75-ae14-06282e3a72c8")
-				c.RegisterAggregate(&AggregateMessageHandlerStub{
-					ConfigureFunc: func(c dogma.AggregateConfigurer) {
-						c.Identity("<aggregate>", "832d78d7-a006-414f-b6d7-3153aa7c9ab8")
+				c.RegisterIntegration(&IntegrationMessageHandlerStub{
+					ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+						c.Identity("<integration>", "832d78d7-a006-414f-b6d7-3153aa7c9ab8")
 						c.Routes(
-							dogma.HandlesCommand[MessageC](),
-							dogma.RecordsEvent[MessageE](),
+							dogma.HandlesCommand[CommandStub[TypeA]](),
 						)
-					},
-					RouteCommandToInstanceFunc: func(
-						dogma.Command,
-					) string {
-						return "<instance>"
-					},
-				})
-				c.RegisterProcess(&ProcessMessageHandlerStub{
-					ConfigureFunc: func(c dogma.ProcessConfigurer) {
-						c.Identity("<process>", "b64cdd19-782e-4e4e-9e5f-a95a943d6340")
-						c.Routes(
-							dogma.HandlesEvent[MessageE](),
-							dogma.ExecutesCommand[MessageC](),
-						)
-					},
-					RouteEventToInstanceFunc: func(
-						context.Context,
-						dogma.Event,
-					) (string, bool, error) {
-						return "<instance>", true, nil
 					},
 				})
 			},
@@ -86,7 +63,7 @@ var _ = g.Describe("func Call()", func() {
 			Call(func() {
 				e.ExecuteCommand(
 					context.Background(),
-					MessageC1,
+					CommandA1,
 				)
 			}),
 		)
@@ -97,8 +74,8 @@ var _ = g.Describe("func Call()", func() {
 					MessageID:     "1",
 					CausationID:   "1",
 					CorrelationID: "1",
-					Message:       MessageC1,
-					Type:          MessageCType,
+					Message:       CommandA1,
+					Type:          message.TypeOf(CommandA1),
 					Role:          message.CommandRole,
 					CreatedAt:     startTime,
 				},
@@ -121,10 +98,10 @@ var _ = g.Describe("func Call()", func() {
 			Call(func() {
 				e.ExecuteCommand(
 					context.Background(),
-					MessageC1,
+					CommandA1,
 				)
 			}),
-			ToExecuteCommand(MessageC1),
+			ToExecuteCommand(CommandA1),
 		)
 	})
 

--- a/action.dispatch.event_test.go
+++ b/action.dispatch.event_test.go
@@ -5,10 +5,8 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
-	. "github.com/dogmatiq/configkit/fixtures"
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/engine"
@@ -37,8 +35,8 @@ var _ = g.Describe("func RecordEvent()", func() {
 					ConfigureFunc: func(c dogma.ProcessConfigurer) {
 						c.Identity("<process>", "1c0dd111-fe12-4dee-a8bc-64abea1dce8f")
 						c.Routes(
-							dogma.HandlesEvent[MessageE](),
-							dogma.ExecutesCommand[MessageC](),
+							dogma.HandlesEvent[EventStub[TypeA]](),
+							dogma.ExecutesCommand[CommandStub[TypeA]](),
 						)
 					},
 					RouteEventToInstanceFunc: func(
@@ -67,7 +65,7 @@ var _ = g.Describe("func RecordEvent()", func() {
 
 	g.It("dispatches the message", func() {
 		test.Prepare(
-			RecordEvent(MessageE1),
+			RecordEvent(EventA1),
 		)
 
 		Expect(buf.Facts()).To(ContainElement(
@@ -76,8 +74,8 @@ var _ = g.Describe("func RecordEvent()", func() {
 					MessageID:     "1",
 					CausationID:   "1",
 					CorrelationID: "1",
-					Message:       MessageE1,
-					Type:          MessageEType,
+					Message:       EventA1,
+					Type:          message.TypeOf(EventA1),
 					Role:          message.EventRole,
 					CreatedAt:     startTime,
 				},
@@ -97,12 +95,12 @@ var _ = g.Describe("func RecordEvent()", func() {
 		t.FailSilently = true
 
 		test.Prepare(
-			RecordEvent(MessageX1),
+			RecordEvent(EventX1),
 		)
 
 		Expect(t.Failed()).To(BeTrue())
 		Expect(t.Logs).To(ContainElement(
-			"cannot record event, fixtures.MessageX is a not a recognized message type",
+			"cannot record event, stubs.EventStub[TypeX] is a not a recognized message type",
 		))
 	})
 
@@ -110,12 +108,12 @@ var _ = g.Describe("func RecordEvent()", func() {
 		t.FailSilently = true
 
 		test.Prepare(
-			RecordEvent(MessageC1),
+			RecordEvent(CommandA1),
 		)
 
 		Expect(t.Failed()).To(BeTrue())
 		Expect(t.Logs).To(ContainElement(
-			"cannot record event, fixtures.MessageC is configured as a command",
+			"cannot record event, stubs.CommandStub[TypeA] is configured as a command",
 		))
 	})
 
@@ -123,8 +121,8 @@ var _ = g.Describe("func RecordEvent()", func() {
 		t.FailSilently = true
 
 		test.Expect(
-			RecordEvent(MessageE1),
-			ToRecordEvent(MessageE1),
+			RecordEvent(EventA1),
+			ToRecordEvent(EventA1),
 		)
 
 		Expect(t.Failed()).To(BeTrue())
@@ -132,11 +130,11 @@ var _ = g.Describe("func RecordEvent()", func() {
 
 	g.It("produces the expected caption", func() {
 		test.Prepare(
-			RecordEvent(MessageE1),
+			RecordEvent(EventA1),
 		)
 
 		Expect(t.Logs).To(ContainElement(
-			"--- recording fixtures.MessageE event ---",
+			"--- recording stubs.EventStub[TypeA] event ---",
 		))
 	})
 
@@ -147,7 +145,7 @@ var _ = g.Describe("func RecordEvent()", func() {
 	})
 
 	g.It("captures the location that the action was created", func() {
-		act := recordEvent(MessageE1)
+		act := recordEvent(EventA1)
 		Expect(act.Location()).To(MatchAllFields(
 			Fields{
 				"Func": Equal("github.com/dogmatiq/testkit_test.recordEvent"),

--- a/compare_test.go
+++ b/compare_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
-	"github.com/dogmatiq/testkit/internal/fixtures"
+	. "github.com/dogmatiq/testkit/internal/fixtures"
 	"github.com/dogmatiq/testkit/internal/testingmock"
 	g "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,14 +29,14 @@ var _ = g.Describe("func DefaultMessageComparator()", func() {
 			),
 			g.Entry(
 				"protocol buffers",
-				&fixtures.ProtoMessage{Value: "<value>"},
-				&fixtures.ProtoMessage{Value: "<value>"},
+				&ProtoMessage{Value: "<value>"},
+				&ProtoMessage{Value: "<value>"},
 			),
 		)
 
 		g.It("ignores unexported fields when comparing protocol buffers messages", func() {
-			a := &fixtures.ProtoMessage{Value: "<value>"}
-			b := &fixtures.ProtoMessage{Value: "<value>"}
+			a := &ProtoMessage{Value: "<value>"}
+			b := &ProtoMessage{Value: "<value>"}
 
 			g.By("initializing the unexported fields within one of the messages")
 			_ = a.String()
@@ -69,8 +69,8 @@ var _ = g.Describe("func DefaultMessageComparator()", func() {
 			),
 			g.Entry(
 				"protocol buffers",
-				&fixtures.ProtoMessage{Value: "<value-a>"},
-				&fixtures.ProtoMessage{Value: "<value-b>"},
+				&ProtoMessage{Value: "<value-a>"},
+				&ProtoMessage{Value: "<value-b>"},
 			),
 		)
 	})

--- a/compare_test.go
+++ b/compare_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/internal/fixtures"
@@ -25,8 +24,8 @@ var _ = g.Describe("func DefaultMessageComparator()", func() {
 			},
 			g.Entry(
 				"plain struct",
-				MessageA1,
-				MessageA1,
+				CommandA1,
+				CommandA1,
 			),
 			g.Entry(
 				"protocol buffers",
@@ -65,8 +64,8 @@ var _ = g.Describe("func DefaultMessageComparator()", func() {
 			},
 			g.Entry(
 				"different types",
-				MessageA1,
-				MessageB1,
+				CommandA1,
+				CommandB1,
 			),
 			g.Entry(
 				"protocol buffers",
@@ -83,8 +82,8 @@ var _ = g.Describe("func WithMessageComparator()", func() {
 			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
 				c.Identity("<handler-name>", "7cb41db6-0116-4d03-80d7-277cc391b47e")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 			HandleCommandFunc: func(
@@ -92,12 +91,12 @@ var _ = g.Describe("func WithMessageComparator()", func() {
 				s dogma.IntegrationCommandScope,
 				_ dogma.Command,
 			) error {
-				s.RecordEvent(MessageE1)
+				s.RecordEvent(EventA1)
 				return nil
 			},
 		}
 
-		app := &Application{
+		app := &ApplicationStub{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "477a9515-8318-4229-8f9d-57d84f463cb7")
 				c.RegisterIntegration(handler)
@@ -115,8 +114,8 @@ var _ = g.Describe("func WithMessageComparator()", func() {
 		).
 			EnableHandlers("<handler-name>").
 			Expect(
-				ExecuteCommand(MessageC1),
-				ToRecordEvent(MessageE2), // this would fail without our custom comparator
+				ExecuteCommand(CommandA1),
+				ToRecordEvent(EventA2), // this would fail without our custom comparator
 			)
 	})
 })

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -190,16 +190,17 @@ func (e *Engine) Dispatch(
 	m dogma.Message,
 	options ...OperationOption,
 ) error {
+	t := message.TypeOf(m)
+
 	if err := m.Validate(); err != nil {
 		panic(fmt.Sprintf(
-			"cannot dispatch invalid %T message: %s",
-			m,
+			"cannot dispatch invalid %s message: %s",
+			t,
 			err,
 		))
 	}
 
 	oo := newOperationOptions(e, options)
-	t := message.TypeOf(m)
 
 	if _, ok := e.routes[t]; !ok {
 		panic(fmt.Sprintf(
@@ -267,16 +268,16 @@ func (e *Engine) mustDispatch(
 			"cannot <produce> <message>, %s",
 			inflect.Sprintf(
 				r,
-				"%T is configured as a <message>",
-				m,
+				"%s is configured as a <message>",
+				t,
 			),
 		))
 	}
 
 	panic(inflect.Sprintf(
 		expected,
-		"cannot <produce> <message>, %T is a not a recognized message type",
-		m,
+		"cannot <produce> <message>, %s is a not a recognized message type",
+		t,
 	))
 }
 

--- a/engine/executor_test.go
+++ b/engine/executor_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/engine"
 	g "github.com/onsi/ginkgo/v2"
@@ -25,8 +24,8 @@ var _ = g.Describe("type CommandExecutor", func() {
 			ConfigureFunc: func(c dogma.AggregateConfigurer) {
 				c.Identity("<aggregate>", "4acf3050-8d02-4052-a9af-abb9e67add78")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 			RouteCommandToInstanceFunc: func(dogma.Command) string {
@@ -59,24 +58,24 @@ var _ = g.Describe("type CommandExecutor", func() {
 				m dogma.Command,
 			) {
 				called = true
-				Expect(m).To(Equal(MessageC1))
+				Expect(m).To(Equal(CommandA1))
 			}
 
-			err := executor.ExecuteCommand(context.Background(), MessageC1)
+			err := executor.ExecuteCommand(context.Background(), CommandA1)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 		})
 
 		g.It("panics if the message is not a command", func() {
 			Expect(func() {
-				executor.ExecuteCommand(context.Background(), MessageE1)
-			}).To(PanicWith("cannot execute command, fixtures.MessageE is configured as an event"))
+				executor.ExecuteCommand(context.Background(), EventA1)
+			}).To(PanicWith("cannot execute command, stubs.EventStub[TypeA] is configured as an event"))
 		})
 
 		g.It("panics if the message is unrecognized", func() {
 			Expect(func() {
-				executor.ExecuteCommand(context.Background(), MessageX1)
-			}).To(PanicWith("cannot execute command, fixtures.MessageX is a not a recognized message type"))
+				executor.ExecuteCommand(context.Background(), CommandX1)
+			}).To(PanicWith("cannot execute command, stubs.CommandStub[TypeX] is a not a recognized message type"))
 		})
 	})
 })

--- a/engine/internal/aggregate/controller.go
+++ b/engine/internal/aggregate/controller.go
@@ -66,7 +66,7 @@ func (c *Controller) Handle(
 			Method:         "RouteCommandToInstance",
 			Implementation: c.Config.Handler(),
 			Message:        env.Message,
-			Description:    fmt.Sprintf("routed a command of type %T to an empty ID", env.Message),
+			Description:    fmt.Sprintf("routed a command of type %s to an empty ID", env.Type),
 			Location:       location.OfMethod(c.Config.Handler(), "RouteCommandToInstance"),
 		})
 	}

--- a/engine/internal/aggregate/scope.go
+++ b/engine/internal/aggregate/scope.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/internal/panicx"
 	"github.com/dogmatiq/testkit/envelope"
@@ -48,14 +49,16 @@ func (s *scope) Destroy() {
 }
 
 func (s *scope) RecordEvent(m dogma.Event) {
-	if !s.config.MessageTypes().Produced.HasM(m) {
+	mt := message.TypeOf(m)
+
+	if !s.config.MessageTypes().Produced.Has(mt) {
 		panic(panicx.UnexpectedBehavior{
 			Handler:        s.config,
 			Interface:      "AggregateMessageHandler",
 			Method:         "HandleCommand",
 			Implementation: s.config.Handler(),
 			Message:        s.command.Message,
-			Description:    fmt.Sprintf("recorded an event of type %T, which is not produced by this handler", m),
+			Description:    fmt.Sprintf("recorded an event of type %s, which is not produced by this handler", mt),
 			Location:       location.OfCall(),
 		})
 	}
@@ -67,7 +70,7 @@ func (s *scope) RecordEvent(m dogma.Event) {
 			Method:         "HandleCommand",
 			Implementation: s.config.Handler(),
 			Message:        s.command.Message,
-			Description:    fmt.Sprintf("recorded an invalid %T event: %s", m, err),
+			Description:    fmt.Sprintf("recorded an invalid %s event: %s", mt, err),
 			Location:       location.OfCall(),
 		})
 	}

--- a/engine/internal/integration/controller_test.go
+++ b/engine/internal/integration/controller_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/engine/internal/integration"
 	"github.com/dogmatiq/testkit/envelope"
@@ -29,7 +28,7 @@ var _ = g.Describe("type Controller", func() {
 	g.BeforeEach(func() {
 		command = envelope.NewCommand(
 			"1000",
-			MessageC1,
+			CommandA1,
 			time.Now(),
 		)
 
@@ -37,8 +36,8 @@ var _ = g.Describe("type Controller", func() {
 			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
 				c.Identity("<name>", "8cbb8bca-b5eb-4c94-a877-dfc8dc9968ca")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 		}
@@ -91,7 +90,7 @@ var _ = g.Describe("type Controller", func() {
 				m dogma.Command,
 			) error {
 				called = true
-				Expect(m).To(Equal(MessageC1))
+				Expect(m).To(Equal(CommandA1))
 				return nil
 			}
 
@@ -112,8 +111,8 @@ var _ = g.Describe("type Controller", func() {
 				s dogma.IntegrationCommandScope,
 				_ dogma.Command,
 			) error {
-				s.RecordEvent(MessageE1)
-				s.RecordEvent(MessageE2)
+				s.RecordEvent(EventA1)
+				s.RecordEvent(EventA2)
 				return nil
 			}
 
@@ -129,7 +128,7 @@ var _ = g.Describe("type Controller", func() {
 			Expect(events).To(ConsistOf(
 				command.NewEvent(
 					"1",
-					MessageE1,
+					EventA1,
 					now,
 					envelope.Origin{
 						Handler:     config,
@@ -138,7 +137,7 @@ var _ = g.Describe("type Controller", func() {
 				),
 				command.NewEvent(
 					"2",
-					MessageE2,
+					EventA2,
 					now,
 					envelope.Origin{
 						Handler:     config,

--- a/engine/internal/integration/scope.go
+++ b/engine/internal/integration/scope.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/engine/internal/panicx"
 	"github.com/dogmatiq/testkit/envelope"
@@ -23,14 +24,16 @@ type scope struct {
 }
 
 func (s *scope) RecordEvent(m dogma.Event) {
-	if !s.config.MessageTypes().Produced.HasM(m) {
+	mt := message.TypeOf(m)
+
+	if !s.config.MessageTypes().Produced.Has(mt) {
 		panic(panicx.UnexpectedBehavior{
 			Handler:        s.config,
 			Interface:      "IntegrationMessageHandler",
 			Method:         "HandleCommand",
 			Implementation: s.config.Handler(),
 			Message:        s.command.Message,
-			Description:    fmt.Sprintf("recorded an event of type %T, which is not produced by this handler", m),
+			Description:    fmt.Sprintf("recorded an event of type %s, which is not produced by this handler", mt),
 			Location:       location.OfCall(),
 		})
 	}
@@ -42,7 +45,7 @@ func (s *scope) RecordEvent(m dogma.Event) {
 			Method:         "HandleCommand",
 			Implementation: s.config.Handler(),
 			Message:        s.command.Message,
-			Description:    fmt.Sprintf("recorded an invalid %T event: %s", m, err),
+			Description:    fmt.Sprintf("recorded an invalid %s event: %s", mt, err),
 			Location:       location.OfCall(),
 		})
 	}

--- a/engine/internal/integration/scope_test.go
+++ b/engine/internal/integration/scope_test.go
@@ -2,12 +2,10 @@ package integration_test
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/engine/internal/integration"
 	"github.com/dogmatiq/testkit/envelope"
@@ -29,7 +27,7 @@ var _ = g.Describe("type scope", func() {
 	g.BeforeEach(func() {
 		command = envelope.NewCommand(
 			"1000",
-			MessageC1,
+			CommandA1,
 			time.Now(),
 		)
 
@@ -37,8 +35,8 @@ var _ = g.Describe("type scope", func() {
 			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
 				c.Identity("<name>", "24ec3839-5d51-4904-9b45-34b5282e7f24")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 		}
@@ -60,7 +58,7 @@ var _ = g.Describe("type scope", func() {
 				s dogma.IntegrationCommandScope,
 				_ dogma.Command,
 			) error {
-				s.RecordEvent(MessageE1)
+				s.RecordEvent(EventA1)
 				return nil
 			}
 		})
@@ -82,7 +80,7 @@ var _ = g.Describe("type scope", func() {
 					Envelope: command,
 					EventEnvelope: command.NewEvent(
 						"1",
-						MessageE1,
+						EventA1,
 						now,
 						envelope.Origin{
 							Handler:     config,
@@ -99,7 +97,7 @@ var _ = g.Describe("type scope", func() {
 				s dogma.IntegrationCommandScope,
 				m dogma.Command,
 			) error {
-				s.RecordEvent(MessageX1)
+				s.RecordEvent(EventX1)
 				return nil
 			}
 
@@ -118,7 +116,7 @@ var _ = g.Describe("type scope", func() {
 						"Method":         Equal("HandleCommand"),
 						"Implementation": Equal(config.Handler()),
 						"Message":        Equal(command.Message),
-						"Description":    Equal("recorded an event of type fixtures.MessageX, which is not produced by this handler"),
+						"Description":    Equal("recorded an event of type stubs.EventStub[TypeX], which is not produced by this handler"),
 						"Location": MatchAllFields(
 							Fields{
 								"Func": Not(BeEmpty()),
@@ -137,8 +135,8 @@ var _ = g.Describe("type scope", func() {
 				s dogma.IntegrationCommandScope,
 				_ dogma.Command,
 			) error {
-				s.RecordEvent(MessageE{
-					Value: errors.New("<invalid>"),
+				s.RecordEvent(EventStub[TypeA]{
+					ValidationError: "<invalid>",
 				})
 				return nil
 			}
@@ -158,7 +156,7 @@ var _ = g.Describe("type scope", func() {
 						"Method":         Equal("HandleCommand"),
 						"Implementation": Equal(config.Handler()),
 						"Message":        Equal(command.Message),
-						"Description":    Equal("recorded an invalid fixtures.MessageE event: <invalid>"),
+						"Description":    Equal("recorded an invalid stubs.EventStub[TypeA] event: <invalid>"),
 						"Location": MatchAllFields(
 							Fields{
 								"Func": Not(BeEmpty()),

--- a/engine/internal/panicx/unexpectedbehavior_test.go
+++ b/engine/internal/panicx/unexpectedbehavior_test.go
@@ -3,7 +3,6 @@ package panicx_test
 import (
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/engine/internal/panicx"
 	g "github.com/onsi/ginkgo/v2"
@@ -16,7 +15,7 @@ var _ = g.Describe("type UnexpectedBehavior", func() {
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<name>", "fce4f9f3-e8ee-45ce-924f-be8c3c0a9285")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
 				)
 			},
 		},

--- a/engine/internal/panicx/unexpectedmessage.go
+++ b/engine/internal/panicx/unexpectedmessage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/location"
 )
@@ -34,12 +35,12 @@ type UnexpectedMessage struct {
 
 func (x UnexpectedMessage) String() string {
 	return fmt.Sprintf(
-		"the '%s' %s message handler did not expect %T.%s() to be called with a message of type %T",
+		"the '%s' %s message handler did not expect %T.%s() to be called with a message of type %s",
 		x.Handler.Identity().Name,
 		x.Handler.HandlerType(),
 		x.Implementation,
 		x.Method,
-		x.Message,
+		message.TypeOf(x.Message),
 	)
 }
 

--- a/engine/internal/panicx/unexpectedmessage_test.go
+++ b/engine/internal/panicx/unexpectedmessage_test.go
@@ -3,7 +3,6 @@ package panicx_test
 import (
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/engine/internal/panicx"
 	g "github.com/onsi/ginkgo/v2"
@@ -17,7 +16,7 @@ var _ = g.Describe("type UnexpectedMessage", func() {
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<name>", "a0eab8dd-db22-467a-87c2-c38138c582e8")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
 				)
 			},
 		},
@@ -31,7 +30,7 @@ var _ = g.Describe("type UnexpectedMessage", func() {
 
 				x := r.(UnexpectedMessage)
 				Expect(x.String()).To(Equal(
-					"the '<name>' projection message handler did not expect *stubs.ProjectionMessageHandlerStub.<method>() to be called with a message of type fixtures.MessageA",
+					"the '<name>' projection message handler did not expect *stubs.ProjectionMessageHandlerStub.<method>() to be called with a message of type stubs.EventStub[TypeX]",
 				))
 			}()
 
@@ -40,7 +39,7 @@ var _ = g.Describe("type UnexpectedMessage", func() {
 				"<interface>",
 				"<method>",
 				config.Handler(),
-				MessageA1,
+				EventX1,
 				func() {
 					panic(dogma.UnexpectedMessage)
 				},
@@ -55,7 +54,7 @@ var _ = g.Describe("func EnrichUnexpectedMessage()", func() {
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<name>", "b665eca3-936e-41e3-b9ab-c618cfa95ec2")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
 				)
 			},
 		},
@@ -69,7 +68,7 @@ var _ = g.Describe("func EnrichUnexpectedMessage()", func() {
 			"<interface>",
 			"<method>",
 			config.Handler(),
-			MessageA1,
+			EventX1,
 			func() {
 				called = true
 			},
@@ -85,7 +84,7 @@ var _ = g.Describe("func EnrichUnexpectedMessage()", func() {
 				"<interface>",
 				"<method>",
 				config.Handler(),
-				MessageA1,
+				EventX1,
 				func() {
 					panic("<panic>")
 				},
@@ -100,7 +99,7 @@ var _ = g.Describe("func EnrichUnexpectedMessage()", func() {
 				"<interface>",
 				"<method>",
 				config.Handler(),
-				MessageA1,
+				EventX1,
 				doPanic,
 			)
 		}).To(PanicWith(
@@ -110,7 +109,7 @@ var _ = g.Describe("func EnrichUnexpectedMessage()", func() {
 					"Interface":      Equal("<interface>"),
 					"Method":         Equal("<method>"),
 					"Implementation": Equal(config.Handler()),
-					"Message":        Equal(MessageA1),
+					"Message":        Equal(EventX1),
 					"PanicLocation": MatchAllFields(
 						Fields{
 							"Func": Equal("github.com/dogmatiq/testkit/engine/internal/panicx_test.doPanic"),

--- a/engine/internal/process/controller.go
+++ b/engine/internal/process/controller.go
@@ -197,7 +197,7 @@ func (c *Controller) routeEvent(
 				Method:         "RouteEventToInstance",
 				Implementation: handler,
 				Message:        env.Message,
-				Description:    fmt.Sprintf("routed an event of type %T to an empty ID", env.Message),
+				Description:    fmt.Sprintf("routed an event of type %s to an empty ID", env.Type),
 				Location:       location.OfMethod(c.Config.Handler(), "RouteEventToInstance"),
 			})
 		}

--- a/engine/internal/process/scope.go
+++ b/engine/internal/process/scope.go
@@ -50,14 +50,16 @@ func (s *scope) End() {
 }
 
 func (s *scope) ExecuteCommand(m dogma.Command) {
-	if s.config.MessageTypes().Produced[message.TypeOf(m)] != message.CommandRole {
+	mt := message.TypeOf(m)
+
+	if s.config.MessageTypes().Produced[mt] != message.CommandRole {
 		panic(panicx.UnexpectedBehavior{
 			Handler:        s.config,
 			Interface:      "ProcessMessageHandler",
 			Method:         s.handleMethod,
 			Implementation: s.config.Handler(),
 			Message:        s.env.Message,
-			Description:    fmt.Sprintf("executed a command of type %T, which is not produced by this handler", m),
+			Description:    fmt.Sprintf("executed a command of type %s, which is not produced by this handler", mt),
 			Location:       location.OfCall(),
 		})
 	}
@@ -69,7 +71,7 @@ func (s *scope) ExecuteCommand(m dogma.Command) {
 			Method:         s.handleMethod,
 			Message:        s.env.Message,
 			Implementation: s.config.Handler(),
-			Description:    fmt.Sprintf("executed an invalid %T command: %s", m, err),
+			Description:    fmt.Sprintf("executed an invalid %s command: %s", mt, err),
 			Location:       location.OfCall(),
 		})
 	}
@@ -112,14 +114,16 @@ func (s *scope) RecordedAt() time.Time {
 }
 
 func (s *scope) ScheduleTimeout(m dogma.Timeout, t time.Time) {
-	if s.config.MessageTypes().Produced[message.TypeOf(m)] != message.TimeoutRole {
+	mt := message.TypeOf(m)
+
+	if s.config.MessageTypes().Produced[mt] != message.TimeoutRole {
 		panic(panicx.UnexpectedBehavior{
 			Handler:        s.config,
 			Interface:      "ProcessMessageHandler",
 			Method:         s.handleMethod,
 			Implementation: s.config.Handler(),
 			Message:        s.env.Message,
-			Description:    fmt.Sprintf("scheduled a timeout of type %T, which is not produced by this handler", m),
+			Description:    fmt.Sprintf("scheduled a timeout of type %s, which is not produced by this handler", mt),
 			Location:       location.OfCall(),
 		})
 	}
@@ -131,7 +135,7 @@ func (s *scope) ScheduleTimeout(m dogma.Timeout, t time.Time) {
 			Method:         s.handleMethod,
 			Message:        s.env.Message,
 			Implementation: s.config.Handler(),
-			Description:    fmt.Sprintf("scheduled an invalid %T timeout: %s", m, err),
+			Description:    fmt.Sprintf("scheduled an invalid %s timeout: %s", mt, err),
 			Location:       location.OfCall(),
 		})
 	}

--- a/engine/internal/projection/controller_test.go
+++ b/engine/internal/projection/controller_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/engine/internal/projection"
 	"github.com/dogmatiq/testkit/envelope"
@@ -28,7 +27,7 @@ var _ = g.Describe("type Controller", func() {
 	g.BeforeEach(func() {
 		event = envelope.NewEvent(
 			"1000",
-			MessageE1,
+			EventA1,
 			time.Now(),
 		)
 
@@ -36,7 +35,7 @@ var _ = g.Describe("type Controller", func() {
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<name>", "fcbe8fe1-1085-497d-ba8e-09bedb031db2")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
 				)
 			},
 		}
@@ -137,7 +136,7 @@ var _ = g.Describe("type Controller", func() {
 				m dogma.Event,
 			) (bool, error) {
 				called = true
-				Expect(m).To(Equal(MessageE1))
+				Expect(m).To(Equal(EventA1))
 				return true, nil
 			}
 

--- a/engine/internal/projection/scope_test.go
+++ b/engine/internal/projection/scope_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/engine/internal/projection"
 	"github.com/dogmatiq/testkit/envelope"
@@ -26,7 +25,7 @@ var _ = g.Describe("type scope", func() {
 	g.BeforeEach(func() {
 		event = envelope.NewEvent(
 			"1000",
-			MessageE1,
+			EventA1,
 			time.Now(),
 		)
 
@@ -34,7 +33,7 @@ var _ = g.Describe("type scope", func() {
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<name>", "deaaf068-bfd3-4ed2-a69d-850cb9bfab8d")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
 				)
 			},
 		}

--- a/envelope/envelope_test.go
+++ b/envelope/envelope_test.go
@@ -4,10 +4,8 @@ import (
 	"time"
 
 	"github.com/dogmatiq/configkit"
-	. "github.com/dogmatiq/configkit/fixtures"
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/envelope"
 	g "github.com/onsi/ginkgo/v2"
@@ -20,7 +18,7 @@ var _ = g.Describe("type Envelope", func() {
 			now := time.Now()
 			env := NewCommand(
 				"100",
-				MessageC1,
+				CommandA1,
 				now,
 			)
 
@@ -29,8 +27,8 @@ var _ = g.Describe("type Envelope", func() {
 					MessageID:     "100",
 					CorrelationID: "100",
 					CausationID:   "100",
-					Message:       MessageC1,
-					Type:          MessageCType,
+					Message:       CommandA1,
+					Type:          message.TypeOf(CommandA1),
 					Role:          message.CommandRole,
 					CreatedAt:     now,
 				},
@@ -43,7 +41,7 @@ var _ = g.Describe("type Envelope", func() {
 			now := time.Now()
 			env := NewEvent(
 				"100",
-				MessageE1,
+				EventA1,
 				now,
 			)
 
@@ -52,8 +50,8 @@ var _ = g.Describe("type Envelope", func() {
 					MessageID:     "100",
 					CorrelationID: "100",
 					CausationID:   "100",
-					Message:       MessageE1,
-					Type:          MessageEType,
+					Message:       EventA1,
+					Type:          message.TypeOf(EventA1),
 					Role:          message.EventRole,
 					CreatedAt:     now,
 				},
@@ -66,8 +64,8 @@ var _ = g.Describe("type Envelope", func() {
 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
 				c.Identity("<handler>", "d1c7e18a-4d72-4705-a120-6cfb29eef655")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
-					dogma.ExecutesCommand[MessageC](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
+					dogma.ExecutesCommand[CommandStub[TypeA]](),
 				)
 			},
 		})
@@ -75,7 +73,7 @@ var _ = g.Describe("type Envelope", func() {
 		g.It("returns the expected envelope", func() {
 			parent := NewEvent(
 				"100",
-				MessageP1,
+				CommandP1,
 				time.Now(),
 			)
 			origin := Origin{
@@ -86,7 +84,7 @@ var _ = g.Describe("type Envelope", func() {
 			now := time.Now()
 			child := parent.NewCommand(
 				"200",
-				MessageC1,
+				CommandA1,
 				now,
 				origin,
 			)
@@ -96,8 +94,8 @@ var _ = g.Describe("type Envelope", func() {
 					MessageID:     "200",
 					CorrelationID: "100",
 					CausationID:   "100",
-					Message:       MessageC1,
-					Type:          MessageCType,
+					Message:       CommandA1,
+					Type:          message.TypeOf(CommandA1),
 					Role:          message.CommandRole,
 					CreatedAt:     now,
 					Origin:        &origin,
@@ -111,8 +109,8 @@ var _ = g.Describe("type Envelope", func() {
 			ConfigureFunc: func(c dogma.AggregateConfigurer) {
 				c.Identity("<handler>", "8688dc39-b5d0-4468-89fd-0d9452667c0c")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 		})
@@ -120,7 +118,7 @@ var _ = g.Describe("type Envelope", func() {
 		g.It("returns the expected envelope", func() {
 			parent := NewCommand(
 				"100",
-				MessageP1,
+				CommandP1,
 				time.Now(),
 			)
 			origin := Origin{
@@ -131,7 +129,7 @@ var _ = g.Describe("type Envelope", func() {
 			now := time.Now()
 			child := parent.NewEvent(
 				"200",
-				MessageE1,
+				EventA1,
 				now,
 				origin,
 			)
@@ -141,8 +139,8 @@ var _ = g.Describe("type Envelope", func() {
 					MessageID:     "200",
 					CorrelationID: "100",
 					CausationID:   "100",
-					Message:       MessageE1,
-					Type:          MessageEType,
+					Message:       EventA1,
+					Type:          message.TypeOf(EventA1),
 					Role:          message.EventRole,
 					CreatedAt:     now,
 					Origin:        &origin,
@@ -156,9 +154,9 @@ var _ = g.Describe("type Envelope", func() {
 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
 				c.Identity("<handler>", "1d4e3d22-52fe-4b1b-9bf5-44b2050c08c2")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
-					dogma.ExecutesCommand[MessageC](),
-					dogma.SchedulesTimeout[MessageT](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
+					dogma.ExecutesCommand[CommandStub[TypeA]](),
+					dogma.SchedulesTimeout[TimeoutStub[TypeA]](),
 				)
 			},
 		})
@@ -166,7 +164,7 @@ var _ = g.Describe("type Envelope", func() {
 		g.It("returns the expected envelope", func() {
 			parent := NewCommand(
 				"100",
-				MessageP1,
+				CommandP1,
 				time.Now(),
 			)
 			origin := Origin{
@@ -178,7 +176,7 @@ var _ = g.Describe("type Envelope", func() {
 			s := time.Now()
 			child := parent.NewTimeout(
 				"200",
-				MessageT1,
+				TimeoutA1,
 				now,
 				s,
 				origin,
@@ -189,8 +187,8 @@ var _ = g.Describe("type Envelope", func() {
 					MessageID:     "200",
 					CorrelationID: "100",
 					CausationID:   "100",
-					Message:       MessageT1,
-					Type:          MessageTType,
+					Message:       TimeoutA1,
+					Type:          message.TypeOf(TimeoutA1),
 					Role:          message.TimeoutRole,
 					CreatedAt:     now,
 					ScheduledFor:  s,

--- a/executor_test.go
+++ b/executor_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/internal/testingmock"
@@ -32,8 +31,8 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 					ConfigureFunc: func(c dogma.IntegrationConfigurer) {
 						c.Identity("<handler-name>", "67c167a8-d09e-4827-beab-7c8c9817bb1a")
 						c.Routes(
-							dogma.HandlesCommand[MessageC](),
-							dogma.RecordsEvent[MessageE](),
+							dogma.HandlesCommand[CommandStub[TypeA]](),
+							dogma.RecordsEvent[EventStub[TypeA]](),
 						)
 					},
 					HandleCommandFunc: func(
@@ -41,7 +40,7 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 						s dogma.IntegrationCommandScope,
 						_ dogma.Command,
 					) error {
-						s.RecordEvent(MessageE1)
+						s.RecordEvent(EventA1)
 						return nil
 					},
 				})
@@ -61,7 +60,7 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 			m dogma.Command,
 			e dogma.CommandExecutor,
 		) error {
-			Expect(m).To(Equal(MessageC1))
+			Expect(m).To(Equal(CommandA1))
 
 			err := e.ExecuteCommand(ctx, m)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -90,11 +89,11 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 				Call(func() {
 					err := test.CommandExecutor().ExecuteCommand(
 						context.Background(),
-						MessageC1,
+						CommandA1,
 					)
 					Expect(err).To(MatchError("<error>"))
 				}),
-				ToRecordEvent(MessageE1),
+				ToRecordEvent(EventA1),
 			)
 		})
 	})
@@ -113,13 +112,13 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 					func() {
 						err := test.CommandExecutor().ExecuteCommand(
 							context.Background(),
-							MessageC1,
+							CommandA1,
 						)
 						Expect(err).To(MatchError("<error>"))
 					},
 					InterceptCommandExecutor(executeCommandAndReturnError),
 				),
-				ToRecordEvent(MessageE1),
+				ToRecordEvent(EventA1),
 			)
 		})
 
@@ -134,7 +133,7 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 					func() {
 						err := test.CommandExecutor().ExecuteCommand(
 							context.Background(),
-							MessageC1,
+							CommandA1,
 						)
 						Expect(err).To(MatchError("<error>"))
 					},
@@ -144,7 +143,7 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 					func() {
 						err := test.CommandExecutor().ExecuteCommand(
 							context.Background(),
-							MessageC1,
+							CommandA1,
 						)
 						Expect(err).ShouldNot(HaveOccurred())
 					},
@@ -164,7 +163,7 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 					func() {
 						err := test.CommandExecutor().ExecuteCommand(
 							context.Background(),
-							MessageC1,
+							CommandA1,
 						)
 						Expect(err).ShouldNot(HaveOccurred())
 					},
@@ -174,7 +173,7 @@ var _ = g.Describe("func InterceptCommandExecutor()", func() {
 					func() {
 						err := test.CommandExecutor().ExecuteCommand(
 							context.Background(),
-							MessageC1,
+							CommandA1,
 						)
 						Expect(err).To(MatchError("<error>"))
 					},

--- a/expectation.go
+++ b/expectation.go
@@ -1,10 +1,7 @@
 package testkit
 
 import (
-	"errors"
-
 	"github.com/dogmatiq/configkit"
-	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/testkit/fact"
 )
 
@@ -70,11 +67,4 @@ type PredicateOptions struct {
 	// If it is false, the predicate must only match against messages produced
 	// by handlers.
 	MatchDispatchCycleStartedFacts bool
-}
-
-func validateMessage(m dogma.Message) error {
-	if m == nil {
-		return errors.New("message must not be nil")
-	}
-	return m.Validate()
 }

--- a/expectation.message.event_test.go
+++ b/expectation.message.event_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/engine"
@@ -13,10 +12,20 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = g.Describe("func ToExecuteCommandType()", func() {
+var _ = g.Describe("func ToRecordEvent()", func() {
 	var (
 		testingT *testingmock.T
 		app      dogma.Application
+	)
+
+	type (
+		CommandThatIsIgnored    = CommandStub[TypeX]
+		CommandThatRecordsEvent = CommandStub[TypeE]
+
+		EventThatIsRecorded      = EventStub[TypeE]
+		EventThatIsNeverRecorded = EventStub[TypeX]
+		EventThatExecutesCommand = EventStub[TypeC]
+		EventThatIsOnlyConsumed  = EventStub[TypeO]
 	)
 
 	g.BeforeEach(func() {
@@ -32,11 +41,12 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 					ConfigureFunc: func(c dogma.AggregateConfigurer) {
 						c.Identity("<aggregate>", "8746651e-df4d-421c-9eea-177585e5b8eb")
 						c.Routes(
-							dogma.HandlesCommand[MessageR](), // R = record an event
-							dogma.HandlesCommand[MessageN](), // N = do nothing
-							dogma.RecordsEvent[MessageE](),
-							dogma.RecordsEvent[*MessageE](), // pointer, used to test type similarity
-							dogma.RecordsEvent[MessageX](),
+							dogma.HandlesCommand[CommandThatIsIgnored](),
+
+							dogma.HandlesCommand[CommandThatRecordsEvent](),
+							dogma.RecordsEvent[EventThatIsRecorded](),
+							dogma.RecordsEvent[*EventThatIsRecorded](), // pointer, used to test type similarity
+							dogma.RecordsEvent[EventThatIsNeverRecorded](),
 						)
 					},
 					RouteCommandToInstanceFunc: func(dogma.Command) string {
@@ -47,8 +57,11 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 						s dogma.AggregateCommandScope,
 						m dogma.Command,
 					) {
-						if _, ok := m.(MessageR); ok {
-							s.RecordEvent(MessageE1)
+						switch m := m.(type) {
+						case CommandThatRecordsEvent:
+							s.RecordEvent(EventThatIsRecorded{
+								Content: m.Content,
+							})
 						}
 					},
 				})
@@ -57,9 +70,9 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 					ConfigureFunc: func(c dogma.ProcessConfigurer) {
 						c.Identity("<process>", "209c7f0f-49ad-4419-88a6-4e9ee1cf204a")
 						c.Routes(
-							dogma.HandlesEvent[MessageE](), // E = execute a command
-							dogma.HandlesEvent[MessageO](), // O = only consumed, never produced
-							dogma.ExecutesCommand[MessageN](),
+							dogma.HandlesEvent[EventThatExecutesCommand](),
+							dogma.HandlesEvent[EventThatIsOnlyConsumed](),
+							dogma.ExecutesCommand[CommandThatIsIgnored](),
 						)
 					},
 					RouteEventToInstanceFunc: func(
@@ -74,8 +87,9 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 						s dogma.ProcessEventScope,
 						m dogma.Event,
 					) error {
-						if _, ok := m.(MessageE); ok {
-							s.ExecuteCommand(MessageN1)
+						switch m.(type) {
+						case EventThatExecutesCommand:
+							s.ExecuteCommand(CommandThatIsIgnored{})
 						}
 						return nil
 					},
@@ -100,20 +114,20 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		},
 		g.Entry(
 			"event recorded as expected",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(MessageE1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
+			ToRecordEvent(EventThatIsRecorded{}),
 			expectPass,
 			expectReport(
-				`✓ record a specific 'fixtures.MessageE' event`,
+				`✓ record a specific 'stubs.EventStub[TypeE]' event`,
 			),
 		),
 		g.Entry(
 			"no matching event recorded",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(MessageX1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
+			ToRecordEvent(EventThatIsNeverRecorded{}),
 			expectFail,
 			expectReport(
-				`✗ record a specific 'fixtures.MessageX' event`,
+				`✗ record a specific 'stubs.EventStub[TypeX]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,
@@ -125,11 +139,11 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		),
 		g.Entry(
 			"no matching event recorded and all relevant handler types disabled",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(MessageX1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
+			ToRecordEvent(EventThatIsRecorded{}),
 			expectFail,
 			expectReport(
-				`✗ record a specific 'fixtures.MessageX' event`,
+				`✗ record a specific 'stubs.EventStub[TypeE]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no relevant handler types were enabled`,
@@ -145,11 +159,11 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		),
 		g.Entry(
 			"no matching event recorded and no relevant handler types engaged",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(MessageX1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
+			ToRecordEvent(EventThatIsRecorded{}),
 			expectFail,
 			expectReport(
-				`✗ record a specific 'fixtures.MessageX' event`,
+				`✗ record a specific 'stubs.EventStub[TypeE]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no relevant handlers (aggregate or integration) were engaged`,
@@ -165,11 +179,11 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		),
 		g.Entry(
 			"no messages produced at all",
-			ExecuteCommand(MessageN1),
-			ToRecordEvent(MessageX1),
+			ExecuteCommand(CommandThatIsIgnored{}),
+			ToRecordEvent(EventThatIsRecorded{}),
 			expectFail,
 			expectReport(
-				`✗ record a specific 'fixtures.MessageX' event`,
+				`✗ record a specific 'stubs.EventStub[TypeE]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no messages were produced at all`,
@@ -181,11 +195,11 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		),
 		g.Entry(
 			"no events recorded at all",
-			RecordEvent(MessageE1),
-			ToRecordEvent(MessageX1),
+			RecordEvent(EventThatExecutesCommand{}),
+			ToRecordEvent(EventThatIsRecorded{}),
 			expectFail,
 			expectReport(
-				`✗ record a specific 'fixtures.MessageX' event`,
+				`✗ record a specific 'stubs.EventStub[TypeE]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no events were recorded at all`,
@@ -197,11 +211,11 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		),
 		g.Entry(
 			"similar event recorded with a different type",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(&MessageE1), // note: message type is pointer
+			ExecuteCommand(CommandThatRecordsEvent{}),
+			ToRecordEvent(&EventThatIsRecorded{}), // note: message type is pointer
 			expectFail,
 			expectReport(
-				`✗ record a specific '*fixtures.MessageE' event`,
+				`✗ record a specific '*stubs.EventStub[TypeE]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     an event of a similar type was recorded by the '<aggregate>' aggregate message handler`,
@@ -210,18 +224,16 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 				`  |     • check the message type, should it be a pointer?`,
 				`  | `,
 				`  | MESSAGE DIFF`,
-				`  |     [-*-]fixtures.MessageE{`,
-				`  |         Value: "E1"`,
-				`  |     }`,
+				`  |     [-*-]stubs.EventStub[github.com/dogmatiq/enginekit/enginetest/stubs.TypeE]{<zero>}`,
 			),
 		),
 		g.Entry(
 			"similar event recorded with a different value",
-			ExecuteCommand(MessageR1),
-			ToRecordEvent(MessageE2),
+			ExecuteCommand(CommandThatRecordsEvent{Content: "<content>"}),
+			ToRecordEvent(EventThatIsRecorded{Content: "<different>"}),
 			expectFail,
 			expectReport(
-				`✗ record a specific 'fixtures.MessageE' event`,
+				`✗ record a specific 'stubs.EventStub[TypeE]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     a similar event was recorded by the '<aggregate>' aggregate message handler`,
@@ -230,23 +242,24 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 				`  |     • check the content of the message`,
 				`  | `,
 				`  | MESSAGE DIFF`,
-				`  |     fixtures.MessageE{`,
-				`  |         Value: "E[-2-]{+1+}"`,
+				`  |     stubs.EventStub[github.com/dogmatiq/enginekit/enginetest/stubs.TypeE]{`,
+				`  |         Content:         "<[-differ-]{+cont+}ent>"`,
+				`  |         ValidationError: ""`,
 				`  |     }`,
 			),
 		),
 		g.Entry(
 			"does not include an explanation when negated and a sibling expectation passes",
-			ExecuteCommand(MessageR1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			NoneOf(
-				ToRecordEvent(MessageE1),
-				ToRecordEvent(MessageE2),
+				ToRecordEvent(EventThatIsRecorded{}),
+				ToRecordEvent(EventThatIsNeverRecorded{}),
 			),
 			expectFail,
 			expectReport(
 				`✗ none of (1 of the expectations passed unexpectedly)`,
-				`    ✓ record a specific 'fixtures.MessageE' event`,
-				`    ✗ record a specific 'fixtures.MessageE' event`,
+				`    ✓ record a specific 'stubs.EventStub[TypeE]' event`,
+				`    ✗ record a specific 'stubs.EventStub[TypeX]' event`,
 			),
 		),
 	)
@@ -255,12 +268,12 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		test := Begin(testingT, app)
 		test.Expect(
 			noop,
-			ToRecordEvent(MessageU1),
+			ToRecordEvent(EventU1),
 		)
 
 		Expect(testingT.Failed()).To(BeTrue())
 		Expect(testingT.Logs).To(ContainElement(
-			"an event of type fixtures.MessageU can never be recorded, the application does not use this message type",
+			"an event of type stubs.EventStub[TypeU] can never be recorded, the application does not use this message type",
 		))
 	})
 
@@ -268,12 +281,12 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		test := Begin(testingT, app)
 		test.Expect(
 			noop,
-			ToRecordEvent(MessageR1),
+			ToRecordEvent(CommandThatIsIgnored{}),
 		)
 
 		Expect(testingT.Failed()).To(BeTrue())
 		Expect(testingT.Logs).To(ContainElement(
-			"fixtures.MessageR is a command, it can never be recorded as an event",
+			"stubs.CommandStub[TypeX] is a command, it can never be recorded as an event",
 		))
 	})
 
@@ -281,12 +294,12 @@ var _ = g.Describe("func ToExecuteCommandType()", func() {
 		test := Begin(testingT, app)
 		test.Expect(
 			noop,
-			ToRecordEvent(MessageO1),
+			ToRecordEvent(EventThatIsOnlyConsumed{}),
 		)
 
 		Expect(testingT.Failed()).To(BeTrue())
 		Expect(testingT.Logs).To(ContainElement(
-			"no handlers record events of type fixtures.MessageO, it is only ever consumed",
+			"no handlers record events of type stubs.EventStub[TypeO], it is only ever consumed",
 		))
 	})
 

--- a/expectation.message.go
+++ b/expectation.message.go
@@ -16,13 +16,19 @@ import (
 // ToExecuteCommand returns an expectation that passes if a command is executed
 // that is equal to m.
 func ToExecuteCommand(m dogma.Command) Expectation {
-	if err := validateMessage(m); err != nil {
-		panic(fmt.Sprintf("ToExecuteCommand(%T): %s", m, err))
+	if m == nil {
+		panic("ToExecuteCommand(<nil>): message must not be nil")
+	}
+
+	mt := message.TypeOf(m)
+
+	if err := m.Validate(); err != nil {
+		panic(fmt.Sprintf("ToExecuteCommand(%s): %s", mt, err))
 	}
 
 	return &messageExpectation{
 		expectedMessage: m,
-		expectedType:    message.TypeOf(m),
+		expectedType:    mt,
 		expectedRole:    message.CommandRole,
 	}
 }
@@ -30,13 +36,19 @@ func ToExecuteCommand(m dogma.Command) Expectation {
 // ToRecordEvent returns an expectation that passes if an event is recorded that
 // is equal to m.
 func ToRecordEvent(m dogma.Command) Expectation {
-	if err := validateMessage(m); err != nil {
-		panic(fmt.Sprintf("ToRecordEvent(%T): %s", m, err))
+	if m == nil {
+		panic("ToRecordEvent(<nil>): message must not be nil")
+	}
+
+	mt := message.TypeOf(m)
+
+	if err := m.Validate(); err != nil {
+		panic(fmt.Sprintf("ToRecordEvent(%s): %s", mt, err))
 	}
 
 	return &messageExpectation{
 		expectedMessage: m,
-		expectedType:    message.TypeOf(m),
+		expectedType:    mt,
 		expectedRole:    message.EventRole,
 	}
 }

--- a/expectation.messagecommon.go
+++ b/expectation.messagecommon.go
@@ -168,6 +168,9 @@ func (t *tracker) Notify(f fact.Fact) (*envelope.Envelope, bool) {
 	case fact.CommandExecutedByProcess:
 		t.messageProduced(x.CommandEnvelope.Role)
 		return x.CommandEnvelope, true
+	case fact.TimeoutScheduledByProcess:
+		t.messageProduced(x.TimeoutEnvelope.Role)
+		return x.TimeoutEnvelope, true
 	}
 
 	return nil, false

--- a/expectation.messagematch.commandonly_test.go
+++ b/expectation.messagematch.commandonly_test.go
@@ -87,7 +87,7 @@ var _ = g.Describe("func ToOnlyExecuteCommandsMatching()", func() {
 			),
 		),
 		g.Entry(
-			"all executed commands match, using predicate with application-defined type parameter",
+			"all executed commands match, using predicate with a more specific type",
 			RecordEvent(MessageE1),
 			ToOnlyExecuteCommandsMatching(
 				func(m MessageC) error {
@@ -166,7 +166,7 @@ var _ = g.Describe("func ToOnlyExecuteCommandsMatching()", func() {
 			),
 		),
 		g.Entry(
-			"no executed commands match, using predicate with application-defined type parameter",
+			"no executed commands match, using predicate with a more specific type",
 			RecordEvent(MessageE1),
 			ToOnlyExecuteCommandsMatching(
 				func(m MessageX) error {

--- a/expectation.messagematch.event_test.go
+++ b/expectation.messagematch.event_test.go
@@ -121,7 +121,7 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			),
 		),
 		g.Entry(
-			"matching event recorded as expected, using predicate with application-defined type parameter",
+			"matching event recorded as expected, using predicate with a more specific type",
 			ExecuteCommand(MessageR1),
 			ToRecordEventMatching(
 				func(m MessageE) error {
@@ -166,7 +166,7 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			),
 		),
 		g.Entry(
-			"no matching event recorded, using predicate with application-defined type parameter",
+			"no matching event recorded, using predicate with a more specific type",
 			ExecuteCommand(MessageR1),
 			ToRecordEventMatching(
 				func(m MessageX) error {

--- a/expectation.messagematch.event_test.go
+++ b/expectation.messagematch.event_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/engine"
@@ -20,6 +19,15 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		app      dogma.Application
 	)
 
+	type (
+		CommandThatIsIgnored    = CommandStub[TypeX]
+		CommandThatRecordsEvent = CommandStub[TypeE]
+
+		EventThatIsRecorded      = EventStub[TypeE]
+		EventThatIsNeverRecorded = EventStub[TypeX]
+		EventThatExecutesCommand = EventStub[TypeC]
+	)
+
 	g.BeforeEach(func() {
 		testingT = &testingmock.T{
 			FailSilently: true,
@@ -31,13 +39,13 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 
 				c.RegisterAggregate(&AggregateMessageHandlerStub{
 					ConfigureFunc: func(c dogma.AggregateConfigurer) {
-						c.Identity("<aggregate>", "8305181b-b87f-4446-8f56-a3c38d5bd32f")
+						c.Identity("<aggregate>", "6a182af9-4659-49cf-8c44-85dfd47dbefc")
 						c.Routes(
-							dogma.HandlesCommand[MessageR](), // R = record an event
-							dogma.HandlesCommand[MessageN](), // N = do nothing
-							dogma.RecordsEvent[MessageE](),
-							dogma.RecordsEvent[*MessageE](), // pointer, used to test type similarity
-							dogma.RecordsEvent[MessageX](),
+							dogma.HandlesCommand[CommandThatIsIgnored](),
+
+							dogma.HandlesCommand[CommandThatRecordsEvent](),
+							dogma.RecordsEvent[EventThatIsRecorded](),
+							dogma.RecordsEvent[EventThatIsNeverRecorded](),
 						)
 					},
 					RouteCommandToInstanceFunc: func(dogma.Command) string {
@@ -48,11 +56,20 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 						s dogma.AggregateCommandScope,
 						m dogma.Command,
 					) {
-						if m, ok := m.(MessageR); ok {
-							s.RecordEvent(MessageE1)
+						switch m := m.(type) {
+						case CommandThatRecordsEvent:
+							s.RecordEvent(
+								EventThatIsRecorded{
+									Content: m.Content,
+								},
+							)
 
-							if m.Value == "<multiple>" {
-								s.RecordEvent(MessageE1)
+							if m.Content == "<multiple>" {
+								s.RecordEvent(
+									EventThatIsRecorded{
+										Content: m.Content,
+									},
+								)
 							}
 						}
 					},
@@ -60,11 +77,10 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 
 				c.RegisterProcess(&ProcessMessageHandlerStub{
 					ConfigureFunc: func(c dogma.ProcessConfigurer) {
-						c.Identity("<process>", "0bd19cfa-c910-453f-a6cc-959fdce9c34f")
+						c.Identity("<process>", "7651ad19-1526-48c0-a53d-676286a34ca6")
 						c.Routes(
-							dogma.HandlesEvent[MessageE](), // E = execute a command
-							dogma.HandlesEvent[MessageO](), // O = only consumed, never produced
-							dogma.ExecutesCommand[MessageN](),
+							dogma.HandlesEvent[EventThatExecutesCommand](),
+							dogma.ExecutesCommand[CommandThatIsIgnored](),
 						)
 					},
 					RouteEventToInstanceFunc: func(
@@ -79,8 +95,9 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 						s dogma.ProcessEventScope,
 						m dogma.Event,
 					) error {
-						if _, ok := m.(MessageE); ok {
-							s.ExecuteCommand(MessageN1)
+						switch m.(type) {
+						case EventThatExecutesCommand:
+							s.ExecuteCommand(CommandThatIsIgnored{})
 						}
 						return nil
 					},
@@ -105,27 +122,10 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		},
 		g.Entry(
 			"matching event recorded as expected",
-			ExecuteCommand(MessageR1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToRecordEventMatching(
 				func(m dogma.Event) error {
-					if m == MessageE1 {
-						return nil
-					}
-
-					return errors.New("<error>")
-				},
-			),
-			expectPass,
-			expectReport(
-				`✓ record an event that matches the predicate near expectation.messagematch.event_test.go:110`,
-			),
-		),
-		g.Entry(
-			"matching event recorded as expected, using predicate with a more specific type",
-			ExecuteCommand(MessageR1),
-			ToRecordEventMatching(
-				func(m MessageE) error {
-					if m == MessageE1 {
+					if m == (EventThatIsRecorded{}) {
 						return nil
 					}
 
@@ -138,26 +138,39 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			),
 		),
 		g.Entry(
-			"no matching event recorded",
-			ExecuteCommand(MessageR1),
+			"matching event recorded as expected, using predicate with a more specific type",
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToRecordEventMatching(
-				func(m dogma.Event) error {
-					if m == MessageX1 {
+				func(m EventThatIsRecorded) error {
+					if m == (EventThatIsRecorded{}) {
 						return nil
 					}
 
 					return errors.New("<error>")
 				},
 			),
+			expectPass,
+			expectReport(
+				`✓ record an event that matches the predicate near expectation.messagematch.event_test.go:144`,
+			),
+		),
+		g.Entry(
+			"no matching event recorded",
+			ExecuteCommand(CommandThatRecordsEvent{}),
+			ToRecordEventMatching(
+				func(m dogma.Event) error {
+					return errors.New("<error>")
+				},
+			),
 			expectFail,
 			expectReport(
-				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:144`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:161`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,
 				`  | `,
 				`  | FAILED MATCHES`,
-				`  |     • fixtures.MessageE: <error>`,
+				`  |     • stubs.EventStub[TypeE]: <error>`,
 				`  | `,
 				`  | SUGGESTIONS`,
 				`  |     • verify the logic within the predicate function`,
@@ -167,15 +180,15 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		),
 		g.Entry(
 			"no matching event recorded, using predicate with a more specific type",
-			ExecuteCommand(MessageR1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToRecordEventMatching(
-				func(m MessageX) error {
+				func(m EventThatIsNeverRecorded) error {
 					panic("unexpected call")
 				},
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:172`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:185`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,
@@ -188,7 +201,7 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		),
 		g.Entry(
 			"no messages produced at all",
-			ExecuteCommand(MessageN1),
+			ExecuteCommand(CommandThatIsIgnored{}),
 			ToRecordEventMatching(
 				func(m dogma.Event) error {
 					panic("unexpected call")
@@ -196,7 +209,7 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:193`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:206`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no messages were produced at all`,
@@ -208,15 +221,15 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		),
 		g.Entry(
 			"no events recorded at all",
-			RecordEvent(MessageE1),
+			RecordEvent(EventThatExecutesCommand{}),
 			ToRecordEventMatching(
 				func(m dogma.Event) error {
-					return IgnoreMessage
+					panic("unexpected call")
 				},
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:213`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:226`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no events were recorded at all`,
@@ -228,7 +241,7 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		),
 		g.Entry(
 			"no matching event recorded and all relevant handler types disabled",
-			ExecuteCommand(MessageR1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToRecordEventMatching(
 				func(m dogma.Event) error {
 					panic("unexpected call")
@@ -236,7 +249,7 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:233`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:246`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no relevant handler types were enabled`,
@@ -250,10 +263,9 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 				engine.EnableIntegrations(false),
 			),
 		),
-
 		g.Entry(
 			"no matching event recorded and events were ignored",
-			ExecuteCommand(MessageR1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToRecordEventMatching(
 				func(m dogma.Event) error {
 					return IgnoreMessage
@@ -261,7 +273,7 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:258`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:270`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,
@@ -274,8 +286,8 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		),
 		g.Entry(
 			"no matching event recorded and error messages were repeated",
-			ExecuteCommand(MessageR{
-				Value: "<multiple>", // trigger multiple MessageE events
+			ExecuteCommand(CommandThatRecordsEvent{
+				Content: "<multiple>",
 			}),
 			ToRecordEventMatching(
 				func(m dogma.Event) error {
@@ -284,13 +296,13 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:281`,
+				`✗ record an event that matches the predicate near expectation.messagematch.event_test.go:293`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the engaged handlers recorded a matching event`,
 				`  | `,
 				`  | FAILED MATCHES`,
-				`  |     • fixtures.MessageE: <error> (repeated 2 times)`,
+				`  |     • stubs.EventStub[TypeE]: <error> (repeated 2 times)`,
 				`  | `,
 				`  | SUGGESTIONS`,
 				`  |     • verify the logic within the predicate function`,
@@ -300,23 +312,15 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 		),
 		g.Entry(
 			"does not include an explanation when negated and a sibling expectation passes",
-			ExecuteCommand(MessageR1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			NoneOf(
 				ToRecordEventMatching(
 					func(m dogma.Event) error {
-						if m == MessageE1 {
-							return nil
-						}
-
-						return errors.New("<error>")
+						return nil
 					},
 				),
 				ToRecordEventMatching(
 					func(m dogma.Event) error {
-						if m == MessageX1 {
-							return nil
-						}
-
 						return errors.New("<error>")
 					},
 				),
@@ -324,8 +328,8 @@ var _ = g.Describe("func ToRecordEventMatching()", func() {
 			expectFail,
 			expectReport(
 				`✗ none of (1 of the expectations passed unexpectedly)`,
-				`    ✓ record an event that matches the predicate near expectation.messagematch.event_test.go:306`,
-				`    ✗ record an event that matches the predicate near expectation.messagematch.event_test.go:315`,
+				`    ✓ record an event that matches the predicate near expectation.messagematch.event_test.go:319`,
+				`    ✗ record an event that matches the predicate near expectation.messagematch.event_test.go:323`,
 			),
 		),
 	)

--- a/expectation.messagematch.eventonly_test.go
+++ b/expectation.messagematch.eventonly_test.go
@@ -81,7 +81,7 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 			),
 		),
 		g.Entry(
-			"all recorded events match, using predicate with application-defined type parameter",
+			"all recorded events match, using predicate with a more specific type",
 			ExecuteCommand(MessageC1),
 			ToOnlyRecordEventsMatching(
 				func(m MessageE) error {
@@ -162,7 +162,7 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 			),
 		),
 		g.Entry(
-			"no matching events recorded, using predicate with application-defined type parameter",
+			"no matching events recorded, using predicate with a more specific type",
 			ExecuteCommand(MessageC1),
 			ToOnlyRecordEventsMatching(
 				func(m MessageX) error {

--- a/expectation.messagematch.eventonly_test.go
+++ b/expectation.messagematch.eventonly_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 
 	"github.com/dogmatiq/dogma"
-	"github.com/dogmatiq/dogma/fixtures"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/internal/testingmock"
@@ -17,6 +15,11 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 	var (
 		testingT *testingmock.T
 		app      dogma.Application
+	)
+
+	type (
+		CommandThatRecordsEvent = CommandStub[TypeE]
+		EventThatIsRecorded     = EventStub[TypeE]
 	)
 
 	g.BeforeEach(func() {
@@ -32,8 +35,8 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 					ConfigureFunc: func(c dogma.AggregateConfigurer) {
 						c.Identity("<aggregate>", "bc64cfe4-3339-4eee-a9d2-364d33dff47d")
 						c.Routes(
-							dogma.HandlesCommand[MessageC](), // C = command
-							dogma.RecordsEvent[MessageE](),   // E = event
+							dogma.HandlesCommand[CommandThatRecordsEvent](),
+							dogma.RecordsEvent[EventThatIsRecorded](),
 						)
 					},
 					RouteCommandToInstanceFunc: func(dogma.Command) string {
@@ -44,9 +47,9 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 						s dogma.AggregateCommandScope,
 						m dogma.Command,
 					) {
-						s.RecordEvent(MessageE1)
-						s.RecordEvent(MessageE2)
-						s.RecordEvent(MessageE3)
+						s.RecordEvent(EventE1)
+						s.RecordEvent(EventE2)
+						s.RecordEvent(EventE3)
 					},
 				})
 			},
@@ -69,7 +72,7 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 		},
 		g.Entry(
 			"all recorded events match",
-			ExecuteCommand(MessageC1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToOnlyRecordEventsMatching(
 				func(m dogma.Event) error {
 					return nil
@@ -77,20 +80,20 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 			),
 			expectPass,
 			expectReport(
-				`✓ only record events that match the predicate near expectation.messagematch.eventonly_test.go:75`,
+				`✓ only record events that match the predicate near expectation.messagematch.eventonly_test.go:78`,
 			),
 		),
 		g.Entry(
 			"all recorded events match, using predicate with a more specific type",
-			ExecuteCommand(MessageC1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToOnlyRecordEventsMatching(
-				func(m MessageE) error {
+				func(m EventThatIsRecorded) error {
 					return nil
 				},
 			),
 			expectPass,
 			expectReport(
-				`✓ only record events that match the predicate near expectation.messagematch.eventonly_test.go:88`,
+				`✓ only record events that match the predicate near expectation.messagematch.eventonly_test.go:91`,
 			),
 		),
 		g.Entry(
@@ -103,12 +106,12 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 			),
 			expectPass,
 			expectReport(
-				`✓ only record events that match the predicate near expectation.messagematch.eventonly_test.go:100`,
+				`✓ only record events that match the predicate near expectation.messagematch.eventonly_test.go:103`,
 			),
 		),
 		g.Entry(
 			"none of the recorded events match",
-			ExecuteCommand(MessageC1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToOnlyRecordEventsMatching(
 				func(m dogma.Event) error {
 					return errors.New("<error>")
@@ -116,13 +119,13 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ only record events that match the predicate near expectation.messagematch.eventonly_test.go:113`,
+				`✗ only record events that match the predicate near expectation.messagematch.eventonly_test.go:116`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the 3 relevant events matched the predicate`,
 				`  | `,
 				`  | FAILED MATCHES`,
-				`  |     • fixtures.MessageE: <error> (repeated 3 times)`,
+				`  |     • stubs.EventStub[TypeE]: <error> (repeated 3 times)`,
 				`  | `,
 				`  | SUGGESTIONS`,
 				`  |     • verify the logic within the predicate function`,
@@ -132,13 +135,13 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 		),
 		g.Entry(
 			"some matching events recorded",
-			ExecuteCommand(MessageC1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToOnlyRecordEventsMatching(
 				func(m dogma.Event) error {
 					switch m {
-					case fixtures.MessageE1:
+					case EventE1:
 						return errors.New("<error>")
-					case fixtures.MessageE2:
+					case EventE2:
 						return IgnoreMessage
 					default:
 						return nil
@@ -147,13 +150,13 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 			),
 			expectFail,
 			expectReport(
-				`✗ only record events that match the predicate near expectation.messagematch.eventonly_test.go:137`,
+				`✗ only record events that match the predicate near expectation.messagematch.eventonly_test.go:140`,
 				``,
 				`  | EXPLANATION`,
 				`  |     only 1 of 2 relevant events matched the predicate`,
 				`  | `,
 				`  | FAILED MATCHES`,
-				`  |     • fixtures.MessageE: <error>`,
+				`  |     • stubs.EventStub[TypeE]: <error>`,
 				`  | `,
 				`  | SUGGESTIONS`,
 				`  |     • verify the logic within the predicate function, it ignored 1 event`,
@@ -163,21 +166,21 @@ var _ = g.Describe("func ToOnlyRecordEventsMatching()", func() {
 		),
 		g.Entry(
 			"no matching events recorded, using predicate with a more specific type",
-			ExecuteCommand(MessageC1),
+			ExecuteCommand(CommandThatRecordsEvent{}),
 			ToOnlyRecordEventsMatching(
-				func(m MessageX) error {
+				func(m EventStub[TypeX]) error {
 					panic("unexpected call")
 				},
 			),
 			expectFail,
 			expectReport(
-				`✗ only record events that match the predicate near expectation.messagematch.eventonly_test.go:168`,
+				`✗ only record events that match the predicate near expectation.messagematch.eventonly_test.go:171`,
 				``,
 				`  | EXPLANATION`,
 				`  |     none of the 3 relevant events matched the predicate`,
 				`  | `,
 				`  | FAILED MATCHES`,
-				`  |     • fixtures.MessageE: predicate function expected fixtures.MessageX (repeated 3 times)`,
+				`  |     • stubs.EventStub[TypeE]: predicate function expected stubs.EventStub[TypeX] (repeated 3 times)`,
 				`  | `,
 				`  | SUGGESTIONS`,
 				`  |     • verify the logic within the predicate function`,

--- a/expectation.messagematch.go
+++ b/expectation.messagematch.go
@@ -3,7 +3,6 @@ package testkit
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
@@ -199,7 +198,7 @@ func (p *messageMatchPredicate[T]) messageProduced(env *envelope.Envelope) {
 	if m, ok := env.Message.(T); ok {
 		err = p.pred(m)
 	} else if p.exhaustive {
-		err = fmt.Errorf("predicate function expected %s", reflect.TypeFor[T]())
+		err = fmt.Errorf("predicate function expected %s", message.TypeFor[T]())
 	} else {
 		err = IgnoreMessage
 	}

--- a/expectation.messagetype.commandcall_test.go
+++ b/expectation.messagetype.commandcall_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/engine"
@@ -20,6 +19,14 @@ var _ = g.Describe("func ToExecuteCommandType() (when used with the Call() actio
 		test     *Test
 	)
 
+	type (
+		CommandThatIsIgnored           = CommandStub[TypeX]
+		CommandThatRecordsEvent        = CommandStub[dogma.Event]
+		CommandThatIsExecutedByProcess = CommandStub[TypeP]
+
+		EventThatExecutesCommand = EventStub[TypeP]
+	)
+
 	g.BeforeEach(func() {
 		testingT = &testingmock.T{
 			FailSilently: true,
@@ -29,35 +36,34 @@ var _ = g.Describe("func ToExecuteCommandType() (when used with the Call() actio
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "f38c3003-bbd0-4b4a-b1f8-6922e9545acd")
 
-				c.RegisterAggregate(&AggregateMessageHandlerStub{
-					ConfigureFunc: func(c dogma.AggregateConfigurer) {
-						c.Identity("<aggregate>", "5c44e153-9e42-4816-87b0-59b4b4943dc4")
+				c.RegisterIntegration(&IntegrationMessageHandlerStub{
+					ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+						c.Identity("<integration>", "efa4e6c1-1131-4ff6-9417-5eda4356c5aa")
 						c.Routes(
-							dogma.HandlesCommand[MessageR](),  // R = record an event
-							dogma.HandlesCommand[*MessageR](), // pointer, used to test type similarity
-							dogma.HandlesCommand[MessageX](),
-							dogma.RecordsEvent[MessageN](),
+							dogma.HandlesCommand[CommandThatIsIgnored](),
+							dogma.HandlesCommand[*CommandThatIsIgnored](), // pointer, used to test type similarity
+							dogma.HandlesCommand[CommandThatRecordsEvent](),
 						)
 					},
-					RouteCommandToInstanceFunc: func(dogma.Command) string {
-						return "<instance>"
-					},
 					HandleCommandFunc: func(
-						_ dogma.AggregateRoot,
-						s dogma.AggregateCommandScope,
-						_ dogma.Command,
-					) {
-						s.RecordEvent(MessageN1)
+						_ context.Context,
+						s dogma.IntegrationCommandScope,
+						m dogma.Command,
+					) error {
+						switch m := m.(type) {
+						case CommandThatRecordsEvent:
+							s.RecordEvent(m.Content)
+						}
+						return nil
 					},
 				})
 
 				c.RegisterProcess(&ProcessMessageHandlerStub{
 					ConfigureFunc: func(c dogma.ProcessConfigurer) {
-						c.Identity("<process>", "3994dd62-43f7-4569-813f-a616dc444486")
+						c.Identity("<process>", "8b4c4701-be92-4b28-83b6-0d69b97fb451")
 						c.Routes(
-							dogma.HandlesEvent[MessageE](),    // E = event
-							dogma.HandlesEvent[MessageN](),    // N = (do) nothing
-							dogma.ExecutesCommand[MessageC](), // C = command
+							dogma.HandlesEvent[EventThatExecutesCommand](),
+							dogma.ExecutesCommand[CommandThatIsExecutedByProcess](),
 						)
 					},
 					RouteEventToInstanceFunc: func(
@@ -72,9 +78,15 @@ var _ = g.Describe("func ToExecuteCommandType() (when used with the Call() actio
 						s dogma.ProcessEventScope,
 						m dogma.Event,
 					) error {
-						if _, ok := m.(MessageE); ok {
-							s.ExecuteCommand(MessageC1)
+						switch m := m.(type) {
+						case EventThatExecutesCommand:
+							s.ExecuteCommand(
+								CommandThatIsExecutedByProcess{
+									Content: m.Content,
+								},
+							)
 						}
+
 						return nil
 					},
 				})
@@ -105,20 +117,20 @@ var _ = g.Describe("func ToExecuteCommandType() (when used with the Call() actio
 		},
 		g.Entry(
 			"command type executed as expected",
-			executeCommandViaExecutor(MessageR1),
-			ToExecuteCommandType[MessageR](),
+			executeCommandViaExecutor(CommandThatIsIgnored{}),
+			ToExecuteCommandType[CommandThatIsIgnored](),
 			expectPass,
 			expectReport(
-				`✓ execute any 'fixtures.MessageR' command`,
+				`✓ execute any 'stubs.CommandStub[TypeX]' command`,
 			),
 		),
 		g.Entry(
 			"no messages produced at all",
 			Call(func() {}),
-			ToExecuteCommandType[MessageC](),
+			ToExecuteCommandType[CommandThatIsIgnored](),
 			expectFail,
 			expectReport(
-				`✗ execute any 'fixtures.MessageC' command`,
+				`✗ execute any 'stubs.CommandStub[TypeX]' command`,
 				``,
 				`  | EXPLANATION`,
 				`  |     no messages were produced at all`,
@@ -129,11 +141,13 @@ var _ = g.Describe("func ToExecuteCommandType() (when used with the Call() actio
 		),
 		g.Entry(
 			"no matching command type executed and all relevant handler types disabled",
-			executeCommandViaExecutor(MessageR1),
-			ToExecuteCommandType[MessageC](),
+			executeCommandViaExecutor(CommandThatRecordsEvent{
+				Content: EventThatExecutesCommand{},
+			}),
+			ToExecuteCommandType[CommandThatIsExecutedByProcess](),
 			expectFail,
 			expectReport(
-				`✗ execute any 'fixtures.MessageC' command`,
+				`✗ execute any 'stubs.CommandStub[TypeP]' command`,
 				``,
 				`  | EXPLANATION`,
 				`  |     nothing executed a matching command`,
@@ -148,11 +162,11 @@ var _ = g.Describe("func ToExecuteCommandType() (when used with the Call() actio
 		),
 		g.Entry(
 			"command of a similar type executed",
-			executeCommandViaExecutor(MessageR1),
-			ToExecuteCommandType[*MessageR](), // note: message type is pointer
+			executeCommandViaExecutor(CommandThatIsIgnored{}),
+			ToExecuteCommandType[*CommandThatIsIgnored](), // note: message type is pointer
 			expectFail,
 			expectReport(
-				`✗ execute any '*fixtures.MessageR' command`,
+				`✗ execute any '*stubs.CommandStub[TypeX]' command`,
 				``,
 				`  | EXPLANATION`,
 				`  |     a command of a similar type was executed via a dogma.CommandExecutor`,
@@ -161,7 +175,7 @@ var _ = g.Describe("func ToExecuteCommandType() (when used with the Call() actio
 				`  |     • check the message type, should it be a pointer?`,
 				`  | `,
 				`  | MESSAGE TYPE DIFF`,
-				`  |     [-*-]fixtures.MessageR`,
+				`  |     [-*-]stubs.CommandStub[TypeX]`,
 			),
 		),
 	)

--- a/fact/logger_test.go
+++ b/fact/logger_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	"github.com/dogmatiq/testkit/envelope"
 	. "github.com/dogmatiq/testkit/fact"
@@ -23,13 +22,13 @@ var _ = g.Describe("type Logger", func() {
 
 		command := envelope.NewCommand(
 			"10",
-			MessageC1,
+			CommandA1,
 			time.Now(),
 		)
 
 		event := envelope.NewEvent(
 			"10",
-			MessageE1,
+			EventA1,
 			time.Now(),
 		)
 
@@ -37,8 +36,8 @@ var _ = g.Describe("type Logger", func() {
 			ConfigureFunc: func(c dogma.AggregateConfigurer) {
 				c.Identity("<aggregate>", "986495b4-c878-4e3a-b16b-73f8aefbc2ca")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 		})
@@ -47,8 +46,8 @@ var _ = g.Describe("type Logger", func() {
 			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
 				c.Identity("<integration>", "2425a151-ba72-42ec-970a-8b3b4133b22f")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 		})
@@ -57,8 +56,8 @@ var _ = g.Describe("type Logger", func() {
 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
 				c.Identity("<process>", "570684db-0144-4628-a58f-ae815c55dea3")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
-					dogma.ExecutesCommand[MessageC](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
+					dogma.ExecutesCommand[CommandStub[TypeA]](),
 				)
 			},
 		})
@@ -67,7 +66,7 @@ var _ = g.Describe("type Logger", func() {
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<projection>", "36f29880-6b87-42c5-848c-f515c9f1c74b")
 				c.Routes(
-					dogma.HandlesEvent[MessageE](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
 				)
 			},
 		})
@@ -134,7 +133,7 @@ var _ = g.Describe("type Logger", func() {
 
 			g.Entry(
 				"DispatchBegun",
-				"= 10  ∵ 10  ⋲ 10  ▼ ⚙    fixtures.MessageC? ● {C1}",
+				"= 10  ∵ 10  ⋲ 10  ▼ ⚙    stubs.CommandStub[TypeA]? ● command(stubs.TypeA:A1, valid)",
 				DispatchBegun{
 					Envelope: command,
 				},
@@ -300,14 +299,14 @@ var _ = g.Describe("type Logger", func() {
 			),
 			g.Entry(
 				"EventRecordedByAggregate",
-				"= 20  ∵ 10  ⋲ 10  ▲ ∴    <aggregate> <instance> ● recorded an event ● fixtures.MessageE! ● {E1}",
+				"= 20  ∵ 10  ⋲ 10  ▲ ∴    <aggregate> <instance> ● recorded an event ● stubs.EventStub[TypeA]! ● event(stubs.TypeA:A1, valid)",
 				EventRecordedByAggregate{
 					Handler:    aggregate,
 					InstanceID: "<instance>",
 					Envelope:   command,
 					EventEnvelope: command.NewEvent(
 						"20",
-						MessageE1,
+						EventA1,
 						time.Now(),
 						envelope.Origin{},
 					),
@@ -391,14 +390,14 @@ var _ = g.Describe("type Logger", func() {
 			),
 			g.Entry(
 				"CommandExecutedByProcess",
-				"= 20  ∵ 10  ⋲ 10  ▲ ≡    <process> <instance> ● executed a command ● fixtures.MessageC? ● {C1}",
+				"= 20  ∵ 10  ⋲ 10  ▲ ≡    <process> <instance> ● executed a command ● stubs.CommandStub[TypeA]? ● command(stubs.TypeA:A1, valid)",
 				CommandExecutedByProcess{
 					Handler:    process,
 					InstanceID: "<instance>",
 					Envelope:   event,
 					CommandEnvelope: event.NewCommand(
 						"20",
-						MessageC1,
+						CommandA1,
 						time.Now(),
 						envelope.Origin{},
 					),
@@ -406,13 +405,13 @@ var _ = g.Describe("type Logger", func() {
 			),
 			g.Entry(
 				"TimeoutScheduledByProcess",
-				"= 20  ∵ 10  ⋲ 10  ▲ ≡    <process> <instance> ● scheduled a timeout for 2006-01-02T15:04:05+07:00 ● fixtures.MessageT@ ● {T1}",
+				"= 20  ∵ 10  ⋲ 10  ▲ ≡    <process> <instance> ● scheduled a timeout for 2006-01-02T15:04:05+07:00 ● stubs.TimeoutStub[TypeA]@ ● timeout(stubs.TypeA:A1, valid)",
 				TimeoutScheduledByProcess{
 					Handler:    process,
 					InstanceID: "<instance>",
 					TimeoutEnvelope: event.NewTimeout(
 						"20",
-						MessageT1,
+						TimeoutA1,
 						time.Now(),
 						now,
 						envelope.Origin{
@@ -439,13 +438,13 @@ var _ = g.Describe("type Logger", func() {
 
 			g.Entry(
 				"EventRecordedByIntegration",
-				"= 20  ∵ 10  ⋲ 10  ▲ ⨝    <integration> ● recorded an event ● fixtures.MessageE! ● {E1}",
+				"= 20  ∵ 10  ⋲ 10  ▲ ⨝    <integration> ● recorded an event ● stubs.EventStub[TypeA]! ● event(stubs.TypeA:A1, valid)",
 				EventRecordedByIntegration{
 					Handler:  integration,
 					Envelope: command,
 					EventEnvelope: command.NewEvent(
 						"20",
-						MessageE1,
+						EventA1,
 						time.Now(),
 						envelope.Origin{},
 					),

--- a/internal/inflect/inflect_test.go
+++ b/internal/inflect/inflect_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/dogmatiq/configkit/message"
-	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/internal/inflect"
 	g "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -76,9 +76,9 @@ var _ = g.Describe("func Sprintf()", func() {
 			Sprintf(
 				message.CommandRole,
 				"the %T <message>",
-				MessageA1,
+				CommandA1,
 			),
-		).To(Equal("the fixtures.MessageA command"))
+		).To(Equal("the stubs.CommandStub[github.com/dogmatiq/enginekit/enginetest/stubs.TypeA] command"))
 	})
 })
 
@@ -99,8 +99,8 @@ var _ = g.Describe("func Errorf()", func() {
 			Errorf(
 				message.CommandRole,
 				"the %T <message>",
-				MessageA1,
+				CommandA1,
 			),
-		).To(MatchError("the fixtures.MessageA command"))
+		).To(MatchError("the stubs.CommandStub[github.com/dogmatiq/enginekit/enginetest/stubs.TypeA] command"))
 	})
 })

--- a/internal/typecmp/distance_test.go
+++ b/internal/typecmp/distance_test.go
@@ -3,7 +3,7 @@ package typecmp_test
 import (
 	"reflect"
 
-	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit/internal/typecmp"
 	g "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,8 +13,8 @@ var _ = g.Describe("func MeasureDistance()", func() {
 	g.It("returns Identical when given two identical types", func() {
 		Expect(
 			MeasureDistance(
-				reflect.TypeOf(MessageA1),
-				reflect.TypeOf(MessageA1),
+				reflect.TypeOf(CommandA1),
+				reflect.TypeOf(CommandA1),
 			),
 		).To(Equal(
 			Identical,
@@ -24,8 +24,8 @@ var _ = g.Describe("func MeasureDistance()", func() {
 	g.It("returns Unrelated when given two unrelated types", func() {
 		Expect(
 			MeasureDistance(
-				reflect.TypeOf(MessageA1),
-				reflect.TypeOf(MessageB1),
+				reflect.TypeOf(CommandA1),
+				reflect.TypeOf(EventA1),
 			),
 		).To(Equal(
 			Unrelated,
@@ -33,8 +33,8 @@ var _ = g.Describe("func MeasureDistance()", func() {
 	})
 
 	g.It("returns some intermediate value when given types that differ only by 'pointer depth'", func() {
-		a := reflect.PtrTo(reflect.TypeOf(MessageA1))
-		b := reflect.TypeOf(MessageA1)
+		a := reflect.PointerTo(reflect.TypeOf(CommandA1))
+		b := reflect.TypeOf(CommandA1)
 
 		dist := MeasureDistance(a, b)
 
@@ -43,8 +43,8 @@ var _ = g.Describe("func MeasureDistance()", func() {
 	})
 
 	g.It("returns the same value regardless of parameter order", func() {
-		a := reflect.PtrTo(reflect.TypeOf(MessageA1))
-		b := reflect.TypeOf(MessageA1)
+		a := reflect.PointerTo(reflect.TypeOf(CommandA1))
+		b := reflect.TypeOf(CommandA1)
 
 		Expect(
 			MeasureDistance(a, b),
@@ -54,9 +54,9 @@ var _ = g.Describe("func MeasureDistance()", func() {
 	})
 
 	g.It("returns a lower value for more similar types", func() {
-		a := reflect.TypeOf(MessageA1)
-		b := reflect.PtrTo(a)
-		c := reflect.PtrTo(b)
+		a := reflect.TypeOf(CommandA1)
+		b := reflect.PointerTo(a)
+		c := reflect.PointerTo(b)
 
 		distA := MeasureDistance(a, b)
 		distB := MeasureDistance(a, c)

--- a/test_test.go
+++ b/test_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/internal/testingmock"
@@ -16,7 +15,7 @@ import (
 var _ = g.Describe("type Test", func() {
 	g.Describe("func Prepare()", func() {
 		g.It("fails the test if the action returns an error", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "c654acb2-3e87-493a-8b9b-f662cd5e0f55")
 				},
@@ -35,7 +34,7 @@ var _ = g.Describe("type Test", func() {
 
 	g.Describe("func Expect()", func() {
 		g.It("fails the test if the action returns an error", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "c691b2ca-4c07-4473-bc42-060266cc7a56")
 				},
@@ -56,14 +55,14 @@ var _ = g.Describe("type Test", func() {
 	g.Describe("func EnableHandlers()", func() {
 		g.It("enables the handler", func() {
 			called := false
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 					c.RegisterProjection(&ProjectionMessageHandlerStub{
 						ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 							c.Identity("<projection>", "fb5f05c0-589c-4d64-9599-a4875b5a3569")
 							c.Routes(
-								dogma.HandlesEvent[MessageE](),
+								dogma.HandlesEvent[EventStub[TypeA]](),
 							)
 						},
 						HandleEventFunc: func(
@@ -81,13 +80,13 @@ var _ = g.Describe("type Test", func() {
 
 			Begin(&testingmock.T{}, app).
 				EnableHandlers("<projection>").
-				Prepare(RecordEvent(MessageE1))
+				Prepare(RecordEvent(EventA1))
 
 			Expect(called).To(BeTrue())
 		})
 
 		g.It("panics if the handler is not recognized", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 				},
@@ -100,14 +99,14 @@ var _ = g.Describe("type Test", func() {
 		})
 
 		g.It("panics if the handler is disabled by its own configuration", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 					c.RegisterProjection(&ProjectionMessageHandlerStub{
 						ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 							c.Identity("<projection>", "fb5f05c0-589c-4d64-9599-a4875b5a3569")
 							c.Routes(
-								dogma.HandlesEvent[MessageE](),
+								dogma.HandlesEvent[EventStub[TypeA]](),
 							)
 							c.Disable()
 						},
@@ -125,14 +124,14 @@ var _ = g.Describe("type Test", func() {
 	g.Describe("func EnableHandlersLike()", func() {
 		g.It("enables handlers with matching names", func() {
 			called := false
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 					c.RegisterProjection(&ProjectionMessageHandlerStub{
 						ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 							c.Identity("<projection>", "fb5f05c0-589c-4d64-9599-a4875b5a3569")
 							c.Routes(
-								dogma.HandlesEvent[MessageE](),
+								dogma.HandlesEvent[EventStub[TypeA]](),
 							)
 						},
 						HandleEventFunc: func(
@@ -150,13 +149,13 @@ var _ = g.Describe("type Test", func() {
 
 			Begin(&testingmock.T{}, app).
 				EnableHandlersLike(`^\<proj`).
-				Prepare(RecordEvent(MessageE1))
+				Prepare(RecordEvent(EventA1))
 
 			Expect(called).To(BeTrue())
 		})
 
 		g.It("panics if there are no matching handlers", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 				},
@@ -169,14 +168,14 @@ var _ = g.Describe("type Test", func() {
 		})
 
 		g.It("does not enable handlers that are disabled by their own configuration", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 					c.RegisterProjection(&ProjectionMessageHandlerStub{
 						ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 							c.Identity("<projection>", "fb5f05c0-589c-4d64-9599-a4875b5a3569")
 							c.Routes(
-								dogma.HandlesEvent[MessageE](),
+								dogma.HandlesEvent[EventStub[TypeA]](),
 							)
 							c.Disable()
 						},
@@ -193,15 +192,15 @@ var _ = g.Describe("type Test", func() {
 
 	g.Describe("func DisableHandlers()", func() {
 		g.It("disables the handler", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "e79bcae1-8b9a-4755-a15a-dd56f2bb2fdb")
 					c.RegisterAggregate(&AggregateMessageHandlerStub{
 						ConfigureFunc: func(c dogma.AggregateConfigurer) {
 							c.Identity("<aggregate>", "524f7944-a252-48e0-864b-503a903067c2")
 							c.Routes(
-								dogma.HandlesCommand[MessageC](),
-								dogma.RecordsEvent[MessageE](),
+								dogma.HandlesCommand[CommandStub[TypeA]](),
+								dogma.RecordsEvent[EventStub[TypeA]](),
 							)
 						},
 						RouteCommandToInstanceFunc: func(dogma.Command) string {
@@ -220,11 +219,11 @@ var _ = g.Describe("type Test", func() {
 
 			Begin(&testingmock.T{}, app).
 				DisableHandlers("<aggregate>").
-				Prepare(ExecuteCommand(MessageC1))
+				Prepare(ExecuteCommand(CommandA1))
 		})
 
 		g.It("panics if the handler is not recognized", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 				},
@@ -239,15 +238,15 @@ var _ = g.Describe("type Test", func() {
 
 	g.Describe("func DisableHandlersLike()", func() {
 		g.It("disables the handlers with matching names", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "e79bcae1-8b9a-4755-a15a-dd56f2bb2fdb")
 					c.RegisterAggregate(&AggregateMessageHandlerStub{
 						ConfigureFunc: func(c dogma.AggregateConfigurer) {
 							c.Identity("<aggregate>", "524f7944-a252-48e0-864b-503a903067c2")
 							c.Routes(
-								dogma.HandlesCommand[MessageC](),
-								dogma.RecordsEvent[MessageE](),
+								dogma.HandlesCommand[CommandStub[TypeA]](),
+								dogma.RecordsEvent[EventStub[TypeA]](),
 							)
 						},
 						RouteCommandToInstanceFunc: func(dogma.Command) string {
@@ -266,11 +265,11 @@ var _ = g.Describe("type Test", func() {
 
 			Begin(&testingmock.T{}, app).
 				DisableHandlersLike(`^\<agg`).
-				Prepare(ExecuteCommand(MessageC1))
+				Prepare(ExecuteCommand(CommandA1))
 		})
 
 		g.It("panics if there are no matching handlers", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "7d5b218d-d69b-48d5-8831-2af77561ee62")
 				},
@@ -285,7 +284,7 @@ var _ = g.Describe("type Test", func() {
 
 	g.Describe("func Annotate()", func() {
 		g.It("includes annotations in diffs", func() {
-			app := &Application{
+			app := &ApplicationStub{
 				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 					c.Identity("<app>", "8ec6465c-d4e3-411c-a05b-898a4b608284")
 
@@ -293,8 +292,8 @@ var _ = g.Describe("type Test", func() {
 						ConfigureFunc: func(c dogma.AggregateConfigurer) {
 							c.Identity("<aggregate>", "a9cdc28d-ec85-4130-af86-4a2ae86a43dd")
 							c.Routes(
-								dogma.HandlesCommand[MessageC](),
-								dogma.RecordsEvent[MessageE](),
+								dogma.HandlesCommand[CommandStub[TypeA]](),
+								dogma.RecordsEvent[EventStub[TypeA]](),
 							)
 						},
 						RouteCommandToInstanceFunc: func(dogma.Command) string {
@@ -305,7 +304,7 @@ var _ = g.Describe("type Test", func() {
 							s dogma.AggregateCommandScope,
 							m dogma.Command,
 						) {
-							s.RecordEvent(MessageE1)
+							s.RecordEvent(EventA1)
 						},
 					})
 				},
@@ -314,15 +313,15 @@ var _ = g.Describe("type Test", func() {
 			t := &testingmock.T{FailSilently: true}
 
 			Begin(t, app).
-				Annotate("E1", "anna's customer ID").
-				Annotate("E2", "bob's customer ID").
+				Annotate(TypeA("A1"), "anna's customer ID").
+				Annotate(TypeA("A2"), "bob's customer ID").
 				Expect(
-					ExecuteCommand(MessageC1),
-					ToRecordEvent(MessageE2),
+					ExecuteCommand(CommandA1),
+					ToRecordEvent(EventA2),
 				)
 
 			expectReport(
-				`✗ record a specific 'fixtures.MessageE' event`,
+				`✗ record a specific 'stubs.EventStub[TypeA]' event`,
 				``,
 				`  | EXPLANATION`,
 				`  |     a similar event was recorded by the '<aggregate>' aggregate message handler`,
@@ -331,8 +330,9 @@ var _ = g.Describe("type Test", func() {
 				`  |     • check the content of the message`,
 				`  | `,
 				`  | MESSAGE DIFF`,
-				`  |     fixtures.MessageE{`,
-				`  |         Value: "E[-2-]{+1+}" <<[-bob-]{+anna+}'s customer ID>>`,
+				`  |     stubs.EventStub[github.com/dogmatiq/enginekit/enginetest/stubs.TypeA]{`,
+				`  |         Content:         "A[-2-]{+1+}" <<[-bob-]{+anna+}'s customer ID>>`,
+				`  |         ValidationError: ""`,
 				`  |     }`,
 			)(t)
 		})

--- a/testoption_test.go
+++ b/testoption_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/enginekit/enginetest/stubs"
 	. "github.com/dogmatiq/testkit"
 	"github.com/dogmatiq/testkit/internal/testingmock"
@@ -22,7 +21,7 @@ var _ = g.Describe("func StartTimeAt()", func() {
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<handler-name>", "ca76057c-9ad0-4a55-a9d9-7fbffe92e644")
 				c.Routes(
-					dogma.HandlesEvent[MessageA](),
+					dogma.HandlesEvent[EventStub[TypeA]](),
 				)
 			},
 			HandleEventFunc: func(
@@ -37,7 +36,7 @@ var _ = g.Describe("func StartTimeAt()", func() {
 			},
 		}
 
-		app := &Application{
+		app := &ApplicationStub{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "d61d15c0-0df7-466b-b0cc-749084399d73")
 				c.RegisterProjection(handler)
@@ -50,7 +49,7 @@ var _ = g.Describe("func StartTimeAt()", func() {
 			StartTimeAt(now),
 		).
 			EnableHandlers("<handler-name>").
-			Prepare(RecordEvent(MessageA1))
+			Prepare(RecordEvent(EventA1))
 
 		Expect(called).To(BeTrue())
 	})
@@ -62,8 +61,8 @@ var _ = g.Describe("func WithMessageComparator()", func() {
 			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
 				c.Identity("<handler-name>", "191580b7-0b16-4e5e-be03-eda07e92b9b0")
 				c.Routes(
-					dogma.HandlesCommand[MessageC](),
-					dogma.RecordsEvent[MessageE](),
+					dogma.HandlesCommand[CommandStub[TypeA]](),
+					dogma.RecordsEvent[EventStub[TypeA]](),
 				)
 			},
 			HandleCommandFunc: func(
@@ -71,12 +70,12 @@ var _ = g.Describe("func WithMessageComparator()", func() {
 				s dogma.IntegrationCommandScope,
 				_ dogma.Command,
 			) error {
-				s.RecordEvent(MessageE1)
+				s.RecordEvent(EventA1)
 				return nil
 			},
 		}
 
-		app := &Application{
+		app := &ApplicationStub{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", "ad2a18d6-d87a-4b5c-a396-aa293ec64fdf")
 				c.RegisterIntegration(handler)
@@ -94,8 +93,8 @@ var _ = g.Describe("func WithMessageComparator()", func() {
 		).
 			EnableHandlers("<handler-name>").
 			Expect(
-				ExecuteCommand(MessageC1),
-				ToRecordEvent(MessageE2), // this would fail without our custom comparator
+				ExecuteCommand(CommandA1),
+				ToRecordEvent(EventA2), // this would fail without our custom comparator
 			)
 	})
 })


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR removes use of the deprecated fixtures from `dogmatiq/dogma`, and replaces them with the newer `enginekit/stubs`.

#### Why make this change?

The deprecated fixtures are not only slated for deletion, they will not be updated to conform to interface changes that will make `Command`, `Event` and `Timeout` incompatible.
